### PR TITLE
Truffle interop fix

### DIFF
--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
@@ -9,11 +9,14 @@
  */
 package org.truffleruby.language.dispatch;
 
+import static org.truffleruby.language.RubyGuards.isForeignObject;
+
+import org.truffleruby.interop.OutgoingForeignCallNode;
+import org.truffleruby.interop.OutgoingForeignCallNodeGen;
+
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.object.DynamicObject;
-import org.truffleruby.interop.OutgoingForeignCallNode;
-import org.truffleruby.interop.OutgoingForeignCallNodeGen;
 
 public final class CachedForeignDispatchNode extends CachedDispatchNode {
 
@@ -29,7 +32,7 @@ public final class CachedForeignDispatchNode extends CachedDispatchNode {
 
     @Override
     protected boolean guard(Object methodName, Object receiver) {
-        return guardName(methodName) && !(receiver instanceof DynamicObject) && (receiver instanceof TruffleObject);
+        return guardName(methodName) && isForeignObject(receiver);
     }
 
     @Override
@@ -42,7 +45,7 @@ public final class CachedForeignDispatchNode extends CachedDispatchNode {
         if (guard(methodName, receiverObject)) {
             return doDispatch(frame, (TruffleObject) receiverObject, argumentsObjects);
         } else {
-            return next.executeDispatch( frame, receiverObject, methodName, blockObject, argumentsObjects);
+            return next.executeDispatch(frame, receiverObject, methodName, blockObject, argumentsObjects);
         }
     }
 

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
@@ -11,7 +11,6 @@ package org.truffleruby.language.dispatch;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.java.JavaInterop;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.interop.OutgoingForeignCallNode;
 import org.truffleruby.interop.OutgoingForeignCallNodeGen;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
@@ -9,10 +9,9 @@
  */
 package org.truffleruby.language.dispatch;
 
-import static org.truffleruby.language.RubyGuards.isForeignObject;
-
 import org.truffleruby.interop.OutgoingForeignCallNode;
 import org.truffleruby.interop.OutgoingForeignCallNodeGen;
+import org.truffleruby.language.RubyGuards;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.TruffleObject;
@@ -32,7 +31,7 @@ public final class CachedForeignDispatchNode extends CachedDispatchNode {
 
     @Override
     protected boolean guard(Object methodName, Object receiver) {
-        return guardName(methodName) && isForeignObject(receiver);
+        return guardName(methodName) && RubyGuards.isForeignObject(receiver);
     }
 
     @Override


### PR DESCRIPTION
CachedForeignDispatchNodes now check their guard and fallback to the next dispatch node for Ruby objects and non-TruffleObjects.