### PR TITLE
Remove support for using GraalVM releases for development

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -131,22 +131,6 @@ sulong: ${labsjdk8} {
   ]
 }
 
-graal-vm-release: {
-  downloads: {
-    GRAALVM_DIR: {
-      name: graalvm-release,
-      version: "0.19",
-      platformspecific: true
-    }
-  }
-
-  environment: {
-    GRAALVM_BIN: "$GRAALVM_DIR/bin/java"
-    HOST_VM: server,
-    HOST_VM_CONFIG: graal-vm
-  }
-}
-
 graal-vm-snapshot: {
   downloads: {
     GRAALVM_DIR: {
@@ -425,16 +409,12 @@ builds: [
   {name: ruby-test-compiler-graal-core} ${common} ${graal-core} ${gate-caps} {run: [${jt} [test, compiler]]},
   {name: ruby-test-compiler-graal-enterprise} ${common} ${graal-enterprise} ${gate-caps} {run: [${jt} [test, compiler]]},
   {name: ruby-test-compiler-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${gate-caps} {run: [${jt} [test, compiler]]},
-  {name: ruby-test-compiler-graal-vm-release} ${common} ${graal-vm-release} ${gate-caps} {run: [${jt} [test, compiler]]},
-
-  {name: ruby-test-specs-vm-release} ${common} ${graal-vm-release} ${daily-caps} ${test-compilation-flags} {run: [${jt} [test, specs, ":command_line", ":language", --graal]]},
 
   {name: ruby-metrics-truffle} ${common} ${no-graal} ${bench-caps} ${jruby-truffle} ${metrics},
   {name: ruby-metrics-compiler-graal-core} ${common} ${graal-core} ${daily-bench-caps} ${jruby-truffle} ${compiler-metrics},
   {name: ruby-metrics-compiler-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${jruby-truffle} ${compiler-metrics},
   {name: ruby-metrics-compiler-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${jruby-truffle} ${compiler-metrics},
   {name: ruby-metrics-compiler-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${jruby-truffle} ${compiler-metrics},
-  {name: ruby-metrics-compiler-graal-vm-release} ${common} ${graal-vm-release} ${bench-caps} ${jruby-truffle} ${compiler-metrics},
 
   {name: ruby-benchmarks-classic-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${classic-benchmarks},
   {name: ruby-benchmarks-classic-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${jruby-truffle} ${classic-benchmarks},
@@ -444,7 +424,6 @@ builds: [
   {name: ruby-benchmarks-classic-graal-enterprise-solaris} ${common} ${graal-enterprise} ${daily-bench-caps-solaris} ${jruby-truffle} ${classic-benchmarks-solaris},
   {name: ruby-benchmarks-classic-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${jruby-truffle} ${classic-benchmarks},
   {name: ruby-benchmarks-classic-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${jruby-truffle} ${classic-benchmarks},
-  {name: ruby-benchmarks-classic-graal-vm-release} ${common} ${graal-vm-release} ${bench-caps} ${jruby-truffle} ${classic-benchmarks},
 
   {name: ruby-benchmarks-chunky-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${chunky-benchmarks},
   {name: ruby-benchmarks-chunky-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${jruby-truffle} ${chunky-benchmarks},
@@ -452,7 +431,6 @@ builds: [
   {name: ruby-benchmarks-chunky-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${jruby-truffle} ${chunky-benchmarks},
   {name: ruby-benchmarks-chunky-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${jruby-truffle} ${chunky-benchmarks},
   {name: ruby-benchmarks-chunky-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${jruby-truffle} ${chunky-benchmarks},
-  {name: ruby-benchmarks-chunky-graal-vm-release} ${common} ${graal-vm-release} ${bench-caps} ${jruby-truffle} ${chunky-benchmarks},
 
   {name: ruby-benchmarks-psd-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${psd-benchmarks},
   {name: ruby-benchmarks-psd-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${jruby-truffle} ${psd-benchmarks},
@@ -460,7 +438,6 @@ builds: [
   {name: ruby-benchmarks-psd-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${jruby-truffle} ${psd-benchmarks},
   {name: ruby-benchmarks-psd-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${jruby-truffle} ${psd-benchmarks},
   {name: ruby-benchmarks-psd-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${jruby-truffle} ${psd-benchmarks},
-  {name: ruby-benchmarks-psd-graal-vm-release} ${common} ${graal-vm-release} ${bench-caps} ${jruby-truffle} ${psd-benchmarks},
 
   {name: ruby-benchmarks-asciidoctor-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${asciidoctor-benchmarks},
   {name: ruby-benchmarks-asciidoctor-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${jruby-truffle} ${asciidoctor-benchmarks},
@@ -468,7 +445,6 @@ builds: [
   {name: ruby-benchmarks-asciidoctor-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${jruby-truffle} ${asciidoctor-benchmarks},
   {name: ruby-benchmarks-asciidoctor-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${jruby-truffle} ${asciidoctor-benchmarks},
   {name: ruby-benchmarks-asciidoctor-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${jruby-truffle} ${asciidoctor-benchmarks},
-  {name: ruby-benchmarks-asciidoctor-graal-vm-release} ${common} ${graal-vm-release} ${bench-caps} ${jruby-truffle} ${asciidoctor-benchmarks},
 
   {name: ruby-benchmarks-other-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${other-benchmarks},
   {name: ruby-benchmarks-other-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${jruby-truffle} ${other-benchmarks},
@@ -476,17 +452,14 @@ builds: [
   {name: ruby-benchmarks-other-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${jruby-truffle} ${other-benchmarks},
   {name: ruby-benchmarks-other-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${jruby-truffle} ${other-benchmarks},
   {name: ruby-benchmarks-other-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${jruby-truffle} ${other-benchmarks},
-  {name: ruby-benchmarks-other-graal-vm-release} ${common} ${graal-vm-release} ${bench-caps} ${jruby-truffle} ${other-benchmarks},
 
   {name: ruby-benchmarks-server-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${jruby-truffle} ${server-benchmarks},
   {name: ruby-benchmarks-server-graal-core} ${common} ${graal-core} ${daily-bench-caps} ${jruby-truffle} ${server-benchmarks},
   {name: ruby-benchmarks-server-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${jruby-truffle} ${server-benchmarks},
   {name: ruby-benchmarks-server-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${jruby-truffle} ${server-benchmarks},
   {name: ruby-benchmarks-server-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${jruby-truffle} ${server-benchmarks},
-  {name: ruby-benchmarks-server-graal-vm-release} ${common} ${graal-vm-release} ${bench-caps} ${jruby-truffle} ${server-benchmarks},
 
   {name: ruby-benchmarks-cext} ${common} ${daily-bench-caps} ${jruby-truffle-cexts} ${cext-benchmarks},
-  {name: ruby-benchmarks-optcarrot-warmup} ${common} ${graal-vm-release} ${daily-bench-caps} ${jruby-truffle} ${optcarrot-warmup},
 
   {name: ruby-deploy-binaries} ${common} ${gate-caps} ${deploy-binaries}
 ]

--- a/doc/contributor/building-graal.md
+++ b/doc/contributor/building-graal.md
@@ -1,11 +1,9 @@
 # Building Graal
 
-The easiest way to get Graal to develop TruffleRuby is to use the GraalVM, as
-described in `doc/user/using-graalvm.md`.
-
-If you want to build Graal from scratch, possibly to modify Graal or Truffle, to
-use developer tools that come with Graal such as the Ideal Graph Visualizer,
-then you should follow the instructions in the Graal core repository.
+If you want to build Graal from scratch to test running with Graal when
+developing TruffleRuby, or possibly to modify Graal or Truffle, or to use
+developer tools that come with Graal such as the Ideal Graph Visualizer, then
+you should follow the instructions in the Graal core repository.
 
 https://github.com/graalvm/graal-core
 

--- a/doc/contributor/using-graalvm.md
+++ b/doc/contributor/using-graalvm.md
@@ -2,8 +2,9 @@
 
 The easiest way for end-users to get the Graal compiler and a compatible JVM is
 with the GraalVM. We recommend that they use the version of TruffleRuby which is
-bundled in GraalVM, but for contributors GraalVM is also a convenient way to get
-everything else.
+bundled in GraalVM. For contributors, the version of Graal and Truffle in
+GraalVM is not always compatible, so we recommend building Graal yourself for
+developing TruffleRuby. See `builing-graal.md`.
 
 Follow the instructions for end-users in `doc/user/using-graalvm.md`, but then
 set the environment variable `GRAALVM_BIN` to the `bin/java` executable in

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -65,10 +65,6 @@ $ ruby ...
 $ jt ruby ...
 ```
 
-Note that running Ruby without any arguments does not start a shell. You should
-run `jt irb` if you want an interactive shell, or `irb` to run the shell of your
-system Ruby or a GraalVM tarball.
-
 ## Options
 
 Specify JVM options with `-J-option`.
@@ -94,14 +90,14 @@ To run with a GraalVM binary tarball, set the `GRAALVM_BIN` environment variable
 and run with the `--graal` option.
 
 ```
-$ export GRAALVM_BIN=.../graalvm-0.18-re/bin/java
+$ export GRAALVM_BIN=.../graalvm-0.19-re/bin/java
 $ jt ruby --graal ...
 ```
 
 You can check this is working by printing the value of `Truffle::Graal.graal?`.
 
 ```
-$ export GRAALVM_BIN=.../graalvm-0.18-re/bin/java
+$ export GRAALVM_BIN=.../graalvm-0.19-re/bin/java
 $ jt ruby --graal -e 'p Truffle::Graal.graal?'
 ```
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -80,14 +80,6 @@ module Utilities
 
     raise "More than one of GRAALVM_BIN, JVMCI_BIN or GRAAL_HOME defined!" if [graalvm, jvmci, graal_home].compact.count > 1
 
-    if !graalvm && !jvmci && !graal_home
-      if truffle_release?
-        graalvm = ENV['GRAALVM_RELEASE_BIN']
-      else
-        graal_home = ENV['GRAAL_HOME_TRUFFLE_HEAD']
-      end
-    end
-
     if graalvm
       javacmd = File.expand_path(graalvm)
       vm_args = []
@@ -511,8 +503,6 @@ module Commands
         GRAAL_HOME                                   Directory where there is a built checkout of the Graal compiler (make sure mx is on your path)
         JVMCI_BIN                                    JVMCI-enabled (so JDK 9 EA build) java command (aslo set JVMCI_GRAAL_HOME)
         JVMCI_GRAAL_HOME                             Like GRAAL_HOME, but only used for the JARs to run with JVMCI_BIN
-        GRAALVM_RELEASE_BIN                          Default GraalVM executable when using a released version of Truffle (such as on master)
-        GRAAL_HOME_TRUFFLE_HEAD                      Default Graal directory when using a snapshot version of Truffle (such as on truffle-head)
         SULONG_HOME                                  The Sulong source repository, if you want to run cextc
         GRAAL_JS_JAR                                 The location of trufflejs.jar
         SL_JAR                                       The location of truffle-sl.jar

--- a/truffle/src/main/java/org/truffleruby/Main.java
+++ b/truffle/src/main/java/org/truffleruby/Main.java
@@ -128,8 +128,7 @@ public class Main {
                     exitCode = checkSyntax(engine, context, getScriptSource(config), filename);
                 } else {
                     if (!Graal.isGraal() && context.getOptions().GRAAL_WARNING_UNLESS) {
-                        Log.performanceOnce("This JVM does not have the Graal compiler - performance will be limited - " +
-                                "see https://github.com/jruby/jruby/wiki/Truffle-FAQ#how-do-i-get-jrubytruffle");
+                        Log.performanceOnce("This JVM does not have the Graal compiler - performance will be limited - see doc/user/using-graalvm.md");
                     }
 
                     if (config.shouldUsePathScript()) {


### PR DESCRIPTION
We're incompatible with GraalVM due to Truffle API changes. I think we should stop encouraging running in development with GraalVM, and not test or benchmark against it. CI is broken at the moment due to the API changes so I need to merge something like this today.