### PR TITLE
Methods need to be copied when a Module is #dup

### DIFF
--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -167,7 +167,10 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
             this.methods.put(method.getName(), method.withDeclaringModule(rubyModuleObject));
         }
 
-        this.constants.putAll(fromFields.constants);
+        for (Entry<String, RubyConstant> entry : fromFields.constants.entrySet()) {
+            this.constants.put(entry.getKey(), entry.getValue());
+        }
+
         this.classVariables.putAll(fromFields.classVariables);
 
         if (fromFields.hasPrependedModules()) {

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -162,7 +162,11 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
 
         // Do not copy name, the copy is an anonymous module
         final ModuleFields fromFields = Layouts.MODULE.getFields(from);
-        this.methods.putAll(fromFields.methods);
+
+        for (InternalMethod method : fromFields.methods.values()) {
+            this.methods.put(method.getName(), method.withDeclaringModule(rubyModuleObject));
+        }
+
         this.constants.putAll(fromFields.constants);
         this.classVariables.putAll(fromFields.classVariables);
 

--- a/truffle/src/main/java/org/truffleruby/language/RubyConstant.java
+++ b/truffle/src/main/java/org/truffleruby/language/RubyConstant.java
@@ -63,6 +63,15 @@ public class RubyConstant {
         }
     }
 
+    public RubyConstant withDeclaringModule(DynamicObject newDeclaringModule) {
+        assert RubyGuards.isRubyModule(newDeclaringModule);
+        if (newDeclaringModule == declaringModule) {
+            return this;
+        } else {
+            return new RubyConstant(newDeclaringModule, value, isPrivate, autoload, isDeprecated);
+        }
+    }
+
     public boolean isVisibleTo(RubyContext context, LexicalScope lexicalScope, DynamicObject module) {
         CompilerAsserts.neverPartOfCompilation();
 


### PR DESCRIPTION
* to use the right declaring Module.