### PR TITLE
Support running from mx jars directly in bin/truffleruby

### DIFF
--- a/bin/truffleruby
+++ b/bin/truffleruby
@@ -41,13 +41,13 @@ declare -a ruby_args
 
 print_command=""
 CP=""
-boot_cp_jar="$root/lib/jruby-truffle.jar"
+boot_cp_jar="$mvn_jar"
 
 if [ "$mx_time" -gt "$mvn_time" ]; then
     # This hash is Truffle's JLINE sha1
     CP="$CP:$HOME/.mx/cache/JLINE_9504d5e2da5d78237239c5226e8200ec21182040.jar"
     CP="$CP:$root/mx.imports/binary/truffle/mxbuild/dists/truffle-debug.jar"
-    CP="$CP:$root/mxbuild/dists/ruby.jar"
+    CP="$CP:$mx_jar"
     boot_cp_jar="$root/mx.imports/binary/truffle/mxbuild/dists/truffle-api.jar"
 fi
 

--- a/bin/truffleruby
+++ b/bin/truffleruby
@@ -8,9 +8,9 @@ set -e
 function mtime {
     uname_str=$(uname)
     if [ "$uname_str" = 'Linux' ]; then
-        stat -c '%Y' "$1" 2> /dev/null || echo 0
+        stat -c '%Y' "$1" 2>/dev/null || echo 0
     elif [ "$uname_str" = 'Darwin' ]; then
-        stat -f '%m' "$1" 2> /dev/null || echo 0
+        stat -f '%m' "$1" 2>/dev/null || echo 0
     else
         echo "unknown platform $uname_str"
         exit 1
@@ -19,17 +19,15 @@ function mtime {
 
 if [ -n "$RUBY_BIN" ]; then
     exec "$RUBY_BIN" "$@"
-else
-    mx_jar="$root"/mxbuild/dists/ruby.jar
-    mvn_jar="$root"/lib/jruby-truffle.jar
-    mx_time=$(mtime "$mx_jar")
-    mvn_time=$(mtime "$mvn_jar")
 fi
 
-if [ -z "$JAVACMD" ]
-then
-  if [ -z "$JAVA_HOME" ]
-  then
+mx_jar="$root/mxbuild/dists/ruby.jar"
+mvn_jar="$root/lib/jruby-truffle.jar"
+mx_time=$(mtime "$mx_jar")
+mvn_time=$(mtime "$mvn_jar")
+
+if [ -z "$JAVACMD" ]; then
+  if [ -z "$JAVA_HOME" ]; then
     JAVACMD='java'
   else
     JAVACMD="$JAVA_HOME/bin/java"

--- a/bin/truffleruby
+++ b/bin/truffleruby
@@ -24,10 +24,6 @@ else
     mvn_jar="$root"/lib/jruby-truffle.jar
     mx_time=$(mtime "$mx_jar")
     mvn_time=$(mtime "$mvn_jar")
-
-    if [ "$mx_time" -gt "$mvn_time" ]; then
-      exec mx -p "$root" ruby "$@"
-    fi
 fi
 
 if [ -z "$JAVACMD" ]
@@ -42,7 +38,18 @@ fi
 
 declare -a java_args
 declare -a ruby_args
+
 print_command=""
+CP=""
+boot_cp_jar="$root/lib/jruby-truffle.jar"
+
+if [ "$mx_time" -gt "$mvn_time" ]; then
+    # This hash is Truffle's JLINE sha1
+    CP="$CP:$HOME/.mx/cache/JLINE_9504d5e2da5d78237239c5226e8200ec21182040.jar"
+    CP="$CP:$root/mx.imports/binary/truffle/mxbuild/dists/truffle-debug.jar"
+    CP="$CP:$root/mxbuild/dists/ruby.jar"
+    boot_cp_jar="$root/mx.imports/binary/truffle/mxbuild/dists/truffle-api.jar"
+fi
 
 # Split out any -J argument for passing to the JVM.
 # Scanning for args is aborted by '--'.
@@ -84,8 +91,13 @@ done
 # Append the rest of the arguments
 ruby_args=("${ruby_args[@]}" "$@")
 
+if [ -n "$CP" ]; then
+    # Add classpath to java_args without leading :
+    java_args=("-cp" "${CP:1}" "${java_args[@]}")
+fi
+
 declare -a full_command
-full_command=("$JAVACMD" $JAVA_OPTS "${java_args[@]}" "-Xbootclasspath/a:$root/lib/jruby-truffle.jar" org.truffleruby.Main "-Xhome=$root" "-Xlauncher=$root/bin/truffleruby" "${ruby_args[@]}")
+full_command=("$JAVACMD" $JAVA_OPTS "-Xbootclasspath/a:$boot_cp_jar" "${java_args[@]}" org.truffleruby.Main "-Xhome=$root" "-Xlauncher=$root/bin/truffleruby" "${ruby_args[@]}")
 
 if [ -n "$print_command" ]; then
     echo "${full_command[@]}"

--- a/bin/truffleruby
+++ b/bin/truffleruby
@@ -17,8 +17,8 @@ function mtime {
     fi
 }
 
-if [ -n "${RUBY_BIN}" ]; then
-    ${RUBY_BIN}
+if [ -n "$RUBY_BIN" ]; then
+    exec "$RUBY_BIN" "$@"
 else
     mx_jar="$root"/mxbuild/dists/ruby.jar
     mvn_jar="$root"/lib/jruby-truffle.jar

--- a/mx.jruby/mx_jruby.py
+++ b/mx.jruby/mx_jruby.py
@@ -86,7 +86,7 @@ def extractArguments(cli_args):
             elif arg.startswith('-J-'):
                 vmArgs.append(arg[2:])
             elif arg.startswith('-J:'):
-                vmArgs.append('-' + arg[2:])
+                vmArgs.append('-' + arg[3:])
             elif arg == '--':
                 rubyArgs.append(arg)
                 rubyArgs.extend(args)

--- a/mx.jruby/mx_jruby.py
+++ b/mx.jruby/mx_jruby.py
@@ -110,6 +110,8 @@ def setup_ruby_home():
 def log(msg):
     print >> sys.stderr, msg
 
+# This launcher runs similarly to GraalVM,
+# with a home only containing files extracted from RUBY-ZIP.
 def ruby_command(args):
     """runs Ruby"""
     java_home = os.getenv('JAVA_HOME', '/usr')

--- a/tool/jruby_mx
+++ b/tool/jruby_mx
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-tool="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-root="$(dirname "$tool")"
-
-exec mx -p "$root" ruby "$@";

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -406,10 +406,6 @@ module ShellUtils
       command, *args = args
     end
 
-    if Utilities.mx?
-      args.unshift "-ttool/jruby_mx"
-    end
-
     sh env_vars, Utilities.find_ruby, 'spec/mspec/bin/mspec', command, '--config', 'spec/truffle/truffle.mspec', *args
   end
 

--- a/truffle/src/main/java/org/truffleruby/RubyContext.java
+++ b/truffle/src/main/java/org/truffleruby/RubyContext.java
@@ -232,22 +232,11 @@ public class RubyContext extends ExecutionContext {
                 final File jar = new File(codeSource.getLocation().getFile());
                 final File jarDir = jar.getParentFile();
 
-                if (jarDir.getName().equals("lib")) {
-                    // Conventional build or distribution
-                    return jarDir.getParentFile().getAbsolutePath();
-                } else if (jarDir.getName().equals("ruby") && new File(jarDir, "lib").exists()) {
+                if (jarDir.getName().equals("ruby") && new File(jarDir, "lib").exists()) {
                     // GraalVM build or distribution
                     return jarDir.getAbsolutePath();
                 }
             }
-        }
-
-        // Just for now, use jruby.home as the launcher sets that
-
-        final String jrubyHome = System.getProperty("jruby.home");
-
-        if (jrubyHome != null) {
-            return new File(jrubyHome).getAbsolutePath();
         }
 
         Log.LOGGER.config("home not explicitly set, and couldn't determine it from the source of the Java classfiles or the JRuby launcher");

--- a/truffle/src/main/java/org/truffleruby/RubyContext.java
+++ b/truffle/src/main/java/org/truffleruby/RubyContext.java
@@ -230,16 +230,14 @@ public class RubyContext extends ExecutionContext {
 
             if (codeSource != null && codeSource.getLocation().getProtocol().equals("file")) {
                 final File jar = new File(codeSource.getLocation().getFile());
+                final File jarDir = jar.getParentFile();
 
-                if (jar.getParentFile().getName().equals("lib")) {
+                if (jarDir.getName().equals("lib")) {
                     // Conventional build or distribution
-                    return jar.getParentFile().getParentFile().getAbsolutePath();
-                } else if (jar.getParentFile().getName().equals("ruby") && new File(jar.getParentFile(), "lib").exists()) {
+                    return jarDir.getParentFile().getAbsolutePath();
+                } else if (jarDir.getName().equals("ruby") && new File(jarDir, "lib").exists()) {
                     // GraalVM build or distribution
-                    return jar.getParentFile().getAbsolutePath();
-                } else if (jar.getParentFile().getName().equals("dists") && jar.getParentFile().getParentFile().getName().equals("mxbuild")) {
-                    // mx build
-                    return new File(jar.getParentFile().getParentFile(), "ruby-zip-extracted").getAbsolutePath();
+                    return jarDir.getAbsolutePath();
                 }
             }
         }


### PR DESCRIPTION
* No need to invoke mx.
* The home is now the same as the repo.
* Fix: add -cp/-classpath entries to the final command line.