### PR TITLE
Java Interop

### DIFF
--- a/lib/truffle/java.rb
+++ b/lib/truffle/java.rb
@@ -1,0 +1,48 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Copyright (C) 2002 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+# Copyright (C) 2002 Jan Arne Petersen <jpetersen@uni-bonn.de>
+# Copyright (C) 2004-2006 Thomas E Enebo <enebo@acm.org>
+# Copyright (C) 2004 David Corbin <dcorbin@users.sourceforge.net>
+# Copyright (C) 2006 Michael Studman <me@michaelstudman.com>
+# Copyright (C) 2006 Kresten Krab Thorup <krab@gnu.org>
+# Copyright (C) 2007 William N Dortch <bill.dortch@gmail.com>
+# Copyright (C) 2007 Miguel Covarrubias <mlcovarrubias@gmail.com>
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+require_relative 'java/core_ext.rb'
+require_relative 'java/java_ext.rb'
+require_relative 'java/java.rb'
+
+require_relative 'java/java_utilities.rb'
+require_relative 'java/class_cache.rb'
+require_relative 'java/java_proxy_methods.rb'
+require_relative 'java/java_proxy.rb'
+require_relative 'java/concrete_java_proxy.rb'
+require_relative 'java/array_java_proxy.rb'
+
+# TODO: Add jruby streams support back in - DMM 2017-02-03
+# require_relative 'java/java_8.rb'

--- a/lib/truffle/java/array_java_proxy.rb
+++ b/lib/truffle/java/array_java_proxy.rb
@@ -1,0 +1,24 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+class ArrayJavaProxy < java.lang.Object
+  include Enumerable
+  
+  def each
+    (0...size).each do |i|
+      yield(self[i])
+    end
+    self
+  end
+
+  def inspect
+    s = "[" + self.map do |x|
+      x.to_s
+    end.join(", ") + "]"
+  end
+end

--- a/lib/truffle/java/class_cache.rb
+++ b/lib/truffle/java/class_cache.rb
@@ -1,0 +1,45 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+module JavaUtilities
+
+  HASH_MAP_CLASS = Java.java_class_by_name("java.util.concurrent.ConcurrentHashMap")
+  
+  CLASS_NEW_INSTANCE = Java.get_java_method(
+    JAVA_CLASS_CLASS, "newInstance", false, JAVA_OBJECT_CLASS)
+  
+  HASH_MAP_GET = Java.get_java_method(
+    HASH_MAP_CLASS, "get", false, JAVA_OBJECT_CLASS, JAVA_OBJECT_CLASS)
+  
+  HASH_MAP_PUT_IF_ABSENT = Java.get_java_method(
+    HASH_MAP_CLASS, "putIfAbsent", false, JAVA_OBJECT_CLASS, JAVA_OBJECT_CLASS, JAVA_OBJECT_CLASS)
+  
+  class ClassCache
+
+    def initialize
+      @cache = Java.invoke_java_method(
+         CLASS_NEW_INSTANCE, HASH_MAP_CLASS)
+    end
+
+    def [](key)
+      Java.invoke_java_method(HASH_MAP_GET, @cache, key)
+    end
+
+    def put_if_absent(key, value)
+      Java.invoke_java_method(HASH_MAP_PUT_IF_ABSENT, @cache, key, value)
+    end
+      
+  end
+
+  private_constant :ClassCache
+
+  PROXIES = ClassCache.new
+
+  private_constant :PROXIES
+
+end

--- a/lib/truffle/java/concrete_java_proxy.rb
+++ b/lib/truffle/java/concrete_java_proxy.rb
@@ -1,0 +1,14 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+class ConcreteJavaProxy < JavaProxy
+
+  def to_s
+    self.toString
+  end
+end

--- a/lib/truffle/java/core_ext.rb
+++ b/lib/truffle/java/core_ext.rb
@@ -1,0 +1,32 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# Extensions to Ruby classes
+
+# These are loads so they don't pollute LOADED_FEATURES
+require_relative 'core_ext/module.rb'
+require_relative 'core_ext/object.rb'
+require_relative 'core_ext/kernel.rb'

--- a/lib/truffle/java/core_ext/kernel.rb
+++ b/lib/truffle/java/core_ext/kernel.rb
@@ -1,0 +1,66 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# Convenience methods for top-level packages without the need to prefix e.g. `Java::java.util.ArrayList`.
+# @note These methods are undef-ed within Java package stubs (in case of *com.foo.com*).
+module Kernel
+  # Java package short-cut method.
+  # @example
+  #    java.lang.System
+  def java
+    Java.java
+  end
+  # Java package short-cut method.
+  # @example
+  #    javax.swing.SwingUtilities
+  def javax
+    Java.javax
+  end
+  # Java package short-cut method.
+  # @example
+  #    javafx.application.Platform
+  def javafx
+    Java.javafx
+  end
+  # Java package short-cut method.
+  # @example
+  #    com.google.common.base.Strings
+  def com
+    Java.com
+  end
+  # Java package short-cut method.
+  # @example
+  #    org.json.JSONArray
+  def org
+    Java.org
+  end
+
+  private :java
+  private :javax
+  private :javafx
+  private :com
+  private :org
+end

--- a/lib/truffle/java/core_ext/module.rb
+++ b/lib/truffle/java/core_ext/module.rb
@@ -1,0 +1,91 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# Extensions to the standard Module package.
+class Module
+  private
+
+  ##
+  # Includes a Java package into this class/module. The Java classes in the
+  # package will become available in this class/module, unless a constant
+  # with the same name as a Java class is already defined.
+  #
+  def include_package(package)
+    package = package.package_name if package.respond_to?(:package_name)
+
+    if defined? @included_packages
+      @included_packages << package
+      return
+    end
+
+    @included_packages = [ package ]
+    @java_aliases ||= {}
+
+    def self.const_missing(constant)
+      real_name = @java_aliases[constant] || constant
+
+      java_class = nil
+      last_error = nil
+
+      @included_packages.each do |package|
+          begin
+            java_class = JavaUtilities.get_java_class("#{package}.#{real_name}")
+          rescue NameError
+            # we only rescue NameError, since other errors should bubble out
+            last_error = $!
+          end
+          break if java_class
+      end
+
+      if java_class
+        return JavaUtilities.create_proxy_class(constant, java_class, self)
+      else
+        # try to chain to super's const_missing
+        begin
+          return super
+        rescue NameError
+          # super didn't find anything either, raise our Java error
+          raise NameError.new("#{constant} not found in packages #{@included_packages.join(', ')}; last error: #{last_error.message}")
+        end
+      end
+    end
+  end
+
+  # Imports the package specified by +package_name+, first by trying to scan JAR resources
+  # for the file in question, and failing that by adding a const_missing hook
+  # to try that package when constants are missing.
+  def import(package_name, &block)
+    if package_name.respond_to?(:java_class) || (String === package_name && package_name.split(/\./).last =~ /^[A-Z]/)
+      return super(package_name, &block)
+    end
+    include_package(package_name, &block)
+  end
+
+  def java_alias(new_id, old_id)
+    (@java_aliases ||= {})[new_id] = old_id
+  end
+
+end

--- a/lib/truffle/java/core_ext/object.rb
+++ b/lib/truffle/java/core_ext/object.rb
@@ -1,0 +1,118 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+class Object
+  
+  # Import one or many Java classes as follows:
+  #
+  #   java_import java.lang.System
+  #   java_import java.lang.System, java.lang.Thread
+  #   java_import [java.lang.System, java.lang.Thread]
+  #
+  # @!visibility public
+  def java_import(*import_classes)
+    import_classes = import_classes.flatten
+    
+    import_classes.map do |import_class|
+      case import_class
+      when String
+        cc = java.lang.Character
+        valid_name = import_class.split(".").all? do |frag|
+          cc.java_identifier_start? frag[0].ord and
+          frag.each_char.all? {|c| cc.java_identifier_part? c.ord }
+        end
+        unless valid_name
+          raise ArgumentError.new "not a valid Java identifier: #{import_class}"
+        end
+        # pull in the class
+        raise ArgumentError.new "must use jvm-style name: #{import_class}" if import_class.include? "::"
+        import_class = JavaUtilities.get_proxy_class(import_class)
+      when Module
+        if import_class.respond_to? "java_class"
+          # ok, it's a proxy
+        else
+          raise ArgumentError.new "not a Java class or interface: #{import_class}"
+        end
+      else
+        raise ArgumentError.new "invalid Java class or interface: #{import_class}"
+      end
+
+      java_class = import_class.java_class
+      class_name = java_class.simple_name
+
+      if block_given?
+        package = java_class.package
+
+        # package can be nil if it's default or no package was defined by the classloader
+        if package
+          package_name = package.name
+        elsif java_class.canonical_name =~ /(.*)\.[^.]$/
+          package_name = $1
+        else
+          package_name = ""
+        end
+
+        constant = yield(package_name, class_name)
+      else
+        constant = class_name
+
+        # Inner classes are separated with $, get last element
+        if constant =~ /\$([^$])$/
+          constant = $1
+        end
+      end
+
+      unless constant =~ /^[A-Z].*/
+        raise ArgumentError.new "cannot import class `" + java_class.name + "' as `" + constant + "'"
+      end
+
+      # JRUBY-3453: Make import not complain if Java already has already imported the specific Java class
+      # If no constant is defined, or the constant is not already set to the java_import, assign it
+      eval_str = "if !defined?(#{constant}) || #{constant} != import_class; #{constant} = import_class; end"
+      if Module === self
+        class_eval(eval_str, __FILE__, __LINE__)
+      else
+        eval(eval_str, binding, __FILE__, __LINE__)
+      end
+
+      import_class
+    end
+  end
+  private :java_import
+
+  # @private
+  def handle_different_imports(*args, &block)
+    if args.first.respond_to?(:java_class)
+      java_import(*args, &block)
+    else
+      other_import(*args, &block)
+    end
+  end
+  
+  unless respond_to?(:import)
+    alias :import :java_import
+  end
+end

