### PR TITLE
Check assumptions in lookup

### DIFF
--- a/truffle/src/main/java/org/truffleruby/RubyContext.java
+++ b/truffle/src/main/java/org/truffleruby/RubyContext.java
@@ -24,6 +24,7 @@ import org.truffleruby.core.encoding.EncodingManager;
 import org.truffleruby.core.exception.CoreExceptions;
 import org.truffleruby.core.kernel.AtExitManager;
 import org.truffleruby.core.kernel.TraceManager;
+import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.core.objectspace.ObjectSpaceManager;
 import org.truffleruby.core.rope.RopeTable;
@@ -249,7 +250,7 @@ public class RubyContext extends ExecutionContext {
 
         assert block == null || RubyGuards.isRubyProc(block);
 
-        final InternalMethod method = ModuleOperations.lookupMethod(coreLibrary.getMetaClass(object), methodName);
+        final InternalMethod method = ModuleOperations.lookupMethod(coreLibrary.getMetaClass(object), methodName).getMethod();
 
         if (method == null || method.isUndefined()) {
             return null;

--- a/truffle/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/truffle/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -22,6 +22,7 @@ import org.truffleruby.RubyContext;
 import org.truffleruby.core.RaiseIfFrozenNode;
 import org.truffleruby.core.array.ArrayUtils;
 import org.truffleruby.core.cast.TaintResultNode;
+import org.truffleruby.core.module.ConstantLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.core.numeric.FixnumLowerNodeGen;
 import org.truffleruby.core.string.StringUtils;
@@ -97,13 +98,13 @@ public class CoreMethodNodeManager {
             module = context.getCoreLibrary().getObjectClass();
 
             for (String moduleName : fullName.split("::")) {
-                final RubyConstant constant = ModuleOperations.lookupConstant(context, module, moduleName);
+                final ConstantLookupResult constant = ModuleOperations.lookupConstant(context, module, moduleName);
 
-                if (constant == null) {
+                if (!constant.isFound()) {
                     throw new RuntimeException(StringUtils.format("Module %s not found when adding core library", moduleName));
                 }
 
-                module = (DynamicObject) constant.getValue();
+                module = (DynamicObject) constant.getConstant().getValue();
             }
         }
 

--- a/truffle/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/truffle/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -377,7 +377,7 @@ public class CoreLibrary {
         Layouts.MODULE.getFields(classClass).parentModule = Layouts.MODULE.getFields(moduleClass).start;
         Layouts.MODULE.getFields(moduleClass).addDependent(classClass);
         Layouts.CLASS.setSuperclass(classClass, moduleClass);
-        Layouts.MODULE.getFields(classClass).newVersion();
+        Layouts.MODULE.getFields(classClass).newHierarchyVersion();
 
         // Set constants in Object and lexical parents
         Layouts.MODULE.getFields(classClass).getAdoptedByLexicalParent(context, objectClass, "Class", node);

--- a/truffle/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/truffle/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -375,7 +375,6 @@ public class CoreLibrary {
         // Close the cycles
         // Set superclass of Class to Module
         Layouts.MODULE.getFields(classClass).parentModule = Layouts.MODULE.getFields(moduleClass).start;
-        Layouts.MODULE.getFields(moduleClass).addDependent(classClass);
         Layouts.CLASS.setSuperclass(classClass, moduleClass);
         Layouts.MODULE.getFields(classClass).newHierarchyVersion();
 

--- a/truffle/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -33,6 +33,7 @@ import org.truffleruby.builtins.NonStandard;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.basicobject.BasicObjectNodesFactory.ReferenceEqualNodeFactory;
 import org.truffleruby.core.cast.BooleanCastNodeGen;
+import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.string.StringOperations;
@@ -365,8 +366,8 @@ public abstract class BasicObjectNodes {
          * The only way to fail if method is not null and not undefined is visibility.
          */
         private Visibility lastCallWasCallingPrivateOrProtectedMethod(Object self, String name) {
-            final InternalMethod method = ModuleOperations.lookupMethod(coreLibrary().getMetaClass(self), name);
-            if (method != null && !method.isUndefined()) {
+            final MethodLookupResult method = ModuleOperations.lookupMethod(coreLibrary().getMetaClass(self), name);
+            if (method.isDefined()) {
                 assert method.getVisibility().isPrivate() || method.getVisibility().isProtected();
                 return method.getVisibility();
             }

--- a/truffle/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -103,7 +103,7 @@ public abstract class ClassNodes {
             Layouts.MODULE.getFields(superclass).addDependent(rubyClass);
             Layouts.CLASS.setSuperclass(rubyClass, superclass);
 
-            fields.newVersion();
+            fields.newHierarchyVersion();
         }
 
         return rubyClass;
@@ -163,7 +163,7 @@ public abstract class ClassNodes {
             fields.parentModule = Layouts.MODULE.getFields(superclass).start;
             Layouts.MODULE.getFields(superclass).addDependent(rubyClass);
 
-            fields.newVersion();
+            fields.newHierarchyVersion();
         }
 
         // Singleton classes cannot be instantiated
@@ -182,7 +182,7 @@ public abstract class ClassNodes {
         Layouts.MODULE.getFields(rubyClass).parentModule = Layouts.MODULE.getFields(superclass).start;
         Layouts.MODULE.getFields(superclass).addDependent(rubyClass);
 
-        Layouts.MODULE.getFields(rubyClass).newVersion();
+        Layouts.MODULE.getFields(rubyClass).newHierarchyVersion();
         ensureItHasSingletonClassCreated(context, rubyClass);
 
         setInstanceFactory(rubyClass, superclass);

--- a/truffle/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -100,7 +100,6 @@ public abstract class ClassNodes {
             assert RubyGuards.isRubyClass(rubyClass);
 
             fields.parentModule = Layouts.MODULE.getFields(superclass).start;
-            Layouts.MODULE.getFields(superclass).addDependent(rubyClass);
             Layouts.CLASS.setSuperclass(rubyClass, superclass);
 
             fields.newHierarchyVersion();
@@ -161,8 +160,6 @@ public abstract class ClassNodes {
 
         if (superclass != null) {
             fields.parentModule = Layouts.MODULE.getFields(superclass).start;
-            Layouts.MODULE.getFields(superclass).addDependent(rubyClass);
-
             fields.newHierarchyVersion();
         }
 
@@ -180,8 +177,6 @@ public abstract class ClassNodes {
         assert !Layouts.CLASS.getIsSingleton(rubyClass) : "Singleton classes can only be created internally";
 
         Layouts.MODULE.getFields(rubyClass).parentModule = Layouts.MODULE.getFields(superclass).start;
-        Layouts.MODULE.getFields(superclass).addDependent(rubyClass);
-
         Layouts.MODULE.getFields(rubyClass).newHierarchyVersion();
         ensureItHasSingletonClassCreated(context, rubyClass);
 

--- a/truffle/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -28,6 +28,7 @@ import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.Hashing;
 import org.truffleruby.core.basicobject.BasicObjectNodes.ReferenceEqualNode;
+import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.core.proc.ProcOperations;
 import org.truffleruby.core.proc.ProcType;
@@ -174,11 +175,11 @@ public abstract class MethodNodes {
             Object receiver = Layouts.METHOD.getReceiver(method);
             InternalMethod internalMethod = Layouts.METHOD.getMethod(method);
             DynamicObject selfMetaClass = metaClassNode.executeMetaClass(receiver);
-            InternalMethod superMethod = ModuleOperations.lookupSuperMethod(internalMethod, selfMetaClass);
-            if (superMethod == null || superMethod.isUndefined()) {
+            MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, selfMetaClass);
+            if (!superMethod.isDefined()) {
                 return nil();
             } else {
-                return Layouts.METHOD.createMethod(coreLibrary().getMethodFactory(), receiver, superMethod);
+                return Layouts.METHOD.createMethod(coreLibrary().getMethodFactory(), receiver, superMethod.getMethod());
             }
         }
 

--- a/truffle/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -22,6 +22,7 @@ import org.truffleruby.builtins.CoreMethod;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.Hashing;
+import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.language.RubyGuards;
@@ -182,12 +183,12 @@ public abstract class UnboundMethodNodes {
         public DynamicObject superMethod(DynamicObject unboundMethod) {
             InternalMethod internalMethod = Layouts.UNBOUND_METHOD.getMethod(unboundMethod);
             DynamicObject origin = Layouts.UNBOUND_METHOD.getOrigin(unboundMethod);
-            InternalMethod superMethod = ModuleOperations.lookupSuperMethod(internalMethod, origin);
-            if (superMethod == null || superMethod.isUndefined()) {
+            MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, origin);
+            if (!superMethod.isDefined()) {
                 return nil();
             } else {
                 return Layouts.UNBOUND_METHOD.createUnboundMethod(coreLibrary().getUnboundMethodFactory(),
-                        superMethod.getDeclaringModule(), superMethod);
+                        superMethod.getMethod().getDeclaringModule(), superMethod.getMethod());
             }
         }
 

--- a/truffle/src/main/java/org/truffleruby/core/module/ConstantLookupResult.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ConstantLookupResult.java
@@ -1,0 +1,47 @@
+package org.truffleruby.core.module;
+
+import java.util.ArrayList;
+
+import org.truffleruby.RubyContext;
+import org.truffleruby.language.LexicalScope;
+import org.truffleruby.language.RubyConstant;
+
+import com.oracle.truffle.api.Assumption;
+import com.oracle.truffle.api.object.DynamicObject;
+
+public class ConstantLookupResult {
+
+    private final RubyConstant constant;
+    private final Assumption[] assumptions;
+
+    public ConstantLookupResult(RubyConstant constant, Assumption assumption) {
+        this.constant = constant;
+        this.assumptions = new Assumption[]{ assumption };
+    }
+
+    public ConstantLookupResult(RubyConstant constant, ArrayList<Assumption> assumptions) {
+        this.constant = constant;
+        this.assumptions = assumptions.toArray(new Assumption[assumptions.size()]);
+    }
+
+    public boolean isFound() {
+        return constant != null;
+    }
+
+    public boolean isDeprecated() {
+        return constant != null && constant.isDeprecated();
+    }
+
+    public boolean isVisibleTo(RubyContext context, LexicalScope lexicalScope, DynamicObject module) {
+        return constant == null || constant.isVisibleTo(context, lexicalScope, module);
+    }
+
+    public RubyConstant getConstant() {
+        return constant;
+    }
+
+    public Assumption[] getAssumptions() {
+        return assumptions;
+    }
+
+}

--- a/truffle/src/main/java/org/truffleruby/core/module/ConstantLookupResult.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ConstantLookupResult.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
 package org.truffleruby.core.module;
 
 import java.util.ArrayList;

--- a/truffle/src/main/java/org/truffleruby/core/module/ConstantLookupResult.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ConstantLookupResult.java
@@ -9,8 +9,6 @@
  */
 package org.truffleruby.core.module;
 
-import java.util.ArrayList;
-
 import org.truffleruby.RubyContext;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyConstant;
@@ -23,14 +21,9 @@ public class ConstantLookupResult {
     private final RubyConstant constant;
     private final Assumption[] assumptions;
 
-    public ConstantLookupResult(RubyConstant constant, Assumption assumption) {
+    public ConstantLookupResult(RubyConstant constant, Assumption... assumptions) {
         this.constant = constant;
-        this.assumptions = new Assumption[]{ assumption };
-    }
-
-    public ConstantLookupResult(RubyConstant constant, ArrayList<Assumption> assumptions) {
-        this.constant = constant;
-        this.assumptions = assumptions.toArray(new Assumption[assumptions.size()]);
+        this.assumptions = assumptions;
     }
 
     public boolean isFound() {

--- a/truffle/src/main/java/org/truffleruby/core/module/MethodLookupResult.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/MethodLookupResult.java
@@ -9,8 +9,6 @@
  */
 package org.truffleruby.core.module;
 
-import java.util.ArrayList;
-
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.methods.InternalMethod;
 
@@ -21,17 +19,9 @@ public class MethodLookupResult {
     private final InternalMethod method;
     private final Assumption[] assumptions;
 
-    private MethodLookupResult(InternalMethod method, Assumption[] assumptions) {
+    public MethodLookupResult(InternalMethod method, Assumption... assumptions) {
         this.method = method;
         this.assumptions = assumptions;
-    }
-
-    public MethodLookupResult(InternalMethod method, Assumption assumption) {
-        this(method, new Assumption[]{ assumption });
-    }
-
-    public MethodLookupResult(InternalMethod method, ArrayList<Assumption> assumptions) {
-        this(method, assumptions.toArray(new Assumption[assumptions.size()]));
     }
 
     public MethodLookupResult withNoMethod() {

--- a/truffle/src/main/java/org/truffleruby/core/module/MethodLookupResult.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/MethodLookupResult.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby.core.module;
+
+import java.util.ArrayList;
+
+import org.truffleruby.language.Visibility;
+import org.truffleruby.language.methods.InternalMethod;
+
+import com.oracle.truffle.api.Assumption;
+
+public class MethodLookupResult {
+
+    private final InternalMethod method;
+    private final Assumption[] assumptions;
+
+    private MethodLookupResult(InternalMethod method, Assumption[] assumptions) {
+        this.method = method;
+        this.assumptions = assumptions;
+    }
+
+    public MethodLookupResult(InternalMethod method, Assumption assumption) {
+        this(method, new Assumption[]{ assumption });
+    }
+
+    public MethodLookupResult(InternalMethod method, ArrayList<Assumption> assumptions) {
+        this(method, assumptions.toArray(new Assumption[assumptions.size()]));
+    }
+
+    public MethodLookupResult withNoMethod() {
+        if (method == null) {
+            return this;
+        } else {
+            return new MethodLookupResult(null, assumptions);
+        }
+    }
+
+    public boolean isDefined() {
+        return method != null && !method.isUndefined();
+    }
+
+    public Visibility getVisibility() {
+        return method.getVisibility();
+    }
+
+    public InternalMethod getMethod() {
+        return method;
+    }
+
+    public Assumption[] getAssumptions() {
+        return assumptions;
+    }
+
+}

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -403,7 +403,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
 
     @TruffleBoundary
     public void undefMethod(RubyContext context, Node currentNode, String methodName) {
-        final InternalMethod method = ModuleOperations.lookupMethod(rubyModuleObject, methodName);
+        final InternalMethod method = ModuleOperations.lookupMethod(rubyModuleObject, methodName).getMethod();
         if (method == null) {
             throw new RaiseException(context.getCoreExceptions().nameErrorUndefinedMethod(
                     methodName,
@@ -420,17 +420,17 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
      */
     @TruffleBoundary
     public InternalMethod deepMethodSearch(RubyContext context, String name) {
-        InternalMethod method = ModuleOperations.lookupMethod(rubyModuleObject, name);
-        if (method != null && !method.isUndefined()) {
-            return method;
+        MethodLookupResult method = ModuleOperations.lookupMethod(rubyModuleObject, name);
+        if (method.isDefined()) {
+            return method.getMethod();
         }
 
         // Also search on Object if we are a Module. JRuby calls it deepMethodSearch().
         if (!RubyGuards.isRubyClass(rubyModuleObject)) { // TODO: handle undefined methods
             method = ModuleOperations.lookupMethod(context.getCoreLibrary().getObjectClass(), name);
 
-            if (method != null && !method.isUndefined()) {
-                return method;
+            if (method.isDefined()) {
+                return method.getMethod();
             }
         }
 

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -556,21 +556,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
     }
 
     public void newMethodsVersion() {
-        newVersion(new HashSet<>());
-    }
-
-    private void newVersion(Set<DynamicObject> alreadyInvalidated) {
-        if (alreadyInvalidated.contains(rubyModuleObject)) {
-            return;
-        }
-
         methodsUnmodifiedAssumption.invalidate();
-        alreadyInvalidated.add(rubyModuleObject);
-
-        // Make dependents new versions
-        for (DynamicObject dependent : dependents) {
-            Layouts.MODULE.getFields(dependent).newVersion(alreadyInvalidated);
-        }
     }
 
     public void addDependent(DynamicObject dependent) {

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -82,7 +82,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
     private final ConcurrentMap<String, RubyConstant> constants = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Object> classVariables = new ConcurrentHashMap<>();
 
-    private final CyclicAssumption unmodifiedAssumption;
+    private final CyclicAssumption methodsUnmodifiedAssumption;
     private final CyclicAssumption constantsUnmodifiedAssumption;
 
     /**
@@ -97,7 +97,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
         this.sourceSection = sourceSection;
         this.lexicalParent = lexicalParent;
         this.givenBaseName = givenBaseName;
-        this.unmodifiedAssumption = new CyclicAssumption(String.valueOf(givenBaseName) + " methods are unmodified");
+        this.methodsUnmodifiedAssumption = new CyclicAssumption(String.valueOf(givenBaseName) + " methods are unmodified");
         this.constantsUnmodifiedAssumption = new CyclicAssumption(String.valueOf(givenBaseName) + " constants are unmodified");
         start = new PrependMarker(this);
     }
@@ -558,7 +558,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
             return;
         }
 
-        unmodifiedAssumption.invalidate();
+        methodsUnmodifiedAssumption.invalidate();
         alreadyInvalidated.add(rubyModuleObject);
 
         // Make dependents new versions
@@ -576,8 +576,8 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
         return constantsUnmodifiedAssumption.getAssumption();
     }
 
-    public Assumption getUnmodifiedAssumption() {
-        return unmodifiedAssumption.getAssumption();
+    public Assumption getMethodsUnmodifiedAssumption() {
+        return methodsUnmodifiedAssumption.getAssumption();
     }
 
     public Iterable<Entry<String, RubyConstant>> getConstants() {

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -586,6 +586,11 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
         return methodsUnmodifiedAssumption.getAssumption();
     }
 
+    public Assumption getHierarchyUnmodifiedAssumption() {
+        // Both assumptions are invalidated on hierarchy changes, just pick one of them.
+        return getMethodsUnmodifiedAssumption();
+    }
+
     public Iterable<Entry<String, RubyConstant>> getConstants() {
         return constants.entrySet();
     }

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -78,7 +78,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
     private boolean hasFullName = false;
     private String name = null;
 
-    private final Map<String, InternalMethod> methods = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, InternalMethod> methods = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, RubyConstant> constants = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Object> classVariables = new ConcurrentHashMap<>();
 

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -278,6 +278,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
         SharedObjects.propagate(context, rubyModuleObject, module);
 
         ModuleChain mod = Layouts.MODULE.getFields(module).start;
+        final ModuleChain topPrependedModule = start.getParentModule();
         ModuleChain cur = start;
         while (mod != null && !(mod instanceof ModuleFields && RubyGuards.isRubyClass(((ModuleFields) mod).rubyModuleObject))) {
             if (!(mod instanceof PrependMarker)) {
@@ -290,7 +291,12 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
             mod = mod.getParentModule();
         }
 
-        newHierarchyVersion();
+        // If there were already prepended modules, invalidate the first of them
+        if (topPrependedModule != this) {
+            Layouts.MODULE.getFields(topPrependedModule.getActualModule()).newHierarchyVersion();
+        } else {
+            this.newHierarchyVersion();
+        }
     }
 
     /**

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1196,7 +1196,7 @@ public abstract class ModuleNodes {
         public boolean isMethodDefined(DynamicObject module, String name, boolean inherit) {
             final InternalMethod method;
             if (inherit) {
-                method = ModuleOperations.lookupMethod(module, name);
+                method = ModuleOperations.lookupMethod(module, name).getMethod();
             } else {
                 method = Layouts.MODULE.getFields(module).getMethod(name);
             }
@@ -1363,9 +1363,9 @@ public abstract class ModuleNodes {
         public DynamicObject publicInstanceMethod(DynamicObject module, String name,
                 @Cached("create()") BranchProfile errorProfile) {
             // TODO(CS, 11-Jan-15) cache this lookup
-            final InternalMethod method = ModuleOperations.lookupMethod(module, name);
+            final MethodLookupResult method = ModuleOperations.lookupMethod(module, name);
 
-            if (method == null || method.isUndefined()) {
+            if (!method.isDefined()) {
                 errorProfile.enter();
                 throw new RaiseException(coreExceptions().nameErrorUndefinedMethod(name, module, this));
             } else if (method.getVisibility() != Visibility.PUBLIC) {
@@ -1373,7 +1373,7 @@ public abstract class ModuleNodes {
                 throw new RaiseException(coreExceptions().nameErrorPrivateMethod(name, module, this));
             }
 
-            return Layouts.UNBOUND_METHOD.createUnboundMethod(coreLibrary().getUnboundMethodFactory(), module, method);
+            return Layouts.UNBOUND_METHOD.createUnboundMethod(coreLibrary().getUnboundMethodFactory(), module, method.getMethod());
         }
 
     }
@@ -1519,14 +1519,14 @@ public abstract class ModuleNodes {
         public DynamicObject instanceMethod(DynamicObject module, String name,
                 @Cached("create()") BranchProfile errorProfile) {
             // TODO(CS, 11-Jan-15) cache this lookup
-            final InternalMethod method = ModuleOperations.lookupMethod(module, name);
+            final MethodLookupResult method = ModuleOperations.lookupMethod(module, name);
 
-            if (method == null || method.isUndefined()) {
+            if (!method.isDefined()) {
                 errorProfile.enter();
                 throw new RaiseException(coreExceptions().nameErrorUndefinedMethod(name, module, this));
             }
 
-            return Layouts.UNBOUND_METHOD.createUnboundMethod(coreLibrary().getUnboundMethodFactory(), module, method);
+            return Layouts.UNBOUND_METHOD.createUnboundMethod(coreLibrary().getUnboundMethodFactory(), module, method.getMethod());
         }
 
     }

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -102,7 +102,7 @@ public abstract class ModuleOperations {
         RubyConstant constant = fields.getConstant(name);
         assumptions.add(fields.getConstantsUnmodifiedAssumption());
         if (constant != null) {
-            return new ConstantLookupResult(constant, assumptions);
+            return new ConstantLookupResult(constant, toArray(assumptions));
         }
 
         // Look in ancestors
@@ -111,12 +111,12 @@ public abstract class ModuleOperations {
             constant = fields.getConstant(name);
             assumptions.add(fields.getConstantsUnmodifiedAssumption());
             if (constant != null) {
-                return new ConstantLookupResult(constant, assumptions);
+                return new ConstantLookupResult(constant, toArray(assumptions));
             }
         }
 
         // Nothing found
-        return new ConstantLookupResult(null, assumptions);
+        return new ConstantLookupResult(null, toArray(assumptions));
     }
 
     private static ConstantLookupResult lookupConstantInObject(RubyContext context, DynamicObject module, String name, ArrayList<Assumption> assumptions) {
@@ -128,7 +128,7 @@ public abstract class ModuleOperations {
             RubyConstant constant = fields.getConstant(name);
             assumptions.add(fields.getConstantsUnmodifiedAssumption());
             if (constant != null) {
-                return new ConstantLookupResult(constant, assumptions);
+                return new ConstantLookupResult(constant, toArray(assumptions));
             }
 
 
@@ -137,12 +137,12 @@ public abstract class ModuleOperations {
                 constant = fields.getConstant(name);
                 assumptions.add(fields.getConstantsUnmodifiedAssumption());
                 if (constant != null) {
-                    return new ConstantLookupResult(constant, assumptions);
+                    return new ConstantLookupResult(constant, toArray(assumptions));
                 }
             }
         }
 
-        return new ConstantLookupResult(null, assumptions);
+        return new ConstantLookupResult(null, toArray(assumptions));
     }
 
     public static ConstantLookupResult lookupConstantAndObject(RubyContext context, DynamicObject module, String name, ArrayList<Assumption> assumptions) {
@@ -165,7 +165,7 @@ public abstract class ModuleOperations {
             RubyConstant constant = fields.getConstant(name);
             assumptions.add(fields.getConstantsUnmodifiedAssumption());
             if (constant != null) {
-                return new ConstantLookupResult(constant, assumptions);
+                return new ConstantLookupResult(constant, toArray(assumptions));
             }
 
             lexicalScope = lexicalScope.getParent();
@@ -307,12 +307,12 @@ public abstract class ModuleOperations {
             assumptions.add(fields.getMethodsUnmodifiedAssumption());
 
             if (method != null) {
-                return new MethodLookupResult(method, assumptions);
+                return new MethodLookupResult(method, toArray(assumptions));
             }
         }
 
         // Nothing found
-        return new MethodLookupResult(null, assumptions);
+        return new MethodLookupResult(null, toArray(assumptions));
     }
 
     public static MethodLookupResult lookupMethod(DynamicObject module, String name, Visibility visibility) {
@@ -342,12 +342,16 @@ public abstract class ModuleOperations {
                 assumptions.add(fields.getMethodsUnmodifiedAssumption());
 
                 if (method != null) {
-                    return new MethodLookupResult(method, assumptions);
+                    return new MethodLookupResult(method, toArray(assumptions));
                 }
             }
         }
 
-        return new MethodLookupResult(null, assumptions);
+        return new MethodLookupResult(null, toArray(assumptions));
+    }
+
+    private static Assumption[] toArray(ArrayList<Assumption> assumptions) {
+        return assumptions.toArray(new Assumption[assumptions.size()]);
     }
 
     @TruffleBoundary

--- a/truffle/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/truffle/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -100,7 +100,7 @@ public abstract class ModuleOperations {
         // Look in the current module
         ModuleFields fields = Layouts.MODULE.getFields(module);
         RubyConstant constant = fields.getConstant(name);
-        assumptions.add(fields.getUnmodifiedAssumption());
+        assumptions.add(fields.getConstantsUnmodifiedAssumption());
         if (constant != null) {
             return new ConstantLookupResult(constant, assumptions);
         }
@@ -109,7 +109,7 @@ public abstract class ModuleOperations {
         for (DynamicObject ancestor : Layouts.MODULE.getFields(module).parentAncestors()) {
             fields = Layouts.MODULE.getFields(ancestor);
             constant = fields.getConstant(name);
-            assumptions.add(fields.getUnmodifiedAssumption());
+            assumptions.add(fields.getConstantsUnmodifiedAssumption());
             if (constant != null) {
                 return new ConstantLookupResult(constant, assumptions);
             }
@@ -126,7 +126,7 @@ public abstract class ModuleOperations {
 
             ModuleFields fields = Layouts.MODULE.getFields(objectClass);
             RubyConstant constant = fields.getConstant(name);
-            assumptions.add(fields.getUnmodifiedAssumption());
+            assumptions.add(fields.getConstantsUnmodifiedAssumption());
             if (constant != null) {
                 return new ConstantLookupResult(constant, assumptions);
             }
@@ -135,7 +135,7 @@ public abstract class ModuleOperations {
             for (DynamicObject ancestor : Layouts.MODULE.getFields(objectClass).prependedAndIncludedModules()) {
                 fields = Layouts.MODULE.getFields(ancestor);
                 constant = fields.getConstant(name);
-                assumptions.add(fields.getUnmodifiedAssumption());
+                assumptions.add(fields.getConstantsUnmodifiedAssumption());
                 if (constant != null) {
                     return new ConstantLookupResult(constant, assumptions);
                 }
@@ -163,7 +163,7 @@ public abstract class ModuleOperations {
         while (lexicalScope != context.getRootLexicalScope()) {
             ModuleFields fields = Layouts.MODULE.getFields(lexicalScope.getLiveModule());
             RubyConstant constant = fields.getConstant(name);
-            assumptions.add(fields.getUnmodifiedAssumption());
+            assumptions.add(fields.getConstantsUnmodifiedAssumption());
             if (constant != null) {
                 return new ConstantLookupResult(constant, assumptions);
             }
@@ -217,7 +217,7 @@ public abstract class ModuleOperations {
         } else {
             final ModuleFields fields = Layouts.MODULE.getFields(module);
             final RubyConstant constant = fields.getConstant(name);
-            return new ConstantLookupResult(constant, fields.getUnmodifiedAssumption());
+            return new ConstantLookupResult(constant, fields.getConstantsUnmodifiedAssumption());
         }
     }
 

--- a/truffle/src/main/java/org/truffleruby/language/constants/LookupConstantNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/constants/LookupConstantNode.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.api.utilities.NeverValidAssumption;
 
 import java.util.ArrayList;
 
@@ -26,6 +27,7 @@ import org.truffleruby.core.module.ConstantLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyConstant;
+import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.control.RaiseException;
@@ -127,6 +129,9 @@ public abstract class LookupConstantNode extends RubyNode implements LookupConst
 
     @TruffleBoundary
     protected ConstantLookupResult doLookup(DynamicObject module, String name) {
+        if (!RubyGuards.isRubyModule(module)) {
+            return new ConstantLookupResult(null, NeverValidAssumption.INSTANCE);
+        }
         if (lookInObject) {
             return ModuleOperations.lookupConstantAndObject(getContext(), module, name, new ArrayList<>());
         } else {

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
@@ -42,7 +42,7 @@ public class CachedBoxedDispatchNode extends CachedDispatchNode {
 
         this.expectedShape = expectedShape;
         this.validShape = expectedShape.getValidAssumption();
-        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getUnmodifiedAssumption();
+        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getMethodsUnmodifiedAssumption();
         this.next = next;
         this.method = method;
         this.callNode = Truffle.getRuntime().createDirectCallNode(method.getCallTarget());

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
@@ -105,11 +105,4 @@ public class CachedBoxedDispatchNode extends CachedDispatchNode {
                 method == null ? "null" : method.toString());
     }
 
-    public InternalMethod getMethod() {
-        return method;
-    }
-
-    public Assumption getUnmodifiedAssumption() {
-        return unmodifiedAssumption;
-    }
 }

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/CachedBoxedSymbolDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/CachedBoxedSymbolDispatchNode.java
@@ -35,7 +35,7 @@ public class CachedBoxedSymbolDispatchNode extends CachedDispatchNode {
             DispatchAction dispatchAction) {
         super(cachedName, next, dispatchAction);
 
-        this.unmodifiedAssumption = Layouts.MODULE.getFields(context.getCoreLibrary().getSymbolClass()).getUnmodifiedAssumption();
+        this.unmodifiedAssumption = Layouts.MODULE.getFields(context.getCoreLibrary().getSymbolClass()).getMethodsUnmodifiedAssumption();
         this.method = method;
         this.callNode = Truffle.getRuntime().createDirectCallNode(method.getCallTarget());
         applySplittingInliningStrategy(callNode, method);

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -9,10 +9,13 @@
  */
 package org.truffleruby.language.dispatch;
 
+import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import org.truffleruby.core.string.StringOperations;
@@ -55,6 +58,14 @@ public abstract class CachedDispatchNode extends DispatchNode {
     @Override
     protected DispatchNode getNext() {
         return next;
+    }
+
+    @ExplodeLoop
+    protected static void checkAssumptions(Assumption[] assumptions) throws InvalidAssumptionException {
+        for (Assumption assumption : assumptions) {
+            CompilerAsserts.compilationConstant(assumption);
+            assumption.check();
+        }
     }
 
     protected final boolean guardName(Object methodName) {

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
@@ -39,7 +39,7 @@ public class CachedMethodMissingDispatchNode extends CachedDispatchNode {
         super(cachedName, next, dispatchAction);
 
         this.expectedClass = expectedClass;
-        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getUnmodifiedAssumption();
+        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getMethodsUnmodifiedAssumption();
         this.method = method;
         this.metaClassNode = MetaClassNodeGen.create(null);
         this.callNode = Truffle.getRuntime().createDirectCallNode(method.getCallTarget());

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/CachedReturnMissingDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/CachedReturnMissingDispatchNode.java
@@ -32,7 +32,7 @@ public class CachedReturnMissingDispatchNode extends CachedDispatchNode {
         super(cachedName, next, dispatchAction);
 
         this.expectedClass = expectedClass;
-        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getUnmodifiedAssumption();
+        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getMethodsUnmodifiedAssumption();
         this.metaClassNode = MetaClassNodeGen.create(null);
     }
 

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/CachedSingletonDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/CachedSingletonDispatchNode.java
@@ -41,7 +41,7 @@ public class CachedSingletonDispatchNode extends CachedDispatchNode {
         super(cachedName, next, dispatchAction);
 
         this.expectedReceiver = expectedReceiver;
-        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getUnmodifiedAssumption();
+        this.unmodifiedAssumption = Layouts.MODULE.getFields(expectedClass).getMethodsUnmodifiedAssumption();
         this.next = next;
         this.method = method;
         this.callNode = Truffle.getRuntime().createDirectCallNode(method.getCallTarget());

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -50,7 +50,7 @@ public abstract class DispatchNode extends RubyNode {
             String name,
             boolean ignoreVisibility) {
         return LookupMethodNode.lookupMethodWithVisibility(getContext(), frame, receiver, name,
-                ignoreVisibility, getHeadNode().onlyCallPublic);
+                ignoreVisibility, getHeadNode().onlyCallPublic).getMethod();
     }
 
     protected Object resetAndDispatch(

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -13,6 +13,8 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.object.DynamicObject;
+
+import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.methods.LookupMethodNode;
@@ -44,13 +46,13 @@ public abstract class DispatchNode extends RubyNode {
             DynamicObject blockObject,
             Object[] argumentsObjects);
 
-    protected InternalMethod lookup(
+    protected MethodLookupResult lookup(
             VirtualFrame frame,
             Object receiver,
             String name,
             boolean ignoreVisibility) {
         return LookupMethodNode.lookupMethodWithVisibility(getContext(), frame, receiver, name,
-                ignoreVisibility, getHeadNode().onlyCallPublic).getMethod();
+                ignoreVisibility, getHeadNode().onlyCallPublic);
     }
 
     protected Object resetAndDispatch(

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -157,7 +157,7 @@ public class RubyCallNode extends RubyNode {
 
         // TODO(CS): this lookup should be cached
 
-        final InternalMethod method = ModuleOperations.lookupMethod(coreLibrary().getMetaClass(receiverObject), methodName);
+        final InternalMethod method = ModuleOperations.lookupMethod(coreLibrary().getMetaClass(receiverObject), methodName).getMethod();
 
         final Object self = RubyArguments.getSelf(frame);
 

--- a/truffle/src/main/java/org/truffleruby/language/dispatch/UnresolvedDispatchNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/dispatch/UnresolvedDispatchNode.java
@@ -111,10 +111,10 @@ public final class UnresolvedDispatchNode extends DispatchNode {
         }
 
         if (receiverObject instanceof Boolean) {
-            final Assumption falseUnmodifiedAssumption = Layouts.MODULE.getFields(coreLibrary().getFalseClass()).getUnmodifiedAssumption();
+            final Assumption falseUnmodifiedAssumption = Layouts.MODULE.getFields(coreLibrary().getFalseClass()).getMethodsUnmodifiedAssumption();
             final InternalMethod falseMethod = lookup(frame, false, methodNameString, ignoreVisibility);
 
-            final Assumption trueUnmodifiedAssumption = Layouts.MODULE.getFields(coreLibrary().getTrueClass()).getUnmodifiedAssumption();
+            final Assumption trueUnmodifiedAssumption = Layouts.MODULE.getFields(coreLibrary().getTrueClass()).getMethodsUnmodifiedAssumption();
             final InternalMethod trueMethod = lookup(frame, true, methodNameString, ignoreVisibility);
             assert falseMethod != null || trueMethod != null;
 
@@ -126,7 +126,7 @@ public final class UnresolvedDispatchNode extends DispatchNode {
         } else {
             return new CachedUnboxedDispatchNode(
                     methodName, first, receiverObject.getClass(),
-                    Layouts.MODULE.getFields(coreLibrary().getLogicalClass(receiverObject)).getUnmodifiedAssumption(), method, getDispatchAction());
+                    Layouts.MODULE.getFields(coreLibrary().getLogicalClass(receiverObject)).getMethodsUnmodifiedAssumption(), method, getDispatchAction());
         }
     }
 

--- a/truffle/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
@@ -9,7 +9,6 @@
  */
 package org.truffleruby.language.methods;
 
-import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
@@ -20,7 +19,6 @@ import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 
-import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
@@ -53,17 +51,13 @@ public abstract class LookupMethodNode extends RubyNode {
                     "metaClass(self) == selfMetaClass",
                     "name == cachedName"
             },
-            assumptions = "getUnmodifiedAssumption(selfMetaClass)",
+            assumptions = "method.getAssumptions()",
             limit = "getCacheLimit()")
     protected InternalMethod lookupMethodCached(VirtualFrame frame, Object self, String name,
             @Cached("metaClass(self)") DynamicObject selfMetaClass,
             @Cached("name") String cachedName,
             @Cached("doLookup(frame, self, name)") MethodLookupResult method) {
         return method.getMethod();
-    }
-
-    protected Assumption getUnmodifiedAssumption(DynamicObject module) {
-        return Layouts.MODULE.getFields(module).getMethodsUnmodifiedAssumption();
     }
 
     @Specialization

--- a/truffle/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
@@ -61,7 +61,7 @@ public abstract class LookupMethodNode extends RubyNode {
     }
 
     protected Assumption getUnmodifiedAssumption(DynamicObject module) {
-        return Layouts.MODULE.getFields(module).getUnmodifiedAssumption();
+        return Layouts.MODULE.getFields(module).getMethodsUnmodifiedAssumption();
     }
 
     @Specialization

--- a/truffle/src/main/java/org/truffleruby/language/methods/ModuleBodyDefinitionNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/methods/ModuleBodyDefinitionNode.java
@@ -14,7 +14,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
 import com.oracle.truffle.api.object.DynamicObject;
-import org.truffleruby.Layouts;
 import org.truffleruby.core.kernel.TraceManager;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyNode;
@@ -70,7 +69,6 @@ public class ModuleBodyDefinitionNode extends RubyNode {
     @TruffleBoundary
     private LexicalScope prepareLexicalScope(LexicalScope staticLexicalScope, LexicalScope parentLexicalScope, DynamicObject module) {
         staticLexicalScope.unsafeSetLiveModule(module);
-        Layouts.MODULE.getFields(staticLexicalScope.getParent().getLiveModule()).addLexicalDependent(module);
         if (!dynamicLexicalScope) {
             return staticLexicalScope;
         } else {

--- a/truffle/src/main/java/org/truffleruby/language/objects/IsANode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/IsANode.java
@@ -39,7 +39,7 @@ public abstract class IsANode extends RubyNode {
                     "getMetaClass(self) == cachedMetaClass",
                     "module == cachedModule"
             },
-            assumptions = "getUnmodifiedAssumption(cachedModule)")
+            assumptions = "getHierarchyUnmodifiedAssumption(cachedModule)")
     public boolean isACached(Object self,
             DynamicObject module,
             @Cached("getMetaClass(self)") DynamicObject cachedMetaClass,
@@ -48,8 +48,8 @@ public abstract class IsANode extends RubyNode {
         return result;
     }
 
-    public Assumption getUnmodifiedAssumption(DynamicObject module) {
-        return Layouts.MODULE.getFields(module).getMethodsUnmodifiedAssumption();
+    public Assumption getHierarchyUnmodifiedAssumption(DynamicObject module) {
+        return Layouts.MODULE.getFields(module).getHierarchyUnmodifiedAssumption();
     }
 
     @Specialization(guards = "isRubyModule(module)", contains = "isACached")

--- a/truffle/src/main/java/org/truffleruby/language/objects/IsANode.java
+++ b/truffle/src/main/java/org/truffleruby/language/objects/IsANode.java
@@ -49,7 +49,7 @@ public abstract class IsANode extends RubyNode {
     }
 
     public Assumption getUnmodifiedAssumption(DynamicObject module) {
-        return Layouts.MODULE.getFields(module).getUnmodifiedAssumption();
+        return Layouts.MODULE.getFields(module).getMethodsUnmodifiedAssumption();
     }
 
     @Specialization(guards = "isRubyModule(module)", contains = "isACached")

--- a/truffle/src/main/java/org/truffleruby/language/supercall/LookupSuperMethodNode.java
+++ b/truffle/src/main/java/org/truffleruby/language/supercall/LookupSuperMethodNode.java
@@ -63,7 +63,7 @@ public abstract class LookupSuperMethodNode extends RubyNode {
     }
 
     public Assumption getUnmodifiedAssumption(DynamicObject module) {
-        return Layouts.MODULE.getFields(module).getUnmodifiedAssumption();
+        return Layouts.MODULE.getFields(module).getMethodsUnmodifiedAssumption();
     }
 
     protected InternalMethod getCurrentMethod(VirtualFrame frame) {


### PR DESCRIPTION
This changes how we check and invalidate assumptions for the lookup of constants and methods.
It used to be that modules have to remember whoever depended on them and invalidated all assertions, and since these relations may be cyclic due to ancestor chain + lexical lookup (for constants) we needed a set to avoid doing it multiple times.

Now, when looking up a constant or method, we collect the Assumptions as we walk the lookup chain, so to remember on what we depend. This is much more natural and does not require to compute the inverse relation of these different kinds of lookup. Therefore, for methods, each lookup node checks all assumptions from the object metaclass until the class where it finds the method.

As an example, defining a method in Object no longer invalidates the whole world, only the method lookups that have to go through Object (so call sites that call methods defined in Object,Kernel or BasicObject) :)