### PR TITLE
Add a preprocess step to compiling cexts so we can rewrite calls to rb_scan_args

### DIFF
--- a/lib/cext/preprocess.rb
+++ b/lib/cext/preprocess.rb
@@ -1,0 +1,36 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+ARGF.each do |line|
+  if line.include?('rb_scan_args')
+    puts line.gsub(/rb_scan_args\((\w+), (\w+), \"(.*)\", /) {
+      argc = $1
+      argv = $2
+      arity = $3
+
+      case arity
+        when '0:'
+          shim = 'rb_jt_scan_args_0_hash'
+        when '02'
+          shim = 'rb_jt_scan_args_02'
+        when '11'
+          shim = 'rb_jt_scan_args_11'
+        when '12'
+          shim = 'rb_jt_scan_args_12'
+        when '1*'
+          shim = 'rb_jt_scan_args_1_star'
+        else
+          shim = 'rb_scan_args' # let it fail at runtime
+      end
+
+      "#{shim}(#{argc}, #{argv}, \"#{arity}\", "
+    }
+  else
+    puts line
+  end
+end

--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -777,7 +777,7 @@ VALUE rb_proc_new(void *function, VALUE value);
 void rb_warn(const char *fmt, ...);
 void rb_warning(const char *fmt, ...);
 
-MUST_INLINE int rb_jt_scan_args_0_HASH(int argc, VALUE *argv, const char *format, VALUE *v1) {
+MUST_INLINE int rb_jt_scan_args_0_hash(int argc, VALUE *argv, const char *format, VALUE *v1) {
   if (argc >= 1) *v1 = argv[0];
   return argc;
 }
@@ -806,6 +806,21 @@ MUST_INLINE int rb_jt_scan_args_12(int argc, VALUE *argv, const char *format, VA
   *v1 = argv[0];
   if (argc >= 2) *v2 = argv[1];
   if (argc >= 3) *v3 = argv[2];
+  return argc - 1;
+}
+
+MUST_INLINE int rb_jt_scan_args_1_star(int argc, VALUE *argv, const char *format, VALUE *v1, VALUE *v2) {
+  if (argc < 1) {
+    rb_jt_error("rb_jt_scan_args_1_star error case not implemented");
+    abort();
+  }
+  *v1 = argv[0];
+  if (argc >= 2) {
+    *v2 = rb_ary_new();
+    for (int n = 1; n < argc; n++) {
+      rb_ary_push(*v2, argv[n]);
+    }
+  }
   return argc - 1;
 }
 

--- a/spec/tags/optional/capi/array_tags.txt
+++ b/spec/tags/optional/capi/array_tags.txt
@@ -1,11 +1,5 @@
 fails:C-API Array function rb_ary_new4 returns returns an array with the passed values
 fails:C-API Array function RARRAY_PTR allows assigning to the elements of the C array
-fails:C-API Array function rb_ary_aref returns the element at the given index
-fails:C-API Array function rb_ary_aref returns nil for an out of range index
-fails:C-API Array function rb_ary_aref returns a new array where the first argument is the index and the second is the length
-fails:C-API Array function rb_ary_aref accepts a range
-fails:C-API Array function rb_ary_aref returns nil when the start of a range is out of bounds
-fails:C-API Array function rb_ary_aref returns an empty array when the start of a range equals the last element
 fails:C-API Array function rb_iterate calls an callback function as a block passed to an method
 fails:C-API Array function rb_iterate calls a function with the other function available as a block
 fails:C-API Array function rb_iterate calls a function which can yield into the original block

--- a/truffleruby/src/main/c/cext/ruby.c
+++ b/truffleruby/src/main/c/cext/ruby.c
@@ -1341,8 +1341,8 @@ VALUE rb_ary_unshift(VALUE array, VALUE value) {
 }
 
 VALUE rb_ary_aref(int n, const VALUE* values, VALUE array) {
-  rb_jt_error("rb_ary_aref not implemented");
-  abort();
+  // TODO CS 21-Feb-17 if values is an RARRAY_PTR, go back to the array directly
+  return (VALUE) truffle_invoke(RUBY_CEXT, "send_splatted", array, rb_str_new_cstr("[]"), rb_ary_new4(n, values));
 }
 
 VALUE rb_ary_clear(VALUE array) {

--- a/truffleruby/src/main/ruby/core/rbconfig.rb
+++ b/truffleruby/src/main/ruby/core/rbconfig.rb
@@ -184,15 +184,16 @@ module RbConfig
     CONFIG.merge!({
         'CC' => cc,
         'CPP' => cpp,
-        'COMPILE_C' => "#{cc} $(INCFLAGS) #{cppflags} #{cflags} $(COUTFLAG)$< -o $@ && #{opt} -always-inline -mem2reg $@ -o $@",
+        'COMPILE_C' => "ruby #{libdir}/cext/preprocess.rb < $< | #{cc} $(INCFLAGS) #{cppflags} #{cflags} $(COUTFLAG) -xc - -o $@ && #{opt} -always-inline -mem2reg $@ -o $@",
         'CFLAGS' => cflags,
         'LINK_SO' => "mx -v -p #{ENV['SULONG_HOME']} su-link -o $@ $(OBJS) #{libs}",
         'TRY_LINK' => "#{clang} $(src) $(INCFLAGS) #{cflags} -I#{ENV['SULONG_HOME']}/include #{libs}"
     })
+
     MAKEFILE_CONFIG.merge!({
         'CC' => cc,
         'CPP' => cpp,
-        'COMPILE_C' => "$(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG)$< -o $@ && #{opt} -always-inline -mem2reg $@ -o $@",
+        'COMPILE_C' => "ruby #{libdir}/cext/preprocess.rb < $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{opt} -always-inline -mem2reg $@ -o $@",
         'CFLAGS' => cflags,
         'LINK_SO' => "mx -v -p #{ENV['SULONG_HOME']} su-link -o $@ $(OBJS) $(LIBS)",
         'TRY_LINK' => "#{clang} $(src) $(INCFLAGS) $(CFLAGS) -I#{ENV['SULONG_HOME']}/include $(LIBS)"

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -833,6 +833,10 @@ module Truffle::CExt
     raise RubyTruffleError.new(message)
   end
 
+  def send_splatted(object, method, args)
+    object.send(method, *args)
+  end
+
 end
 
 Truffle::Interop.export(:ruby_cext, Truffle::CExt)


### PR DESCRIPTION
`rb_scan_args` has variadic pointers used as out-arguments.

```c
int rb_scan_args(int argc, VALUE *argv, const char *format, ...);
```

This is tricky because it causes the local variables in the caller to escape and so be allocated in unmanaged memory, where we can't store Ruby objects. We could get around this if we always inlined the function, as then the local variables wouldn't escape, but LLVM cannot inline variadic functions!

I've got non-standard versions of these which aren't variadic, for example:

```c
MUST_INLINE int rb_jt_scan_args_11(int argc, VALUE *argv, const char *format, VALUE *v1, VALUE *v2) {
  if (argc < 1) {
    rb_jt_error("rb_jt_scan_args_11 error case not implemented");
    abort();
  }
  *v1 = argv[0];
  if (argc >= 2) *v2 = argv[1];
  return argc - 1;
}
```

But these vary based on the third parameter so you need to call the right one, and we can't call the right one for you in `rb_scan_args`, as it's too late by then - your local variables have escaped. We need to modify the code to call the right one in the first place, which is what I was manually doing to the `openssl` gem source code.

My solution is a preprocess step to automatically rewrite the calls. I didn't really want this extra step, but running these array specs was the first time I encountered some code I can't modify in place.

@grimmerm