--- a/lib/truffle/java/interface_java_proxy.rb
+++ b/lib/truffle/java/interface_java_proxy.rb
@@ -1,0 +1,10 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+class InterfaceJavaProxy
+end

--- a/lib/truffle/java/java.rb
+++ b/lib/truffle/java/java.rb
@@ -1,0 +1,189 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+module Java
+  class JavaObject
+
+    NULL_LOCK = Mutex.new
+
+    attr_reader :value
+
+    private :value
+
+    private_constant :NULL_LOCK
+
+    def initialize(a_value)
+      if a_value != nil && a_value.class != Truffle::Interop::Foreign
+        raise ArgumentError, "Can only wrap native java objects"
+      end
+      @value = a_value
+    end
+
+    def to_s
+      return @value.java_send("toString") if @value != nil
+      ""
+    end
+
+    def wrap obj
+      return JavaObject.new(obj.value) if obj.is_kind_of?(JavaObject)
+    end
+
+    def hash
+      @value.hashCode() if @value != nil
+      0
+    end
+
+    def eql?(another)
+      return Truffle::Interop::Java.java_eql?(@value, @value)
+    end
+
+    alias_method :eql?, :==
+
+    def equal?(another)
+      nil != @value and JavaObject === another and @value.equals(another.value)
+    end
+
+    def java_type
+      @value.getClass().getName()
+    end
+
+    def java_class
+      JavaClass.get(@value.getClass())
+    end
+
+    def length
+      raise TypeError, "Not a java array"
+    end
+
+    def java_proxy?
+      true
+    end
+
+    def synchronized(&block)
+      return @value.__synchronize__(block) if @value != nil
+      NULL_LOCK.synchronize block
+    end
+
+    def marshal_dump
+    end
+
+    def marshal_load
+    end
+  end
+
+  class JavaArray < JavaObject
+    def length
+      java.lang.reflect.Array.getLength(@value)
+    end
+  end
+
+  class JavaClass
+  end
+
+  class JavaPackage < Module
+
+    attr_reader :package_name
+    attr_reader :children
+
+    def self.new(*name_parts)
+      const_name = name_parts.reduce("") { |memo, obj| memo + obj.capitalize }
+      return ::Java.const_get(const_name) if ::Java.const_defined?(const_name, false)
+      super(*name_parts)
+    end
+
+    def initialize(*name_parts)
+      ruby_name = name_parts.reduce("") do |memo, obj| memo + obj.capitalize end
+      java_name = name_parts.join(".")
+      @package_name = java_name
+      @children = {}
+      ::Java.const_set(ruby_name, self)
+      parent = JavaPackage.new(*name_parts.first(name_parts.size - 1)) unless name_parts.size <= 1
+      parent.add_child(name_parts.last, self) unless parent == nil
+      super()
+    end
+
+    def self.capitalised_name(name)
+      name = ""
+      package_name.split(".").each do |s|
+        name += s.capitalize
+      end
+    end
+
+    def to_s
+      @package_name
+    end
+
+    def inspect
+      super.to_s
+    end
+
+    def const_missing(name)
+       method_missing(name)
+    end
+
+    def add_child(package, name)
+      @children[name] = package
+    end
+
+    def method_missing(name, *args)
+      if args.size != 0
+        raise ArgumentError, "#{self} does not have a method #{name} with #{args.size} arguments."
+      end
+
+      val = @children[name]
+
+      return val if val != nil
+
+      val = JavaUtilities.get_relative_package_or_class(self, name)
+      @children[name] = val
+
+      if name[0] == name[0].upcase && !val.kind_of?(JavaPackage)
+        const_set(name, val)
+      end
+      val
+    end
+  end
+
+  class JavaProxy
+  end
+
+  @packages = {}
+
+  def self.const_missing name
+    JavaPackage.new(name.to_s)
+  end
+
+  def self.method_missing(name, *args)
+    if args.size != 0
+      raise ArgumentError, "Java does not have a method #{name} with #{args.size} arguments."
+    end
+
+    val = @packages[name.capitalize]
+
+    return val if val != nil
+
+    val = JavaUtilities.get_package_module_dot_format(name.to_s)
+
+    @packages[name.capitalize] = val
+  end
+
+  def self.java_to_ruby obj
+    # TODO: DMM 2017-02-07
+    # We'll do something here, not sure what yet.
+  end
+
+  def self.ruby_to_java obj
+  end
+
+  def self.java_to_primitive obj
+  end
+
+  def self.new_proxy_instance2 wrapper, interfaces
+  end
+
+end

--- a/lib/truffle/java/java_ext.rb
+++ b/lib/truffle/java/java_ext.rb
@@ -1,0 +1,34 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# Extensions to Java classes
+
+# TODO: Recreate this JRuby functionality - DMM 2017-02-06
+# require_relative 'java_ext/java.lang.rb'
+# require_relative 'java_ext/java.util.rb'
+# require_relative 'java_ext/java.util.regex.rb'
+# require_relative 'java_ext/java.io.rb'
+# require_relative 'java_ext/java.net.rb'

--- a/lib/truffle/java/java_ext/java.io.rb
+++ b/lib/truffle/java/java_ext/java.io.rb
@@ -1,0 +1,68 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# NOTE: these Ruby extensions were moved to native code!
+# @see org.jruby.javasupport.ext.JavaIo.java
+# this file is no longer loaded but is kept to provide doc stubs
+
+# Java *java.io.InputStream* objects are convertible to Ruby `IO`.
+# @note Only explicit (or customized) Ruby methods are listed here,
+#       instances will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html
+class Java::java::io::InputStream
+  # Convert a Java input stream to a Ruby `IO`.
+  # @option opts [Types] autoclose changes `IO#autoclose=` if set
+  # @return [IO]
+  def to_io(opts = nil)
+    # stub implemented in org.jruby.javasupport.ext.JavaIo.java
+  end
+end if false
+
+# Java *java.io.OutputStream* objects are convertible to Ruby `IO`.
+# @note Only explicit (or customized) Ruby methods are listed here,
+#       instances will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/io/OutputStream.html
+class Java::java::io::OutputStream
+  # Convert a Java output stream to a Ruby `IO`.
+  # @option opts [Types] autoclose changes `IO#autoclose=` if set
+  # @return [IO]
+  def to_io(opts = nil)
+    # stub implemented in org.jruby.javasupport.ext.JavaIo.java
+  end
+end if false
+
+# Java channels (*java.nio.channels.Channel*) are convertible to Ruby `IO`.
+# @note Only explicit (or customized) Ruby methods are listed here,
+#       instances will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/nio/channels/Channel.html
+module Java::java::nio::channels::Channel
+  # Convert a Java channel to a Ruby `IO`.
+  # @option opts [Types] autoclose changes `IO#autoclose=` if set
+  # @return [IO]
+  def to_io(opts = nil)
+    # stub implemented in org.jruby.javasupport.ext.JavaIo.java
+  end
+end if false

