### PR TITLE
Automatically require a specific workaround when a lib is seen

### DIFF
--- a/lib/truffle/rspec-workarounds.rb
+++ b/lib/truffle/rspec-workarounds.rb
@@ -1,0 +1,11 @@
+module RSpec
+  module Support
+    module RubyFeatures
+      module_function
+        def ripper_supported?
+          false
+        end
+    end
+  end
+end
+puts "WORKAROUND for ripper_supported? loaded" if $VERBOSE

--- a/truffleruby/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -50,6 +50,7 @@ public abstract class RequireNode extends RubyNode {
     @Child private IndirectCallNode callNode = IndirectCallNode.create();
     @Child private CallDispatchHeadNode isInLoadedFeatures = CallDispatchHeadNode.createMethodCall();
     @Child private CallDispatchHeadNode addToLoadedFeatures = CallDispatchHeadNode.createMethodCall();
+    @Child private RequireNode afterRequireNode;
 
     @Child private Node isExecutableNode = Message.IS_EXECUTABLE.createNode();
     @Child private Node executeNode = Message.createExecute(0).createNode();
@@ -160,6 +161,14 @@ public abstract class RequireNode extends RubyNode {
                 }
 
                 addToLoadedFeatures(frame, pathString);
+
+                if(feature.endsWith("rspec/support/ruby_features")) {
+                    if (afterRequireNode == null) {
+                        CompilerDirectives.transferToInterpreterAndInvalidate();
+                        afterRequireNode = insert(RequireNode.create());
+                    }
+                    afterRequireNode.executeRequire(frame, "rspec-workarounds");
+                }
 
                 return true;
             } finally {


### PR DESCRIPTION
We had discussed recently the idea of being able to automatically load some workaround before or after a specific rb file/class/module was loaded.

This is my example implementation to solve this rspec issue where we currently need to stub this ripper_supported? method if this file `rspec/support/ruby_features` is loaded.

My test for this locally was (`rspec-3.5.4`):
```
require "rspec/support"
puts RSpec::Support::RubyFeatures.ripper_supported?
```

An example of something that might be required before could be the "openssl-workarounds" could be loaded before "openssl" if "openssl" is required.