### PR TITLE
Ignore build directory for graal build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ gems/*/lib/*.jar
 gems/*/lib/jruby-jars/version.rb
 gems/*/pkg
 glob_test
+graal
 jruby-complete.jar
 jruby-findbugs.html
 latest_source_cache


### PR DESCRIPTION
As of d70323eae0 there is a cool tool to install an up to date
version of graal-core to run truffleruby with, which is great.

This just gitignores the directory it clones and builds it in
so that nobody commits it accidentally or is annoyed by
`git status` always showing up with untracked files :)