--- a/lib/truffle/java/java_ext/java.lang.rb
+++ b/lib/truffle/java/java_ext/java.lang.rb
@@ -1,0 +1,471 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# NOTE: these Ruby extensions were moved to native code!
+# - **org.jruby.javasupport.ext.JavaLang.java**
+# - **org.jruby.javasupport.ext.JavaLangReflect.java**
+# this file is no longer loaded but is kept to provide doc stubs
+
+# @private internal helper
+module JavaUtilities::ModifierShortcuts
+  # @private
+  Modifier = java.lang.reflect.Modifier
+
+  def public?
+    Modifier.is_public(modifiers)
+  end
+
+  def protected?
+    Modifier.is_protected(modifiers)
+  end
+
+  def private?
+    Modifier.is_private(modifiers)
+  end
+
+  def final?
+    Modifier.is_final(modifiers)
+  end
+
+  def static?
+    Modifier.is_static(modifiers)
+  end
+end
+
+# *java.lang.Runnable* instances allow for a `to_proc` conversion.
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/Runnable.html
+module Java::java::lang::Runnable
+  # @return [Proc] calling #run when caled
+  def to_proc
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # proc { self.run }
+  end
+end if false
+
+# A `java.lang.Iterable` will act like a Ruby `Enumerable`.
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html
+module Java::java::lang::Iterable
+  include ::Enumerable
+
+  # Ruby style `Enumerable#each` iteration for Java iterable types.
+  # @return [Java::java::util::Iterable] self (since 9.1.3)
+  # @return [Enumerator] if called without a block to yield to
+  def each(&block)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # iter = iterator
+    # yield(iter.next) while iter.hasNext
+  end
+
+  # Ruby style `Enumerable#each_with_index` for Java iterable types.
+  # @return [Java::java::util::Iterable] self (since 9.1.3)
+  # @return [Enumerator] if called without a block to yield to
+  def each_with_index(&block)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # index = 0
+    # iter = iterator
+    # while iter.hasNext
+    #   yield(iter.next, index)
+    #   index += 1
+    # end
+  end
+
+  # Re-defined `Enumerable#to_a`.
+  # @return [Array]
+  # @since 9.1.3
+  def to_a
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+  alias entries to_a
+
+  # Re-defined `Enumerable#count`.
+  # @return [Integer] matched elements count
+  # @since 9.1.3
+  def count(obj = nil, &block)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+end if false
+
+# *java.lang.Comparable* mixes in Ruby's `Comparable` support.
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html
+module Java::java::lang::Comparable
+  include ::Comparable
+
+  def <=>(a)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # return nil if a.nil?
+    # compareTo(a)
+  end
+end if false
+
+# Java's *java.lang.Throwable* (exception/error) classes resemble Ruby's `Exception`.
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html
+class Java::java::lang::Throwable
+
+  # @return [Array] the mapped stack-trace
+  def backtrace
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # stack_trace.map(&:to_s)
+  end
+
+  # @note Noop as Java exceptions can not change their stack-trace.
+  def set_backtrace(trace)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # Always a non-nil to follow Ruby's {Exception#message} conventions.
+  # @note getMessage still returns nil, when no message was given for the Java exception!
+  # @return [String]
+  def message
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # getLocalizedMessage || ''
+  end
+
+  def to_s
+    # message
+  end
+
+  def inspect
+    # to_string
+  end
+
+  # Adds case compare against `NativeException` wrapped throwables.
+  # @example
+  #    begin
+  #      java.lang.Integer.parseInt('gg', 16)
+  #    rescue NativeException => ex
+  #      expect( java.lang.NumberFormatException === ex ).to be true
+  #    end
+  # @return [true, false]
+  def self.===(ex)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+end if false
+
+# *java.lang.Character* represents an object wrapper for Java's *char* primitive.
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/Character.html
+class Java::java::lang::Character
+
+  # `java.lang.Character.isJavaIdentifierStart(char)`
+  # @return [true, false]
+  def self.java_identifier_start?(char)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # `java.lang.Character.isJavaIdentifierPart(char)`
+  # @return [true, false]
+  def self.java_identifier_part?(char)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+end if false
+
+# *java.lang.Class*
+# @note Only explicit (or customized) Ruby methods are listed here,
+#       Java classes will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/Class.html
+# @todo likely to get revised!
+class Java::java::lang::Class
+  include ::Comparable
+  # include ::JavaUtilities::ModifierShortcuts
+
+  # @return [Class, Module] the proxy class (or module in case of an interface).
+  def ruby_class
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # ::JRuby.runtime.java_support.get_proxy_class_from_cache(self)
+  end
+
+  # @return [String] the Java class name
+  def to_s
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [String] `java.lang.Class#toString`
+  def inspect
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [Java::java::io::InputStream]
+  def resource_as_stream(name)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [String]
+  def resource_as_string(name)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # resource_as_stream(name).to_io.read
+  end
+
+  # @return [true, false]
+  def annotations?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # !annotations.empty?
+  end
+
+  # @return [true, false]
+  def declared_annotations?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # !declared_annotations.empty?
+  end
+
+  def <=>(other)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # return nil unless other.class == java::lang::Class
+    #
+    # return  0 if self == other
+    # return +1 if self.is_assignable_from(other)
+    # return -1 if other.is_assignable_from(self)
+  end
+
+  def java_instance_methods
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  def declared_instance_methods
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  def java_class_methods
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  def declared_class_methods
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [true, false]
+  # @since 9.1
+  def anonymous?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [true, false]
+  # @since 9.1
+  def abstract?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [true, false]
+  def public?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [true, false]
+  def protected?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [true, false]
+  def private?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [true, false]
+  def final?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @private
+  def static?
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+end if false
+
+# *java.lang.ClassLoader*
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html
+class Java::java::lang::ClassLoader
+  # @return [Java::java::io::InputStream]
+  def resource_as_stream(name)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+
+  # @return [String]
+  def resource_as_string(name)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+    # resource_as_stream(name).to_io.read
+  end
+
+  def resource_as_url(name)
+    # stub implemented in org.jruby.javasupport.ext.JavaLang.java
+  end
+end if false
+
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Constructor.html
+class Java::java::lang::reflect::Constructor
+
+  def return_type
+    nil
+  end
+
+  def argument_types
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+    # parameter_types
+  end
+
+  # @return [true, false]
+  def public?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def protected?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def private?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def final?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @private
+  def static?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+end if false
+
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Method.html
+class Java::java::lang::reflect::Method
+
+  def return_type
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  def argument_types
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+    # parameter_types
+  end
+
+  def invoke_static(*args)
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+    # invoke(nil, *args)
+  end
+
+  # @return [true, false]
+  # @since 9.1
+  def abstract?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def public?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def protected?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def private?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def final?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def static?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+end if false
+
+# @see http://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Field.html
+class Java::java::lang::reflect::Field
+
+  def value_type
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  def value(obj)
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+    # get(obj)
+  end
+
+  def set_value(obj, value)
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+    # set(obj, value)
+  end
+
+  def static_value
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+    # get(nil)
+  end
+
+  def set_static_value(value)
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+    # set(nil, value)
+  end
+
+  # @return [true, false]
+  def public?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def protected?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def private?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def final?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+  # @return [true, false]
+  def static?
+    # stub implemented in org.jruby.javasupport.ext.JavaLangReflect.java
+  end
+
+end if false
+
+Java::byte[].class_eval do
+  def ubyte_get(index)
+    byte = self[index]
+    byte += 256 if byte < 0
+    byte
+  end
+
+  def ubyte_set(index, value)
+    value -= 256 if value > 127
+    self[index] = value
+  end
+end if false

--- a/lib/truffle/java/java_ext/java.net.rb
+++ b/lib/truffle/java/java_ext/java.net.rb
@@ -1,0 +1,52 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# NOTE: these Ruby extensions were moved to native code!
+# - **org.jruby.javasupport.ext.JavaNet.java**
+# this file is no longer loaded but is kept to provide doc stubs
+
+# *java.net.URL* extensions.
+# @note Only explicit (or customized) Ruby methods are listed here,
+#       instances will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/net/URL.html
+class Java::java::net::URL
+  # Open the URL stream and yield it as a Ruby `IO`.
+  # @return [IO] if no block given, otherwise yielded result
+  def open(&block)
+    # stub implemented in org.jruby.javasupport.ext.JavaNet.java
+    # stream = openStream
+    # io = stream.to_io
+    # if block
+    #   begin
+    #     block.call(io)
+    #   ensure
+    #     stream.close
+    #   end
+    # else
+    #   io
+    # end
+  end
+end if false

