### PR TITLE
Add jt test mri openssl to run MRI openssl tests

### DIFF
--- a/test/openssl.index
+++ b/test/openssl.index
@@ -1,0 +1,37 @@
+openssl/test_asn1.rb
+openssl/test_bn.rb
+openssl/test_buffering.rb
+# openssl/test_certificate.rb # no file
+openssl/test_cipher.rb
+openssl/test_config.rb
+openssl/test_digest.rb
+
+# openssl/test_ec.rb  # no file
+
+openssl/test_engine.rb
+openssl/test_hmac.rb
+# openssl/test_imaps.rb  # no file
+# openssl/test_integration.rb # no file
+openssl/test_ns_spki.rb
+
+openssl/test_ocsp.rb
+# openssl/test_parse_certificate.rb # no file
+openssl/test_pair.rb
+openssl/test_partial_record_read.rb
+openssl/test_pkcs12.rb
+openssl/test_pkcs7.rb
+openssl/test_pkey_dh.rb
+openssl/test_pkey_dsa.rb
+
+openssl/test_pkey_ec.rb
+openssl/test_pkey_rsa.rb
+
+openssl/test_ssl.rb
+
+openssl/test_ssl_session.rb
+openssl/test_x509cert.rb
+openssl/test_x509crl.rb
+openssl/test_x509ext.rb
+openssl/test_x509name.rb
+openssl/test_x509req.rb
+openssl/test_x509store.rb

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -450,6 +450,7 @@ module Commands
       jt test                                        run all mri tests, specs and integration tests (set SULONG_HOME)
       jt test tck [--jdebug]                         run the Truffle Compatibility Kit tests
       jt test mri                                    run mri tests
+            openssl       runs openssl.index         use with --graal
           --aot           use AOT TruffleRuby image (set AOT_BIN)
           --graal         use Graal (set either GRAALVM_BIN, JVMCI_BIN or GRAAL_HOME)
       jt test specs                                  run all specs
@@ -760,7 +761,9 @@ module Commands
     }
     jruby_args = %w[-J-Xmx2G -J-ea -J-esa --jexceptions]
 
-    if args.count { |arg| !arg.start_with?('-') } == 0
+    if args.count { |arg| !arg.start_with?('-') } == 1 && args[0] == "openssl"
+      args += File.readlines("#{JRUBY_DIR}/test/openssl.index").grep(/^[^#]\w+/).map(&:chomp)
+    elsif args.count { |arg| !arg.start_with?('-') } == 0
       args += File.readlines("#{JRUBY_DIR}/test/mri_truffle.index").grep(/^[^#]\w+/).map(&:chomp)
     end
 


### PR DESCRIPTION
@chrisseaton This is just an idea I had to run a suite of MRI openssl tests with `jt test mri openssl --graal` which I thought might be useful for the openssl implementation?  If it's not useful, I'll just close the PR.