### PR TITLE
Don't use statics for shared objects options

### DIFF
--- a/truffle/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
@@ -656,7 +656,7 @@ public abstract class VMPrimitiveNodes {
 
         @Specialization(guards = "isRubyClass(newClass)")
         public DynamicObject setClass(DynamicObject object, DynamicObject newClass) {
-            SharedObjects.propagate(object, newClass);
+            SharedObjects.propagate(getContext(), object, newClass);
             synchronized (object) {
                 Layouts.BASIC_OBJECT.setLogicalClass(object, newClass);
                 Layouts.BASIC_OBJECT.setMetaClass(object, newClass);

--- a/truffle/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -853,7 +853,7 @@ public abstract class KernelNodes {
             final String ivar = SymbolTable.checkInstanceVariableName(getContext(), name, object, this);
             final Object value = ReadObjectFieldNode.read(object, ivar, nil());
 
-            if (SharedObjects.isShared(object)) {
+            if (SharedObjects.isShared(getContext(), object)) {
                 synchronized (object) {
                     removeField(object, name);
                 }

--- a/truffle/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -241,7 +241,7 @@ public abstract class ClassNodes {
 
         String name = StringUtils.format("#<Class:%s>", Layouts.MODULE.getFields(rubyClass).getName());
         DynamicObject metaClass = ClassNodes.createRubyClass(context, Layouts.MODULE.getFields(rubyClass).getSourceSection(), Layouts.BASIC_OBJECT.getLogicalClass(rubyClass), null, singletonSuperclass, name, true, rubyClass, true);
-        SharedObjects.propagate(rubyClass, metaClass);
+        SharedObjects.propagate(context, rubyClass, metaClass);
         Layouts.BASIC_OBJECT.setMetaClass(rubyClass, metaClass);
 
         return Layouts.BASIC_OBJECT.getMetaClass(rubyClass);

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -216,7 +216,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
             throw new RaiseException(context.getCoreExceptions().argumentError("cyclic include detected", currentNode));
         }
 
-        SharedObjects.propagate(rubyModuleObject, module);
+        SharedObjects.propagate(context, rubyModuleObject, module);
 
         // We need to include the module ancestors in reverse order for a given inclusionPoint
         ModuleChain inclusionPoint = this;
@@ -278,7 +278,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
             throw new RaiseException(context.getCoreExceptions().argumentError("cyclic prepend detected", currentNode));
         }
 
-        SharedObjects.propagate(rubyModuleObject, module);
+        SharedObjects.propagate(context, rubyModuleObject, module);
 
         ModuleChain mod = Layouts.MODULE.getFields(module).start;
         ModuleChain cur = start;
@@ -327,7 +327,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
         // TODO(CS): warn when redefining a constant
         // TODO (nirvdrum 18-Feb-15): But don't warn when redefining an autoloaded constant.
 
-        SharedObjects.propagate(rubyModuleObject, value);
+        SharedObjects.propagate(context, rubyModuleObject, value);
 
         while (true) {
             final RubyConstant previous = constants.get(name);
@@ -368,9 +368,9 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
 
         checkFrozen(context, currentNode);
 
-        if (SharedObjects.isShared(rubyModuleObject)) {
+        if (SharedObjects.isShared(context, rubyModuleObject)) {
             for (DynamicObject object : method.getAdjacentObjects()) {
-                SharedObjects.writeBarrier(object);
+                SharedObjects.writeBarrier(context, object);
             }
         }
 

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -356,7 +356,7 @@ public abstract class ModuleOperations {
         assert RubyGuards.isRubyModule(module);
         ModuleFields moduleFields = Layouts.MODULE.getFields(module);
         moduleFields.checkFrozen(context, currentNode);
-        SharedObjects.propagate(module, value);
+        SharedObjects.propagate(context, module, value);
 
         // if the cvar is not already defined we need to take lock and ensure there is only one
         // defined in the class tree

--- a/truffle/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/truffle/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -95,7 +95,7 @@ public class ThreadManager {
 
     public static void initialize(final DynamicObject thread, RubyContext context, Node currentNode, final Object[] arguments, final DynamicObject block) {
         if (context.getOptions().SHARED_OBJECTS_ENABLED) {
-            SharedObjects.shareDeclarationFrame(block);
+            SharedObjects.shareDeclarationFrame(context, block);
         }
 
         final SourceSection sourceSection = Layouts.PROC.getSharedMethodInfo(block).getSourceSection();
@@ -125,7 +125,7 @@ public class ThreadManager {
         try {
             task.run();
         } catch (ThreadExitException e) {
-            setThreadValue(thread, context.getCoreLibrary().getNilObject());
+            setThreadValue(context, thread, context.getCoreLibrary().getNilObject());
             return;
         } catch (RaiseException e) {
             setException(context, thread, e.getException(), currentNode);
@@ -137,9 +137,9 @@ public class ThreadManager {
         }
     }
 
-    private static void setThreadValue(final DynamicObject thread, final Object value) {
+    private static void setThreadValue(RubyContext context, DynamicObject thread, final Object value) {
         // A Thread is always shared (Thread.list)
-        SharedObjects.propagate(thread, value);
+        SharedObjects.propagate(context, thread, value);
         Layouts.THREAD.setValue(thread, value);
     }
 
@@ -149,7 +149,7 @@ public class ThreadManager {
         if (thread != mainThread && (isSystemExit || Layouts.THREAD.getAbortOnException(thread))) {
             ThreadNodes.ThreadRaisePrimitiveNode.raiseInThread(context, mainThread, exception, currentNode);
         }
-        SharedObjects.propagate(thread, exception);
+        SharedObjects.propagate(context, thread, exception);
         Layouts.THREAD.setException(thread, exception);
     }
 
@@ -334,7 +334,7 @@ public class ThreadManager {
 
         if (context.getOptions().SHARED_OBJECTS_ENABLED && runningRubyThreads.size() > 1) {
             context.getSharedObjects().startSharing();
-            SharedObjects.writeBarrier(thread);
+            SharedObjects.writeBarrier(context, thread);
         }
     }
 

--- a/truffle/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/truffle/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -94,7 +94,7 @@ public class ThreadManager {
     }
 
     public static void initialize(final DynamicObject thread, RubyContext context, Node currentNode, final Object[] arguments, final DynamicObject block) {
-        if (SharedObjects.ENABLED) {
+        if (context.getOptions().SHARED_OBJECTS_ENABLED) {
             SharedObjects.shareDeclarationFrame(block);
         }
 
@@ -332,7 +332,7 @@ public class ThreadManager {
         initializeCurrentThread(thread);
         runningRubyThreads.add(thread);
 
-        if (SharedObjects.ENABLED && runningRubyThreads.size() > 1) {
+        if (context.getOptions().SHARED_OBJECTS_ENABLED && runningRubyThreads.size() > 1) {
             context.getSharedObjects().startSharing();
             SharedObjects.writeBarrier(thread);
         }

--- a/truffle/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/truffle/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -205,7 +205,7 @@ public abstract class TruffleDebugNodes {
 
         @Specialization
         public boolean isShared(DynamicObject object) {
-            return SharedObjects.isShared(object);
+            return SharedObjects.isShared(getContext(), object);
         }
 
     }

--- a/truffle/src/main/java/org/truffleruby/language/LazyRubyRootNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/LazyRubyRootNode.java
@@ -102,7 +102,7 @@ public class LazyRubyRootNode extends RootNode implements InternalRootNode {
 
         // The return value will be leaked to Java, share it.
         if (context.getOptions().SHARED_OBJECTS_ENABLED) {
-            SharedObjects.writeBarrier(value);
+            SharedObjects.writeBarrier(context, value);
         }
 
         return value;

--- a/truffle/src/main/java/org/truffleruby/language/LazyRubyRootNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/LazyRubyRootNode.java
@@ -101,7 +101,7 @@ public class LazyRubyRootNode extends RootNode implements InternalRootNode {
         final Object value = callNode.call(frame, arguments);
 
         // The return value will be leaked to Java, share it.
-        if (SharedObjects.ENABLED) {
+        if (context.getOptions().SHARED_OBJECTS_ENABLED) {
             SharedObjects.writeBarrier(value);
         }
 

--- a/truffle/src/main/java/org/truffleruby/language/RubyObjectType.java
+++ b/truffle/src/main/java/org/truffleruby/language/RubyObjectType.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.ObjectType;
 import org.truffleruby.Layouts;
+import org.truffleruby.RubyContext;
 import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.core.string.StringUtils;
@@ -26,8 +27,6 @@ public class RubyObjectType extends ObjectType {
     @Override
     @TruffleBoundary
     public String toString(DynamicObject object) {
-        CompilerAsserts.neverPartOfCompilation();
-
         if (RubyGuards.isRubyString(object)) {
             return RopeOperations.decodeRope(StringOperations.rope(object));
         } else if (RubyGuards.isRubySymbol(object)) {
@@ -38,7 +37,7 @@ public class RubyObjectType extends ObjectType {
             return Layouts.MODULE.getFields(object).getName();
         } else {
             final String className = Layouts.MODULE.getFields(Layouts.BASIC_OBJECT.getLogicalClass(object)).getName();
-            final Object isShared = SharedObjects.isShared(object) ? "(shared)" : "";
+            final Object isShared = SharedObjects.isShared(RubyContext.getInstance(), object) ? "(shared)" : "";
             return StringUtils.format("DynamicObject@%x<%s>%s", System.identityHashCode(object), className, isShared);
         }
     }

--- a/truffle/src/main/java/org/truffleruby/language/globals/GlobalVariableStorage.java
+++ b/truffle/src/main/java/org/truffleruby/language/globals/GlobalVariableStorage.java
@@ -14,12 +14,11 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.utilities.CyclicAssumption;
+import org.truffleruby.RubyContext;
 import org.truffleruby.options.OptionsBuilder;
 import org.truffleruby.options.OptionsCatalog;
 
 public class GlobalVariableStorage {
-
-    private static final int GLOBAL_VARIABLE_MAX_INVALIDATIONS = OptionsBuilder.readSystemProperty(OptionsCatalog.GLOBAL_VARIABLE_MAX_INVALIDATIONS);
 
     private final CyclicAssumption unchangedAssumption = new CyclicAssumption("global variable unchanged");
     private int changes = 0;
@@ -50,14 +49,14 @@ public class GlobalVariableStorage {
     }
 
     @TruffleBoundary
-    public void updateAssumeConstant() {
+    public void updateAssumeConstant(RubyContext context) {
         synchronized (this) {
             if (!assumeConstant) {
                 // Compiled code didn't see that we do not assumeConstant anymore
                 return;
             }
 
-            if (changes <= GLOBAL_VARIABLE_MAX_INVALIDATIONS) {
+            if (changes <= context.getOptions().GLOBAL_VARIABLE_MAX_INVALIDATIONS) {
                 changes++;
                 unchangedAssumption.invalidate();
             } else {

--- a/truffle/src/main/java/org/truffleruby/language/globals/WriteGlobalVariableNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/globals/WriteGlobalVariableNode.java
@@ -48,7 +48,7 @@ public abstract class WriteGlobalVariableNode extends RubyNode {
             writeBarrierNode.executeWriteBarrier(value);
         }
         storage.setValueInternal(value);
-        storage.updateAssumeConstant();
+        storage.updateAssumeConstant(getContext());
         return value;
     }
 

--- a/truffle/src/main/java/org/truffleruby/language/objects/ObjectIDOperations.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/ObjectIDOperations.java
@@ -121,7 +121,7 @@ public abstract class ObjectIDOperations {
 
         final long objectID = context.getObjectSpaceManager().getNextObjectID();
 
-        if (SharedObjects.isShared(object)) {
+        if (SharedObjects.isShared(context, object)) {
             synchronized (object) {
                 // no need for a write barrier here, objectID is a long.
                 object.define(Layouts.OBJECT_ID_IDENTIFIER, objectID);

--- a/truffle/src/main/java/org/truffleruby/language/objects/ObjectIVarSetNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/ObjectIVarSetNode.java
@@ -41,8 +41,8 @@ public abstract class ObjectIVarSetNode extends RubyNode {
     @TruffleBoundary
     @Specialization(contains = "ivarSetCached")
     public Object ivarSetUncached(DynamicObject object, String name, Object value) {
-        if (SharedObjects.isShared(object)) {
-            SharedObjects.writeBarrier(value);
+        if (SharedObjects.isShared(getContext(), object)) {
+            SharedObjects.writeBarrier(getContext(), value);
             synchronized (object) {
                 object.define(checkName(name, object), value);
             }

--- a/truffle/src/main/java/org/truffleruby/language/objects/ShapeCachingGuards.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/ShapeCachingGuards.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.ObjectType;
 import com.oracle.truffle.api.object.Shape;
 import org.truffleruby.Layouts;
+import org.truffleruby.RubyContext;
 import org.truffleruby.language.objects.shared.SharedObjects;
 
 public abstract class ShapeCachingGuards {
@@ -23,7 +24,7 @@ public abstract class ShapeCachingGuards {
         CompilerDirectives.transferToInterpreter();
         boolean updated = object.updateShape();
         if (updated) {
-            assert !SharedObjects.isShared(object);
+            assert !SharedObjects.isShared(RubyContext.getInstance(), object);
         }
         return updated;
     }

--- a/truffle/src/main/java/org/truffleruby/language/objects/SingletonClassNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/SingletonClassNode.java
@@ -152,7 +152,7 @@ public abstract class SingletonClassNode extends RubyNode {
                 freeze(singletonClass);
             }
 
-            SharedObjects.propagate(object, singletonClass);
+            SharedObjects.propagate(getContext(), object, singletonClass);
 
             Layouts.BASIC_OBJECT.setMetaClass(object, singletonClass);
             return singletonClass;

--- a/truffle/src/main/java/org/truffleruby/language/objects/WriteObjectFieldNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/WriteObjectFieldNode.java
@@ -125,9 +125,9 @@ public abstract class WriteObjectFieldNode extends RubyBaseNode {
     @TruffleBoundary
     @Specialization(contains = { "writeExistingField", "writeNewField", "updateShapeAndWrite" })
     public void writeUncached(DynamicObject object, Object value) {
-        final boolean shared = SharedObjects.isShared(object);
+        final boolean shared = SharedObjects.isShared(getContext(), object);
         if (shared) {
-            SharedObjects.writeBarrier(value);
+            SharedObjects.writeBarrier(getContext(), value);
             synchronized (object) {
                 Shape shape = object.getShape();
                 Shape newShape = defineProperty(shape, value);
@@ -173,7 +173,7 @@ public abstract class WriteObjectFieldNode extends RubyBaseNode {
     }
 
     protected boolean isShared(Shape shape) {
-        return SharedObjects.isShared(shape);
+        return SharedObjects.isShared(getContext(), shape);
     }
 
     protected WriteBarrierNode createWriteBarrierNode(boolean shared) {

--- a/truffle/src/main/java/org/truffleruby/language/objects/shared/IsSharedNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/shared/IsSharedNode.java
@@ -15,10 +15,11 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.Shape;
+import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.objects.ShapeCachingGuards;
 
 @ImportStatic(ShapeCachingGuards.class)
-public abstract class IsSharedNode extends Node {
+public abstract class IsSharedNode extends RubyBaseNode {
 
     protected static final int CACHE_LIMIT = 8;
 
@@ -41,11 +42,11 @@ public abstract class IsSharedNode extends Node {
 
     @Specialization(contains = { "isShareCached", "updateShapeAndIsShared" })
     protected boolean isSharedUncached(DynamicObject object) {
-        return SharedObjects.isShared(object);
+        return SharedObjects.isShared(getContext(), object);
     }
 
     protected boolean isShared(Shape shape) {
-        return SharedObjects.isShared(shape);
+        return SharedObjects.isShared(getContext(), shape);
     }
 
 }

--- a/truffle/src/main/java/org/truffleruby/language/objects/shared/ShareInternalFieldsNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/shared/ShareInternalFieldsNode.java
@@ -21,6 +21,7 @@ import org.truffleruby.Layouts;
 import org.truffleruby.collections.BoundaryIterable;
 import org.truffleruby.core.array.ArrayGuards;
 import org.truffleruby.core.queue.UnsizedQueue;
+import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.objects.ShapeCachingGuards;
 
 import java.util.Arrays;
@@ -30,7 +31,7 @@ import java.util.Collection;
  * Share the internal field of an object, accessible by its Layout
  */
 @ImportStatic({ ShapeCachingGuards.class, ArrayGuards.class })
-public abstract class ShareInternalFieldsNode extends Node {
+public abstract class ShareInternalFieldsNode extends RubyBaseNode {
 
     protected static final int CACHE_LIMIT = 8;
 
@@ -98,7 +99,7 @@ public abstract class ShareInternalFieldsNode extends Node {
 
     @Specialization(contains = { "shareCachedObjectArray", "shareCachedOtherArray", "shareCachedQueue", "shareCachedBasicObject", "updateShapeAndShare" })
     protected void shareUncached(DynamicObject object) {
-        SharedObjects.writeBarrier(object);
+        SharedObjects.writeBarrier(getContext(), object);
     }
 
     protected WriteBarrierNode createWriteBarrierNode() {

--- a/truffle/src/main/java/org/truffleruby/language/objects/shared/SharedObjects.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/shared/SharedObjects.java
@@ -27,11 +27,6 @@ import java.util.Deque;
 
 public class SharedObjects {
 
-    // TODO CS 3-Dec-16 these shouldn't be static
-    public static final boolean ENABLED = OptionsBuilder.readSystemProperty(OptionsCatalog.SHARED_OBJECTS_ENABLED);
-    public static final boolean SHARE_ALL = OptionsBuilder.readSystemProperty(OptionsCatalog.SHARED_OBJECTS_SHARE_ALL);
-    public static final boolean DEBUG = OptionsBuilder.readSystemProperty(OptionsCatalog.SHARED_OBJECTS_DEBUG);
-
     private final RubyContext context;
     // No need for volatile since we change this before starting the 2nd Thread
     private boolean sharing = false;
@@ -75,7 +70,7 @@ public class SharedObjects {
     public static void shareDeclarationFrame(DynamicObject block) {
         final Deque<DynamicObject> stack = new ArrayDeque<>();
 
-        if (DEBUG) {
+        if (RubyContext.getInstance().getOptions().SHARED_OBJECTS_DEBUG) {
             final SourceSection sourceSection = Layouts.PROC.getSharedMethodInfo(block).getSourceSection();
             Log.LOGGER.info("sharing decl frame of " + RubyLanguage.fileLine(sourceSection));
         }
@@ -108,11 +103,11 @@ public class SharedObjects {
     }
 
     public static boolean isShared(Shape shape) {
-        return ENABLED && (SHARE_ALL || shape.isShared());
+        return RubyContext.getInstance().getOptions().SHARED_OBJECTS_ENABLED && (RubyContext.getInstance().getOptions().SHARED_OBJECTS_SHARE_ALL || shape.isShared());
     }
 
     public static void writeBarrier(Object value) {
-        if (ENABLED && value instanceof DynamicObject && !isShared((DynamicObject) value)) {
+        if (RubyContext.getInstance().getOptions().SHARED_OBJECTS_ENABLED && value instanceof DynamicObject && !isShared((DynamicObject) value)) {
             shareObject(value);
         }
     }

--- a/truffle/src/main/java/org/truffleruby/language/objects/shared/WriteBarrierNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/shared/WriteBarrierNode.java
@@ -15,10 +15,11 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.Shape;
+import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.objects.ShapeCachingGuards;
 
 @ImportStatic(ShapeCachingGuards.class)
-public abstract class WriteBarrierNode extends Node {
+public abstract class WriteBarrierNode extends RubyBaseNode {
 
     protected static final int CACHE_LIMIT = 8;
     protected static final int MAX_DEPTH = 3;
@@ -55,7 +56,7 @@ public abstract class WriteBarrierNode extends Node {
 
     @Specialization(contains = { "writeBarrierCached", "updateShapeAndWriteBarrier" })
     protected void writeBarrierUncached(DynamicObject value) {
-        SharedObjects.writeBarrier(value);
+        SharedObjects.writeBarrier(getContext(), value);
     }
 
     @Specialization(guards = "!isDynamicObject(value)")
@@ -70,8 +71,8 @@ public abstract class WriteBarrierNode extends Node {
         return value instanceof DynamicObject;
     }
 
-    protected static boolean isShared(Shape shape) {
-        return SharedObjects.isShared(shape);
+    protected boolean isShared(Shape shape) {
+        return SharedObjects.isShared(getContext(), shape);
     }
 
     protected ShareObjectNode createShareObjectNode(boolean alreadyShared) {


### PR DESCRIPTION
Options aren't going to be stored in properties soon, as doing that doesn't work in some distributions. And anyway - none of our options are global - they're per `PolyglotEngine`.