--- a/lib/truffle/java/java_ext/java.util.rb
+++ b/lib/truffle/java/java_ext/java.util.rb
@@ -1,0 +1,518 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# NOTE: these Ruby extensions were moved to native code!
+# - **org.jruby.javasupport.ext.JavaUtil.java**
+# this file is no longer loaded but is kept to provide doc stubs
+
+# *java.util.Collection* is enhanced (not just) to act like Ruby's `Enumerable`.
+# @note Only explicit (or customized) Ruby methods are listed here,
+#       instances will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/util/Collection.html
+module Java::java::util::Collection
+  include ::Enumerable
+
+  # @see Java::java::lang::Iterable#each
+  def each(&block)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+  # @see Java::java::lang::Iterable#each_with_index
+  def each_with_index(&block)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+  # Re-implemented for efficiency, so that we do not (`#each`) loop over the collection
+  # for types where its not necessary (e.g. *java.util.Set* instances), uses (native) `java.util.Collection#contains`.
+  # @see Java::java::lang::Iterable#include?
+  # @return [true, false]
+  # @since 9.1.3
+  def include?(obj)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+  alias member? include?
+
+  # `Enumerable#first`
+  # @note Might collide with *java.util.Deque#getFirst* in which case you want to alias its ruby_ name
+  #       so that the Ruby version is used e.g. `java.util.ArrayDeque.class_eval { alias first ruby_first }`
+  # @since 9.1
+  def first(count = nil)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+  alias ruby_first first
+
+  # Pushes (adds) and element into this collection.
+  # @example
+  #    coll = java.util.ArrayDeque.new
+  #    coll << 111
+  # @return [Java::java::util::Collection]
+  def <<(a)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+    # add(a)
+    # self
+  end
+
+  # Join this collection with another (adding all elements).
+  # @example
+  #    coll1 = java.util.ArrayList.new [1, 2]
+  #    coll2 = java.util.LinkedHashSet.new [2, 3]
+  #    coll1 + coll2 # [ 1, 2, 2, 3 ] (java.util.ArrayList)
+  #    coll2 + coll1 # [ 2, 3, 1 ] (java.util.LinkedHashSet)
+  # @return [Java::java::util::Collection] a new collection
+  def +(oth)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+    # nw = self.dup
+    # nw.addAll(oth)
+    # nw
+  end
+
+  # Subtract all elements in the provided collection from this one.
+  # @example
+  #    coll1= java.util.HashSet.new [2, 3]
+  #    coll2 = java.util.LinkedList.new [1, 2]
+  #    coll1 - coll2 # [ 3 ] (java.util.HashSet)
+  # @return [Java::java::util::Collection] a new collection
+  def -(oth)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+    # nw = self.dup
+    # nw.removeAll(oth)
+    # nw
+  end
+
+  # @return [Integer] the collection size
+  def size
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+  alias length size
+
+  # @private Not sure if this makes sense to have.
+  def join(*args)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+  # Converts a collection instance to an array.
+  # @return [Array]
+  def to_a
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+  # @since 9.1.3
+  alias entries to_a
+
+  # Return a dup-ed collection (if possible).
+  # @example
+  #    arr = java.util.concurrent.CopyOnWriteArrayList.new ['0']
+  #    arr.dup # ['0'] a new CopyOnWriteArrayList instance
+  # @return [Java::java::util::Collection] of the same type as target.
+  # @since 9.1
+  def dup
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+end if false
+
+# A *java.util.Enumeration* instance might be iterated Ruby style.
+# @see http://docs.oracle.com/javase/8/docs/api/java/util/Enumeration.html
+module Java::java::util::Enumeration
+  include ::Enumerable
+
+  def each
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+    # while hasMoreElements
+    #   yield nextElement
+    # end
+  end
+end if false
+
+# A *java.util.Iterator* acts like an `Enumerable`.
+# @see http://docs.oracle.com/javase/8/docs/api/java/util/Iterator.html
+module Java::java::util::Iterator
+  include ::Enumerable
+
+  def each
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+    # while hasNext
+    #   yield next
+    # end
+  end
+end if false
+
+# Ruby extensions for *java.util.List* instances.
+# All of the {@link Java::java::util::Collection} methods are available.
+# @note Only explicit (or customized) Ruby methods are listed here,
+#       instances will have all of their Java methods available.
+# @see Java::java::util::Collection
+# @see http://docs.oracle.com/javase/8/docs/api/java/util/List.html
+module Java::java::util::List
+  # @private
+  module RubyComparators
+    class BlockComparator
+      include java::util::Comparator
+
+      def initialize(block)
+        @block = block
+      end
+
+      def compare(o1, o2)
+        @block.call(o1, o2)
+      end
+    end
+    class SpaceshipComparator
+      include java::util::Comparator
+      def compare(o1, o2)
+        o1 <=> o2
+      end
+    end
+  end
+  private_constant :RubyComparators
+
+  # Element retrieval (slicing) similar to `Array#[]`.
+  # @example
+  #    list = java.util.ArrayList.new ['foo', 'bar', 'baz']
+  #    list[0] # 'foo'
+  #    list[-2] # 'bar'
+  #    list[10] # nil
+  #    list[1, 2] # ['bar','baz'] sub-list
+  #    list[0..2] # ['foo','bar'] sub-list
+  # @return [Java::java::util::List, Object, nil] sub-list, list element or nil
+  # @note Like with an `Array` will return *nil* for "out-of-bound" indexes.
+  def [](i1, i2 = nil)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+  # Set an element or multiple elements like `Array#[]=`.
+  # @example
+  #    list = java.util.ArrayList.new ['foo', 'bar', 'baz']
+  #    list[-3] = 1 # [1, 'bar', 'baz']
+  #    list[4] = 4 # [1, 'bar', 'baz', nil, 4]
+  #    list[1..2] = 3 # [1, nil, 3, 4]
+  # @return [Object] set value
+  def []=(i, val)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+  # Return an index for the first occurrence of the matched element (similar to `Array#index`).
+  # @example
+  #    list = java.util.LinkedList.new [ 'foo', 'bar', 'foo' ]
+  #    list.index 'foo' # 0
+  #    list.index 'baz' # nil
+  #    list.index { |e| e.start_with?('ba') } # 1
+  # @return [Integer, nil, Enumerator]
+  def index(obj = nil, &block)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+  # Return an index for the last occurrence of the matched element (similar to `Array#rindex`).
+  # @example
+  #    list = java.util.LinkedList.new [ 'foo', 'bar', 'foo' ]
+  #    list.rindex 'foo' # 2
+  #    list.rindex 'baz' # nil
+  #    list.rindex { |e| e.start_with?('ba') } # 1
+  # @return [Integer, nil, Enumerator]
+  def rindex(obj = nil, &block)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+
+  # Sort a (mutable) list, returning a new instance of same type.
+  # @example
+  #    list = java.util.ArrayList.new [ 22, 1, 333 ]
+  #    list.sort # [ 1, 22, 333 ] (java.util.ArrayList) ... only works on Java 7 by default!
+  # @note Since Java 8 this method collides with the built-in *java.util.List#sort* in which case you want to alias its
+  #       ruby_ name for list types where you want to have the Ruby version available
+  #       e.g. `java.util.ArrayList.class_eval { alias sort ruby_sort }`
+  # @return [Java::java::util::List] dup-ed list with element sorted
+  def sort(&block)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+    # comparator = block ? RubyComparators::BlockComparator.new(block) : RubyComparators::SpaceshipComparator.new
+    # list = self.dup
+    # java::util::Collections.sort(list, comparator)
+    # list
+  end
+  alias ruby_sort sort
+
+  # Sort a (mutable) list, in place.
+  # @example
+  #    list = java.util.Vector.new [ '22', '1', '333' ]
+  #    list.sort! { |a, b| a.length <=> b.length } # [ '1', '22', '333' ]
+  # @return [Java::java::util::List] self
+  def sort!(&block)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+    # comparator = block ? RubyComparators::BlockComparator.new(block) : RubyComparators::SpaceshipComparator.new
+    # java::util::Collections.sort(self, comparator)
+    # self
+  end
+
+  # @see Java::java::util::Collection#to_a
+  # @return [Array]
+  def to_a
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+  alias_method :to_ary, :to_a
+
+  # `Enumerable#first`
+  # @example
+  #    list = java.util.ArrayList.new [1, 2, 3]
+  #    expect( list.first ).to eq 1
+  #    expect( list.first(2).to_a ).to eq [1, 2]
+  #    list = java.util.LinkedList.new
+  #    expect( list.ruby_first ).to be nil
+  # @note Might collide with *#getFirst* on some list impls in which case you want to alias its ruby_ name
+  #       so that the Ruby version is used e.g. `java.util.LinkedList.class_eval { alias first ruby_first }`
+  # @since 9.1
+  def first(count = nil)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+  alias ruby_first first
+
+  # `Array#last`
+  # @example
+  #    list = java.util.Vector.new [1, 2, 3]
+  #    expect( list.last ).to eq 3
+  #    expect( list.last(2).to_a ).to eq [2, 3]
+  # @note Might collide with *#getLast* on some list impls in which case you want to alias its ruby_ name
+  #       so that the Ruby version is used e.g. `java.util.LinkedList.class_eval { alias last ruby_last }`
+  # @since 9.1
+  def last(count = nil)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtil.java
+  end
+  alias ruby_last last
+
+end if false
+
+# Ruby extensions for *java.util.Map* instances.
+# Generally maps behave like Ruby's `Hash` objects.
+# @see http://docs.oracle.com/javase/8/docs/api/java/util/Map.html
+module Java::java::util::Map
+
+  def default(arg = nil)
+    # stub
+  end
+
+  def default=(value)
+    # stub
+  end
+
+  def default_proc()
+    # stub
+  end
+
+  def default_proc=(proc)
+    # stub
+  end
+
+  alias size length
+
+  def empty?
+    # stub
+  end
+
+  # @return [Array]
+  def to_a
+    # stub
+  end
+
+  # @return [Proc]
+  def to_proc
+    # stub
+  end
+
+  # @return [Hash]
+  def to_h
+    # stub
+  end
+  alias to_hash to_h
+
+  def [](key)
+    # stub
+  end
+
+  def []=(key, value)
+    # stub
+  end
+  alias store []
+
+  def fetch(key, default = nil, &block)
+    # stub
+  end
+
+  def key?(key)
+    # stub
+  end
+  alias has_key? key?
+  alias include? key?
+  alias member? key?
+
+  def value?(value)
+    # stub
+  end
+  alias has_value? value?
+
+  def each(&block)
+    # stub
+  end
+  alias each_pair each
+
+  def each_key(&block)
+    # stub
+  end
+
+  def each_value(&block)
+    # stub
+  end
+
+  def ==(other)
+    # stub
+  end
+
+  def <(other)
+    # stub
+  end
+
+  def <=(other)
+    # stub
+  end
+
+  def >(other)
+    # stub
+  end
+
+  def >=(other)
+    # stub
+  end
+
+  def select(&block)
+    # stub
+  end
+
+  def select!(&block)
+    # stub
+  end
+
+  def keep_if(&block)
+    # stub
+  end
+
+  def sort(&block)
+    # stub
+  end
+
+  def delete(key, &block)
+    # stub
+  end
+
+  def delete_if(&block)
+    # stub
+  end
+
+  def reject(&block)
+    # stub
+  end
+
+  def reject!(&block)
+    # stub
+  end
+
+  def invert
+    # stub
+  end
+
+  def key(value)
+    # stub
+  end
+
+  def keys
+    # stub
+  end
+
+  def values
+    # stub
+  end
+  alias ruby_values values
+
+  def values_at(*args)
+    # stub
+  end
+
+  def fetch_values(*args)
+    # stub
+  end
+
+  def clear
+    # stub
+  end
+  alias ruby_clear clear
+
+  # `Hash#merge`
+  # @example
+  #    map = java.util.HashMap.new({ 1 => '1', 2 => '2' })
+  #    map.merge 1 => 'one' # { 1 => "one", 2 => "2" } (java.util.HashMap)
+  # @note Since Java 8 this method collides with the built-in *java.util.Map#merge* in which case you want to alias its
+  #       ruby_ name for map types where you want to have the Ruby version available
+  #       e.g. `java.util.HashMap.class_eval { alias merge ruby_merge }`
+  # @return [Java::java::util::Map] merged map instance
+  def merge(other, &block)
+    # stub
+  end
+  alias ruby_merge merge
+
+  def merge!(other, &block)
+    # stub
+  end
+
+  # `Hash#replace`
+  # @example
+  #    map1 = java.util.Hashtable.new({ 1 => '1', 2 => '2' })
+  #    map2 = java.util.LinkedHashMap.new; map2[1] = 'one'
+  #    map1.replace map2 # { 1 => "one" } (java.util.Hashtable)
+  # @note Since Java 8 this method collides with the built-in *java.util.Map#replace* in which case you want to alias its
+  #       ruby_ name for map types where you want to have the Ruby version available
+  #       e.g. `java.util.Hashtable.class_eval { alias replace ruby_replace }`
+  # @return [Java::java::util::Map] replaced map instance
+  def replace(other)
+    # stub
+  end
+  alias ruby_replace replace
+
+  def flatten(level = nil)
+    # stub
+  end
+
+  def assoc(obj)
+    # stub
+  end
+
+  def rassoc(obj)
+    # stub
+  end
+
+  def any?(&block)
+    # stub
+  end
+
+  def dig(*args)
+    # stub
+  end
+
+end if false

