### PR TITLE
Fix Gem.default_dir path

### DIFF
--- a/truffle/src/main/ruby/post-boot/shims.rb
+++ b/truffle/src/main/ruby/post-boot/shims.rb
@@ -10,7 +10,7 @@ if Truffle::Boot.rubygems_enabled?
   module Gem
     # Update the default_dir to match JRuby's.
     def self.default_dir
-      File.expand_path(File.join(ConfigMap[:libdir], '..', '..', 'ruby', 'gems', 'shared'))
+      File.expand_path(File.join(ConfigMap[:libdir], 'ruby', 'gems', 'shared'))
     end
   end
 end


### PR DESCRIPTION
Saw an issue with `Gem.default_dir` going to:
`/Users/brandonfish/Documents/ruby/gems/shared`

This fixes it to:
`/Users/brandonfish/Documents/jruby/lib/ruby/gems/shared`

I think it should fix an issue seen where bundler-workarounds was not requiring bundler correctly.

cc: @pitr-ch @nirvdrum 