--- a/lib/truffle/java/java_ext/java.util.regex.rb
+++ b/lib/truffle/java/java_ext/java.util.regex.rb
@@ -1,0 +1,191 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# NOTE: these Ruby extensions were moved to native code!
+# @see org.jruby.javasupport.ext.JavaUtilRegex.java
+# this file is no longer loaded but is kept to provide doc stubs
+
+# *java.util.regex.Pattern* enhanced to act similar to Ruby's `Regexp`.
+# @note Only explicit (or customized) Ruby methods are listed, instances will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+class Java::java::util::regex::Pattern
+  # Matches this pattern against provided string.
+  # @return [Integer, nil] start (index) of the match if any
+  def =~(str)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+    # m = matcher(str)
+    # m.find ? m.start : nil
+  end
+
+  # Case equality for Java patterns.
+  # @return [true, false]
+  def ===(str)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+    # matcher(str).find
+  end
+
+  # Returns a `Matcher` object describing the match against the string (or nil if there was no match).
+  # @example
+  #    pattern = java.util.regex.Pattern.compile('[a-f]')
+  #    matcher = pattern.match('abcdef') # java.util.regex.Matcher[pattern=[a-f] region=0,6 lastmatch=a]
+  # @return [Java::java::util::regex::Matcher, nil]
+  def match(str)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+    # m = matcher(str)
+    # m.find ? m : nil
+  end
+
+  # Returns the value of the case-insensitive flag.
+  # @return [true, false]
+  # @since 9.1
+  def casefold?
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+end if false
+
+# *java.util.regex.Matcher* represents a Java regex `Pattern` match, customized to quack like Ruby's `MatchData`.
+# @note Only explicit (or customized) Ruby methods are listed, instances will have all of their Java methods available.
+# @see http://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html
+class Java::java::util::regex::Matcher
+  # @private
+  #attr_accessor :str
+
+  # @return [Java::java::util::regex::Pattern]
+  # @since 9.1
+  def regexp
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  def string
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Returns an array of captures.
+  #    pattern = java.util.regex.Pattern.compile("(.)(.)(\\d+)(\\d)")
+  #    pattern.match('THX1138.').captures # ['H', 'X', '113', '8']
+  # @return [Array]
+  # @see #to_a
+  def captures
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Matcher acts like an array and its capture elements might be accessed.
+  # @example
+  #    pattern = java.util.regex.Pattern.compile("(.)(.)(\\d+)(\\d)")
+  #    matcher = pattern.match('THX1138.')
+  #    expect( m[0] ).to eq 'HX1138'
+  #    expect( m[1, 2] ).to eq ['H', 'X']
+  #    expect( m[1..3] ).to eq ['H', 'X', '113']
+  # @return [Array]
+  # @see #to_a
+  def [](*args)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Returns the array of matches.
+  # @example
+  #    pattern = java.util.regex.Pattern.compile("(.)(.)(\\d+)(\\d)")
+  #    pattern.match('THX1138.').captures # ['HX1138', 'H', 'X', '113', '8']
+  # @return [Array]
+  def to_a
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  def values_at(*args)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Returns the number of elements in the match array.
+  # @example
+  #    pattern = java.util.regex.Pattern.compile("(.)(.)(\\d+)(\\d)")
+  #    pattern.match('THX1138.').size # 5
+  # @return [Integer]
+  def size
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+  alias length size
+
+  # Returns the offset of the start of the n-th element of the match array in the string.
+  # @example
+  #    pattern = java.util.regex.Pattern.compile("(.)(.)(\\d+)(\\d)")
+  #    matcher = pattern.match('THX1138.')
+  #    expect( matcher.begin(0) ).to eq 1
+  #    expect( matcher.begin(2) ).to eq 2
+  # @param n can be a string or symbol to reference a named capture
+  # @return [Integer]
+  # @see #offset
+  # @see #end
+  # @note Named captures referencing is not available on Java 7.
+  def begin(n)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Returns the offset of the character immediately following the end of the n-th element of the match array in the string.
+  # @example
+  #    pattern = java.util.regex.Pattern.compile("(.)(.)(\\d+)(\\d)")
+  #    matcher = pattern.match('THX1138.')
+  #    expect( matcher.begin(0) ).to eq 7
+  #    expect( matcher.begin(2) ).to eq 3
+  # @param n can be a string or symbol to reference a named capture
+  # @return [Integer]
+  # @see #offset
+  # @see #begin
+  # @note Named captures referencing is not available on Java 7.
+  def end(n)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Returns the offset of the character immediately following the end of the n-th element of the match array in the string.
+  # @example
+  #    pattern = java.util.regex.Pattern.compile("(.)(.)(\\d+)(\\d)")
+  #    matcher = pattern.match('THX1138.')
+  #    expect( m.offset(0) ).to eq [1, 7]
+  #    expect( m.offset(4) ).to eq [6, 7]
+  #
+  #    pattern = java.util.regex.Pattern.compile("(?<foo>.)(.)(?<bar>.)")
+  #    matcher = pattern.match('hoge')
+  #    expect( m.offset(:bar) ).to eq [2, 3]
+  # @param n can be a string or symbol to reference a named capture
+  # @return [Array]
+  # @see #begin
+  # @see #end
+  def offset(n)
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Returns the portion of the original string before the current match.
+  # @return [String]
+  def pre_match
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+  # Returns the portion of the original string after the current match.
+  # @return [String]
+  def post_match
+    # stub implemented in org.jruby.javasupport.ext.JavaUtilRegex.java
+  end
+
+end if false

--- a/lib/truffle/java/java_proxy.rb
+++ b/lib/truffle/java/java_proxy.rb
@@ -1,0 +1,29 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+class JavaProxy
+  include JavaProxyMethods
+
+  attr_accessor :java_object
+
+  class << self
+    attr_accessor :java_class
+  end
+
+  def self.const_missing(name)
+    JavaUtilities.get_inner_class(java_class, name)
+  end
+  
+  def to_java_object
+    java_object
+  end
+
+  def eql?(another)
+  end
+  
+end

--- a/lib/truffle/java/java_proxy_methods.rb
+++ b/lib/truffle/java/java_proxy_methods.rb
@@ -1,0 +1,11 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+module JavaProxyMethods
+  attr_accessor :java_object
+end

--- a/lib/truffle/java/java_utilities.rb
+++ b/lib/truffle/java/java_utilities.rb
@@ -1,0 +1,504 @@
+###### BEGIN LICENSE BLOCK ######
+# Version: EPL 1.0/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Common Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of
+# the License at http://www.eclipse.org/legal/cpl-v10.html
+#
+# Software distributed under the License is distributed on an "AS
+# IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either of the GNU General Public License Version 2 or later (the "GPL"),
+# or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the EPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the EPL, the GPL or the LGPL.
+###### END LICENSE BLOCK ######
+
+# @private
+module JavaUtilities
+
+  Java = ::Truffle::Interop::Java
+
+  def self.extend_proxy(java_class_name, &block)
+    java_class = JavaUtilities.get_proxy_class(java_class_name)
+    java_class.class_eval(&block)
+  end
+
+  def self.print_class(java_type, indent="")
+    while (!java_type.nil? && java_type.name != "java.lang.Class")
+      puts "#{indent}Name:  #{java_type.name}, access: #{ JavaUtilities.access(java_type) }  Interfaces: "
+      java_type.interfaces.each { |i| print_class(i, "  #{indent}") }
+      puts "#{indent}SuperClass: "
+      print_class(java_type.superclass, "  #{indent}")
+      java_type = java_type.superclass
+    end
+  end
+
+  def self.get_package_module_dot_format(name)
+    get_package_or_class(name, false)
+  end
+
+  def self.get_class_full_name(name)
+    get_package_or_class(name, true)
+  end
+
+  def self.get_relative_package_or_class(parent, name)
+    probably_class = (name[0] == name[0].upcase)
+    full_name = "#{parent}.#{name}"
+    get_package_or_class(full_name, probably_class)
+  end
+
+  def self.get_inner_class(a_class, inner_name)
+    outer_name = Java.to_ruby_string(
+      Java.invoke_java_method(CLASS_GET_NAME, a_class))
+    self.get_package_or_class("#{outer_name}$#{inner_name}", true)
+  end
+
+  def self.get_package_or_class(name, probably_class)
+    a_class = begin
+                Java.java_class_by_name(name)
+              rescue Exception
+                nil
+              end
+    if !probably_class
+      # Probably not true, but somebody may have been silly in their class names.
+      return make_proxy(a_class) if a_class != nil
+
+      return ::Java::JavaPackage.new(*name.split("."))
+    else
+      if a_class == nil
+        raise NameError, "Missing class name ('#{name}')"
+      end
+
+      return make_proxy(a_class)
+    end
+  end
+
+  # Classes we'll need to bootstrap things.
+  JAVA_CLASS_CLASS = Java.java_class_by_name("java.lang.Class")
+  JAVA_CLASS_ARRAY = Java.java_class_by_name("[Ljava.lang.Class;")
+  JAVA_FIELD_CLASS = Java.java_class_by_name("java.lang.reflect.Field")
+  JAVA_FIELD_ARRAY = Java.java_class_by_name("[Ljava.lang.reflect.Field;")
+  JAVA_METHOD_CLASS = Java.java_class_by_name("java.lang.reflect.Method")
+  JAVA_METHOD_ARRAY = Java.java_class_by_name("[Ljava.lang.reflect.Method;")
+  JAVA_MODIFIERS_CLASS = Java.java_class_by_name("java.lang.reflect.Modifier")
+  JAVA_OBJECT_CLASS = Java.java_class_by_name("java.lang.Object")
+  JAVA_OBJECT_ARRAY = Java.java_class_by_name("[Ljava.lang.Object;")
+  JAVA_PACKAGE_CLASS = Java.java_class_by_name("java.lang.Package")
+  JAVA_STRING_CLASS = Java.java_class_by_name("java.lang.String")
+
+  # We'll also need the primitive classes for int and boolean, but can't get those by name.
+  CLASS_GET_FIELD = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getField", false, JAVA_FIELD_CLASS, JAVA_STRING_CLASS)
+  FIELD_GET = Java.get_java_method(
+    JAVA_FIELD_CLASS, "get", false, JAVA_OBJECT_CLASS, JAVA_OBJECT_CLASS)
+  JAVA_BOOLEAN_CLASS = Java.java_class_by_name("java.lang.Boolean")
+  JAVA_PRIM_BOOLEAN_CLASS = Java.invoke_java_method(
+    FIELD_GET, Java.invoke_java_method(
+      CLASS_GET_FIELD, JAVA_BOOLEAN_CLASS, Java.to_java_string("TYPE")),
+    nil)
+  JAVA_INTEGER_CLASS = Java.java_class_by_name("java.lang.Integer")
+  JAVA_PRIM_INT_CLASS = Java.invoke_java_method(
+    FIELD_GET, Java.invoke_java_method(
+      CLASS_GET_FIELD, JAVA_INTEGER_CLASS, Java.to_java_string("TYPE")),
+    nil)
+
+  # We'll also want the modifiers for methods and fields.
+  module Modifiers
+    names = ["ABSTRACT",
+             "FINAL",
+             "INTERFACE",
+             "NATIVE",
+             "PRIVATE",
+             "PROTECTED",
+             "PUBLIC",
+             "STATIC",
+             "STRICT",
+             "SYNCHRONIZED",
+             "TRANSIENT",
+             "VOLATILE" ]
+    names.each do |s|
+      js = Java.to_java_string(s)
+      val = Java.invoke_java_method(
+        FIELD_GET,
+        Java.invoke_java_method(
+          CLASS_GET_FIELD, JAVA_MODIFIERS_CLASS, js), nil)
+      const_set(s, val)
+    end
+  end
+
+  # Methods we'll need to bootstrap stuff.
+  CLASS_GET_DECLARED_FIELDS = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getDeclaredFields", false, JAVA_FIELD_ARRAY)
+  CLASS_GET_DECLARED_METHODS = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getDeclaredMethods", false, JAVA_METHOD_ARRAY)
+  CLASS_GET_ENCLOSING_CLASS = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getEnclosingClass", false, JAVA_CLASS_CLASS)
+  CLASS_GET_INTERFACES = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getInterfaces", false, JAVA_CLASS_ARRAY)
+  CLASS_GET_NAME = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getName", false, JAVA_STRING_CLASS)
+  CLASS_GET_PACKAGE = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getPackage", false, JAVA_PACKAGE_CLASS)
+  CLASS_GET_SIMPLE_NAME = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getSimpleName", false, JAVA_STRING_CLASS)
+  CLASS_GET_SUPER_CLASS = Java.get_java_method(
+    JAVA_CLASS_CLASS, "getSuperclass", false, JAVA_CLASS_CLASS)
+  CLASS_IS_ARRAY = Java.get_java_method(
+    JAVA_CLASS_CLASS, "isArray", false, JAVA_PRIM_BOOLEAN_CLASS)
+  CLASS_IS_INTERFACE = Java.get_java_method(
+    JAVA_CLASS_CLASS, "isInterface", false, JAVA_PRIM_BOOLEAN_CLASS)
+  CLASS_IS_MEMBER_CLASS = Java.get_java_method(
+    JAVA_CLASS_CLASS, "isMemberClass", false, JAVA_PRIM_BOOLEAN_CLASS)
+  CLASS_IS_PRIMITIVE = Java.get_java_method(
+    JAVA_CLASS_CLASS, "isPrimitive", false, JAVA_PRIM_BOOLEAN_CLASS)
+  FIELD_GET_MODIFIERS = Java.get_java_method(
+    JAVA_FIELD_CLASS, "getModifiers", false, JAVA_PRIM_INT_CLASS)
+  FIELD_GET_NAME = Java.get_java_method(
+    JAVA_FIELD_CLASS, "getName", false, JAVA_STRING_CLASS)
+  METHOD_GET_MODIFIERS = Java.get_java_method(
+    JAVA_METHOD_CLASS, "getModifiers", false, JAVA_PRIM_INT_CLASS)
+  METHOD_GET_NAME = Java.get_java_method(
+    JAVA_METHOD_CLASS, "getName", false, JAVA_STRING_CLASS)
+  OBJECT_GET_CLASS = Java.get_java_method(
+    JAVA_OBJECT_CLASS, "getClass", false, JAVA_CLASS_CLASS)
+  PACKAGE_GET_NAME = Java.get_java_method(
+    JAVA_PACKAGE_CLASS, "getName", false, JAVA_STRING_CLASS)
+
+  def self.make_proxy(a_class)
+    a_proxy = PROXIES[a_class]
+
+    return a_proxy if a_proxy != nil
+
+    parent = ensure_owner(a_class)
+
+    a_proxy = if Java.invoke_java_method(CLASS_IS_INTERFACE, a_class)
+                make_interface_proxy(a_class)
+              elsif Java.invoke_java_method(CLASS_IS_ARRAY, a_class)
+                make_array_proxy(a_class)
+              else
+                make_object_proxy(a_class)
+              end
+
+    # Setting up the parent classes may have caused the child to be
+    # bootstrapped. Consider class A with a static public final field
+    # of B and class B which extends A. To create the proxy for B we
+    # must first create the parent A, but it then must create the
+    # proxy for B to wrap its constant value. This situation is
+    # resolved as follows
+    #
+    # 1. Start to create proxy for B (proxy 1).
+    # 2. Start to create proxy for A (proxy 2).
+    # 3. Add A's proxy to PROXIES.
+    # 4. Add static fields to A.
+    # 5. Start to create proxy for B (proxy 3).
+    # 6. Add B's proxy to PROXIES
+    # 7. Finish creating proxy for B.(proxy 3).
+    # 8. Finish creating proxy for A.(proxy 2).
+    # 9. Don't set const since PROXIES now contains a case for B (proxy 3).
+
+    a_proxy.java_class = a_class
+
+    add_interfaces(a_proxy)
+    add_static_fields(a_proxy)
+    add_static_methods(a_proxy)
+    add_instance_fields(a_proxy)
+    add_instance_methods(a_proxy)
+    existing_proxy = PROXIES.put_if_absent(a_class, a_proxy)
+
+    if existing_proxy == nil
+      # Not all proxies can be added as constants.
+      begin
+        parent.const_set(
+          Java.to_ruby_string(
+            Java.invoke_java_method(CLASS_GET_SIMPLE_NAME, a_class)),
+          a_proxy) unless parent == nil
+      rescue
+      end
+    else
+      a_proxy = existing_proxy
+    end
+ 
+    a_proxy
+  end
+
+  def self.ensure_owner(a_class)
+    if Java.invoke_java_method(CLASS_IS_MEMBER_CLASS, a_class)
+      package = make_proxy(Java.invoke_java_method(CLASS_GET_ENCLOSING_CLASS, a_class))
+    else
+      package = Java.invoke_java_method(CLASS_GET_PACKAGE, a_class)
+      if package != nil
+        name = Java.to_ruby_string(
+          Java.invoke_java_method(PACKAGE_GET_NAME, package))
+        ::Java::JavaPackage.new(*name.split("."))
+      else
+        ::Java
+      end
+    end
+  end
+
+  def self.make_array_proxy(a_class)
+    a_proxy = Class.new(ArrayJavaProxy)
+    # This is done here to break the circle in bootstrapping.
+    add_array_accessors(a_proxy, a_class)
+    a_proxy
+  end
+
+  def self.make_interface_proxy(a_class)
+    a_proxy = Module.new do
+      class << self
+        attr_accessor :java_class
+      end
+    end
+
+    a_proxy
+  end
+
+  def self.wrap_java_value(val)
+    if val.kind_of?(Truffle::Interop::Foreign)
+      a_class = get_java_class(val)
+      if Java.java_refs_equal?(a_class, JAVA_STRING_CLASS)
+        return Java.to_ruby_string(val)
+      end
+      wrapped_val = make_proxy(a_class).allocate
+      wrapped_val.java_object = val
+      return wrapped_val
+    end
+    val
+  end
+
+  def self.unwrap_java_value(val)
+    if val.kind_of?(String)
+      Java.to_java_string(val)
+    elsif val.kind_of?(JavaProxy)
+      val.java_object
+    else
+      val
+    end
+  end
+
+  JAVA_LOOKUP_CLASS = Java.java_class_by_name("java.lang.invoke.MethodHandles$Lookup")
+  JAVA_METHODHANDLE_CLASS = Java.java_class_by_name("java.lang.invoke.MethodHandle")
+  JAVA_METHODHANDLES_CLASS = Java.java_class_by_name("java.lang.invoke.MethodHandles")
+
+  LOOKUP_UNREFLECT = Java.get_java_method(
+    JAVA_LOOKUP_CLASS, "unreflect", false, JAVA_METHODHANDLE_CLASS, JAVA_METHOD_CLASS)
+  LOOKUP_UNREFLECT_GETTER = Java.get_java_method(
+    JAVA_LOOKUP_CLASS, "unreflectGetter", false, JAVA_METHODHANDLE_CLASS, JAVA_FIELD_CLASS)
+  LOOKUP_UNREFLECT_SETTER = Java.get_java_method(
+    JAVA_LOOKUP_CLASS, "unreflectSetter", false, JAVA_METHODHANDLE_CLASS, JAVA_FIELD_CLASS)
+
+  # We can't use the public lookup because it won't resolve caller sensitive things.
+  LOOKUP = Java.get_lookup
+
+  def self.unreflect_method(a_method)
+    begin
+      Java.invoke_java_method(LOOKUP_UNREFLECT, LOOKUP, a_method)
+    rescue Exception => exception
+    end
+  end
+
+  def self.unreflect_getter(a_field)
+    begin
+      Java.invoke_java_method(LOOKUP_UNREFLECT_GETTER, LOOKUP, a_field)
+    rescue Exception
+    end
+  end
+
+  def self.unreflect_setter(a_field)
+    begin
+      Java.invoke_java_method(LOOKUP_UNREFLECT_SETTER, LOOKUP, a_field)
+    rescue Exception
+      nil
+    end
+  end
+
+  REFLECT_ARRAY_CLASS = Java.java_class_by_name("java.lang.reflect.Array")
+  REFLECT_ARRAY_LENGTH = Java.get_java_method(
+    REFLECT_ARRAY_CLASS, "getLength", true, JAVA_PRIM_INT_CLASS, JAVA_OBJECT_CLASS)
+
+  ARRAY_GETTER_GETTER = Java.get_java_method(
+    JAVA_METHODHANDLES_CLASS, "arrayElementGetter", true, JAVA_METHODHANDLE_CLASS, JAVA_CLASS_CLASS)
+  ARRAY_SETTER_GETTER = Java.get_java_method(
+    JAVA_METHODHANDLES_CLASS, "arrayElementSetter", true, JAVA_METHODHANDLE_CLASS, JAVA_CLASS_CLASS)
+  ARRAY_GETTER = Java.invoke_java_method(ARRAY_GETTER_GETTER, JAVA_OBJECT_ARRAY)
+  
+  def self.java_array_size(an_array)
+    Java.invoke_java_method(REFLECT_ARRAY_LENGTH, an_array)
+  end
+
+  def self.java_array_get(an_array, index)
+    Java.invoke_java_method(ARRAY_GETTER, an_array, index)
+  end
+
+  def self.get_java_class(obj)
+      Java.invoke_java_method(OBJECT_GET_CLASS, obj)
+  end
+  
+  def self.add_array_accessors(a_proxy, a_class)
+    array_getter = Java.invoke_java_method(ARRAY_GETTER_GETTER, a_class)
+    array_setter = Java.invoke_java_method(ARRAY_SETTER_GETTER, a_class)
+
+    getter = lambda { |i| ::JavaUtilities.wrap_java_value(
+                        Java.invoke_java_method(
+                          array_getter, self.java_object, i)) }
+    setter = lambda { |i,v| Java.invoke_java_method(
+                        array_setter, self.java_object, i,
+                        ::JavaUtilities.unwrap_java_value(v)) }
+    size = lambda { Java.invoke_java_method(REFLECT_ARRAY_LENGTH, self.java_object) }
+    
+    a_proxy.__send__(:define_method, "[]", getter)
+    a_proxy.__send__(:define_method, "[]=", setter)
+    a_proxy.__send__(:define_method, "size", size)
+  end
+  
+  def self.add_static_fields(a_proxy)
+    fields = Java.invoke_java_method(CLASS_GET_DECLARED_FIELDS, a_proxy.java_class)
+    # Not using idiomatic Ruby here as we might not have bootstrapped that at this point.
+    fields_size = java_array_size(fields)
+    (0...fields_size).each do |i; f|
+      f = java_array_get(fields, i)
+      mh = unreflect_getter(f)
+      if mh != nil
+        if constant_field?(f)
+          val = wrap_java_value(Java.invoke_java_method(mh))
+          begin
+            a_proxy.const_set(Hava.to_ruby_string(
+                                Java.invoke_java_method(FIELD_GET_NAME, f)),
+                              val)
+          rescue NameError
+          end
+        end
+        if static_field?(f)
+          a_proxy.__send__(:define_singleton_method,
+                           Java.to_ruby_string(
+                             Java.invoke_java_method(FIELD_GET_NAME, f))) do
+            ::JavaUtilities.wrap_java_value(Java.invoke_java_method(mh))
+          end
+        end
+      end
+    end
+    a_proxy
+  end
+
+  def self.add_static_methods(a_proxy)
+    methods = Java.invoke_java_method(CLASS_GET_DECLARED_METHODS, a_proxy.java_class)
+    # Not using idiomatic Ruby here as we might not have bootstrapped that at this point.
+    methods_size = java_array_size(methods)
+    (0...methods_size).each do |i; m|
+      m = java_array_get(methods, i)
+      if static_method?(m)
+        mh = unreflect_method(m)
+        if mh != nil
+          a_proxy.__send__(:define_singleton_method,
+                           Java.to_ruby_string(Java.invoke_java_method(METHOD_GET_NAME, m))) do |*args|
+            args = args.map do |x|
+              ::JavaUtilities.unwrap_java_value(x)
+            end
+            ::JavaUtilities.wrap_java_value(Java.invoke_java_method(mh, *args))
+          end
+        end
+      end
+    end
+    a_proxy
+  end
+
+  def self.add_instance_fields(a_proxy)
+    fields = Java.invoke_java_method(CLASS_GET_DECLARED_FIELDS, a_proxy.java_class)
+    # Not using idiomatic Ruby here as we might not have bootstrapped that at this point.
+    fields_size = java_array_size(fields)
+    (0...fields_size).each do |i; f|
+      f = java_array_get(fields, i)
+      if !static_field?(f)
+        mh = unreflect_getter(f)
+        if mh != nil
+          a_proxy.__send__(:define_method,
+                           Java.to_ruby_string(Java.invoke_java_method(FIELD_GET_NAME, f))) do
+            ::JavaUtilities.wrap_java_value(Java.invoke_java_method(mh, java_object))
+          end
+          if !final_field?(f)
+            mh = unreflect_setter(f)
+            a_proxy.__send__(:define_method,
+                             Java.to_ruby_string(Java.invoke_java_method(FIELD_GET_NAME, f)) + "=") do |v|
+              ::JavaUtilities.wrap_java_value(Java.invoke_java_method(mh, java_object, v))
+            end
+          end
+        end
+      end
+    end
+    a_proxy
+  end
+
+  def self.add_instance_methods(a_proxy)
+    methods = Java.invoke_java_method(CLASS_GET_DECLARED_METHODS, a_proxy.java_class)
+    # Not using idiomatic Ruby here as we might not have bootstrapped that at this point.
+    methods_size = java_array_size(methods)
+    (0...methods_size).each do |i; m|
+      m = java_array_get(methods, i)
+      if !static_method?(m)
+        mh = unreflect_method(m)
+        if mh != nil
+          a_proxy.__send__(:define_method,
+                           Java.to_ruby_string(Java.invoke_java_method(METHOD_GET_NAME, m))) do |*args|
+            args = args.map do |x|
+              ::JavaUtilities.unwrap_java_value(x)
+            end
+            ::JavaUtilities.wrap_java_value(Java.invoke_java_method(mh, self.java_object, *args))
+          end
+        end
+      end
+    end
+    a_proxy
+  end
+
+  def self.constant_field?(a_field)
+    modifiers = Java.invoke_java_method(FIELD_GET_MODIFIERS, a_field)
+    constant = Modifiers::FINAL | Modifiers::PUBLIC | Modifiers::STATIC
+    constant == modifiers & constant
+  end
+
+  def self.static_field?(a_field)
+    modifiers = Java.invoke_java_method(FIELD_GET_MODIFIERS, a_field)
+    modifiers == modifiers | Modifiers::STATIC
+  end
+
+  def self.final_field?(a_field)
+    modifiers = Java.invoke_java_method(FIELD_GET_MODIFIERS, a_field)
+    modifiers == modifiers | Modifiers::FINAL
+  end
+
+  def self.static_method?(a_method)
+    modifiers = Java.invoke_java_method(METHOD_GET_MODIFIERS, a_method)
+    modifiers == modifiers | Modifiers::STATIC
+  end
+
+  def self.make_object_proxy(a_class)
+    super_class = if Java.java_refs_equal?(a_class, JAVA_OBJECT_CLASS)
+                    ConcreteJavaProxy
+                  else
+                    make_proxy(Java.invoke_java_method(CLASS_GET_SUPER_CLASS, a_class))
+                  end
+    a_proxy = Class.new(super_class)
+  end
+
+  def self.add_interfaces(a_proxy)
+    interfaces = Java.invoke_java_method(CLASS_GET_INTERFACES, a_proxy.java_class)
+    # Not using idiomatic Ruby here as we might not have bootstrapped that at this point.
+    interfaces_size = java_array_size(interfaces)
+    (0...interfaces_size).each do |i|
+      interface_proxy = make_proxy(java_array_get(interfaces, i))
+      a_proxy.include(interface_proxy) unless a_proxy.ancestors.include?(interface_proxy)
+    end
+    a_proxy
+  end
+end

--- a/truffleruby/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -105,6 +105,7 @@ import org.truffleruby.extra.TruffleGraalNodesFactory;
 import org.truffleruby.extra.TrufflePosixNodesFactory;
 import org.truffleruby.extra.ffi.PointerPrimitiveNodesFactory;
 import org.truffleruby.gem.bcrypt.BCryptNodesFactory;
+import org.truffleruby.interop.java.JavaUtilitiesNodesFactory;
 import org.truffleruby.interop.InteropNodesFactory;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyGuards;
@@ -242,6 +243,7 @@ public class CoreLibrary {
     private final DynamicObject truffleModule;
     private final DynamicObject truffleBootModule;
     private final DynamicObject truffleInteropModule;
+    private final DynamicObject truffleInteropJavaModule;
     private final DynamicObject truffleKernelModule;
     private final DynamicObject bigDecimalClass;
     private final DynamicObject encodingCompatibilityErrorClass;
@@ -574,6 +576,7 @@ public class CoreLibrary {
 
         truffleModule = defineModule("Truffle");
         truffleInteropModule = defineModule(truffleModule, "Interop");
+        truffleInteropJavaModule = defineModule(truffleInteropModule, "Java");
         defineModule(truffleModule, "CExt");
         defineModule(truffleModule, "Debug");
         defineModule(truffleModule, "Digest");
@@ -1481,6 +1484,10 @@ public class CoreLibrary {
         return truffleInteropModule;
     }
 
+    public Object getTruffleInteropJavaModule() {
+        return truffleInteropJavaModule;
+    }
+
     public Object getTruffleKernelModule() {
         return truffleKernelModule;
     }
@@ -1508,6 +1515,7 @@ public class CoreLibrary {
             FiberNodesFactory.getFactories(),
             FixnumNodesFactory.getFactories(),
             FloatNodesFactory.getFactories(),
+            JavaUtilitiesNodesFactory.getFactories(),
             HashNodesFactory.getFactories(),
             IntegerNodesFactory.getFactories(),
             InteropNodesFactory.getFactories(),

--- a/truffleruby/src/main/java/org/truffleruby/interop/InteropNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/interop/InteropNodes.java
@@ -37,6 +37,7 @@ import org.truffleruby.builtins.CoreClass;
 import org.truffleruby.builtins.CoreMethod;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.CoreMethodNode;
+import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.core.cast.NameToJavaStringNode;
 import org.truffleruby.core.cast.NameToJavaStringNodeGen;
 import org.truffleruby.core.rope.Rope;
@@ -704,5 +705,4 @@ public abstract class InteropNodes {
         }
 
     }
-
 }

--- a/truffleruby/src/main/java/org/truffleruby/interop/java/JavaUtilitiesNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/interop/java/JavaUtilitiesNodes.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby.interop.java;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.jcodings.specific.UTF8Encoding;
+
+import org.truffleruby.builtins.CoreClass;
+import org.truffleruby.builtins.CoreMethod;
+import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
+import org.truffleruby.builtins.CoreMethodNode;
+
+import org.truffleruby.core.array.ArrayStrategy;
+import org.truffleruby.core.cast.NameToJavaStringNode;
+import org.truffleruby.core.cast.NameToJavaStringNodeGen;
+import org.truffleruby.core.rope.Rope;
+import org.truffleruby.core.string.StringOperations;
+import org.truffleruby.core.string.StringUtils;
+import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.control.JavaException;
+import org.truffleruby.language.control.RaiseException;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.TruffleOptions;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.CreateCast;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node.Child;
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.profiles.BranchProfile;
+
+@CoreClass("Truffle::Interop::Java")
+public class JavaUtilitiesNodes {
+
+    @CoreMethod(names = "to_ruby_string", required = 1, isModuleFunction = true)
+    public static abstract class ToRubyStringNode extends CoreMethodArrayArgumentsNode {
+        @Specialization
+        public DynamicObject toRubyString(String target) {
+            return createString(getRope(target));
+        }
+
+        protected Rope getRope(String value) {
+            return StringOperations.encodeRope(value, UTF8Encoding.INSTANCE);
+        }
+    }
+
+    @CoreMethod(names = "java_class_by_name", isModuleFunction = true, required = 1)
+    @NodeChild(value = "name", type = RubyNode.class)
+    public abstract static class JavaClassByNameNode extends CoreMethodNode {
+        @CreateCast("name")
+        public RubyNode coercetNameToString(RubyNode newName) {
+            return NameToJavaStringNodeGen.create(newName);
+        }
+
+        @Specialization
+        public Object javaClassByName(String name,
+                                      @Cached("create()") BranchProfile errorProfile) {
+            if (!TruffleOptions.AOT) {
+                try {
+                    Class<?> klass =  Class.forName(name);
+                    return klass;
+                } catch (Exception e) {
+                    errorProfile.enter();
+                    throw new RaiseException(coreExceptions().nameErrorImportNotFound(name, this));
+                }
+            } else {
+                throw new RaiseException(coreExceptions().runtimeError("Not available on SVM.", this));
+            }
+        }
+    }
+
+    @CoreMethod(names = "to_java_string", required = 1, isModuleFunction = true)
+    public static abstract class ToJavaStringNode extends CoreMethodArrayArgumentsNode {
+        @Specialization
+        public String toJavaString(VirtualFrame frame, DynamicObject string,
+                                   @Cached("create()") NameToJavaStringNode toJavaStringNode) {
+            return toJavaStringNode.executeToJavaString(frame, string);
+        }
+    }
+
+    @CoreMethod(names = "java_hash", required = 1, isModuleFunction = true)
+    public static abstract class JavaHashNode extends CoreMethodArrayArgumentsNode {
+        @TruffleBoundary
+        @Specialization
+        public int toJavaHash(Object target) {
+            return target.hashCode();
+        }
+    }
+
+    @CoreMethod(names = "java_refs_equal?", required = 2, isModuleFunction = true)
+    public static abstract class JavaEqlNode extends CoreMethodArrayArgumentsNode {
+        @Specialization
+        public boolean toJavaHash(Object a, Object b) {
+            return a == b;
+        }
+    }
+
+    @CoreMethod(names = "get_java_method", required = 4, rest = true, isModuleFunction = true)
+    public static abstract class JavaGetMethodNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        public Object getJavaMethod(VirtualFrame frame, Object target, Object name,
+                boolean staticMethod, Object returnType, Object[] rest,
+                @Cached("create()") NameToJavaStringNode toJavaStringNode) {
+            if (!TruffleOptions.AOT) {
+                String methodName = toJavaStringNode.executeToJavaString(frame, name);
+                Class<?> klass = (Class<?>) target;
+                Class<?> returnClass = (Class<?>) returnType;
+                Class<?>[] args = new Class[rest.length];
+                for (int i = 0; i < rest.length; i++) {
+                    args[i] = (Class<?>) rest[i];
+                }
+                try {
+                    if (staticMethod) {
+                        return MethodHandles.lookup().findStatic(klass, methodName, MethodType.methodType(returnClass, args));
+                    } else {
+                        return MethodHandles.lookup().findVirtual(klass, methodName, MethodType.methodType(returnClass, args));
+                    }
+                } catch (Exception e) {
+                    throw new RaiseException(coreExceptions().nameError(StringUtils.format("Method %s cannot be accessed.", methodName), null, methodName, this));
+                }
+            } else {
+                throw new RaiseException(coreExceptions().runtimeError("Not available on SVM.", this));
+            }
+        }
+    }
+
+    @CoreMethod(names = "get_lookup", required = 0, rest = false, isModuleFunction = true)
+    public static abstract class GetLookupNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        public Object getLookup() {
+            if (!TruffleOptions.AOT) {
+                return MethodHandles.lookup();
+            } else {
+                throw new RaiseException(coreExceptions().runtimeError("Not available on SVM.", this));
+            }
+        }
+    }
+
+    @CoreMethod(names = "invoke_java_method", required = 1, rest = true, isModuleFunction = true)
+    public static abstract class JavaInvokeMethodNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        public Object invokeJavaMethod(MethodHandle method, Object[] rest) {
+            if (!TruffleOptions.AOT) {
+                try {
+                    Object res = method.invokeWithArguments(rest);
+                    return res == null ? nil() : res;
+                } catch (Throwable e) {
+                    throw new JavaException(e);
+                }
+            } else {
+                throw new RaiseException(coreExceptions().runtimeError("Not available on SVM.", this));
+            }
+        }
+    }
+}

--- a/truffleruby/src/main/ruby/core/truffle/interop.rb
+++ b/truffleruby/src/main/ruby/core/truffle/interop.rb
@@ -65,7 +65,6 @@ module Truffle
     class Foreign
 
     end
-
   end
 
 end


### PR DESCRIPTION
This PR starts to replicate the JRuby Java interop, with only a tiny stub written in Java and the rest in Ruby. It enables the building of the proxy class hierarchy and calling of Java methods. It does not yet enable dispatch based on argument types or many of the more advanced features such as subclassing.

It is expected that the core of this functionality will be moved to the standard truffle interop API once that has all the required features.