### PR TITLE
Use a macro for rb_scan_args

### DIFF
--- a/lib/cext/preprocess.rb
+++ b/lib/cext/preprocess.rb
@@ -8,7 +8,7 @@
 
 ARGF.each do |line|
   if line.include?('rb_scan_args')
-    puts line.gsub(/rb_scan_args\((\w+), (\w+), \"(.*)\", /) {
+    puts line.gsub(/\srb_scan_args\((\w+), (\w+), \"(.*)\", /) {
       argc = $1
       argv = $2
       arity = $3
@@ -25,7 +25,7 @@ ARGF.each do |line|
         when '1*'
           shim = 'rb_jt_scan_args_1_star'
         else
-          shim = 'rb_scan_args' # let it fail at runtime
+          shim = 'rb_scan_args' # use the macro
       end
 
       "#{shim}(#{argc}, #{argv}, \"#{arity}\", "

--- a/lib/cext/preprocess.rb
+++ b/lib/cext/preprocess.rb
@@ -8,7 +8,7 @@
 
 ARGF.each do |line|
   if line.include?('rb_scan_args')
-    puts line.gsub(/\srb_scan_args\((\w+), (\w+), \"(.*)\", /) {
+    puts line.gsub(/\brb_scan_args\((\w+), (\w+), \"(.*)\", /) {
       argc = $1
       argv = $2
       arity = $3

--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -829,39 +829,19 @@ MUST_INLINE int rb_jt_scan_args(int argc, VALUE *argv, const char *format, VALUE
     case '0':
       switch (format[1]) {
         case ':':
-          switch (format[2]) {
-            case '\0':
-              return rb_jt_scan_args_0_hash(argc, argv, format, v1);
-          }
-          break;
+          return rb_jt_scan_args_0_hash(argc, argv, format, v1);
         case '2':
-          switch (format[2]) {
-            case '\0':
-              return rb_jt_scan_args_02(argc, argv, format, v1, v2);
-          }
-          break;
+          return rb_jt_scan_args_02(argc, argv, format, v1, v2);
       }
       break;
     case '1':
       switch (format[1]) {
         case '1':
-          switch (format[2]) {
-            case '\0':
-              return rb_jt_scan_args_11(argc, argv, format, v1, v2);
-          }
-          break;
+          return rb_jt_scan_args_11(argc, argv, format, v1, v2);
         case '2':
-          switch (format[2]) {
-            case '\0':
-              return rb_jt_scan_args_12(argc, argv, format, v1, v2, v3);
-          }
-          break;
+          return rb_jt_scan_args_12(argc, argv, format, v1, v2, v3);
         case '*':
-          switch (format[2]) {
-            case '\0':
-              return rb_jt_scan_args_1_star(argc, argv, format, v1, v2);
-          }
-          break;
+          return rb_jt_scan_args_1_star(argc, argv, format, v1, v2);
       }
       break;
   }

--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -824,9 +824,66 @@ MUST_INLINE int rb_jt_scan_args_1_star(int argc, VALUE *argv, const char *format
   return argc - 1;
 }
 
-int rb_scan_args(int argc, VALUE *argv, const char *format, ...);
+MUST_INLINE int rb_jt_scan_args(int argc, VALUE *argv, const char *format, VALUE *v1, VALUE *v2, VALUE *v3, VALUE *v4, VALUE *v5, VALUE *v6, VALUE *v7, VALUE *v8, VALUE *v9, VALUE *v10) {
+  switch (format[0]) {
+    case '0':
+      switch (format[1]) {
+        case ':':
+          switch (format[2]) {
+            case '\0':
+              return rb_jt_scan_args_0_hash(argc, argv, format, v1);
+          }
+          break;
+        case '2':
+          switch (format[2]) {
+            case '\0':
+              return rb_jt_scan_args_02(argc, argv, format, v1, v2);
+          }
+          break;
+      }
+      break;
+    case '1':
+      switch (format[1]) {
+        case '1':
+          switch (format[2]) {
+            case '\0':
+              return rb_jt_scan_args_11(argc, argv, format, v1, v2);
+          }
+          break;
+        case '2':
+          switch (format[2]) {
+            case '\0':
+              return rb_jt_scan_args_12(argc, argv, format, v1, v2, v3);
+          }
+          break;
+        case '*':
+          switch (format[2]) {
+            case '\0':
+              return rb_jt_scan_args_1_star(argc, argv, format, v1, v2);
+          }
+          break;
+      }
+      break;
+  }
+
+  rb_jt_error("rb_jt_scan_args case not implemented");
+  abort();
+}
 
 VALUE rb_enumeratorize(VALUE obj, VALUE meth, int argc, const VALUE *argv);
+#define rb_jt_scan_args_1(ARGC, ARGV, FORMAT, V1) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+#define rb_jt_scan_args_2(ARGC, ARGV, FORMAT, V1, V2) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+#define rb_jt_scan_args_3(ARGC, ARGV, FORMAT, V1, V2, V3) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+#define rb_jt_scan_args_4(ARGC, ARGV, FORMAT, V1, V2, V3, V4) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, V4, NULL, NULL, NULL, NULL, NULL, NULL)
+#define rb_jt_scan_args_5(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, NULL, NULL, NULL, NULL, NULL)
+#define rb_jt_scan_args_6(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, NULL, NULL, NULL, NULL)
+#define rb_jt_scan_args_7(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7, NULL, NULL, NULL)
+#define rb_jt_scan_args_8(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7, V8) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7, V8, NULL, NULL)
+#define rb_jt_scan_args_9(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7, V8, V9) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7, V8, V9, NULL)
+#define rb_jt_scan_args_10(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10) rb_jt_scan_args(ARGC, ARGV, FORMAT, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10)
+
+#define SCAN_ARGS_IMPL(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
+#define rb_scan_args(ARGC, ARGV, FORMAT, ...) SCAN_ARGS_IMPL(__VA_ARGS__, rb_jt_scan_args_10, rb_jt_scan_args_9, rb_jt_scan_args_8, rb_jt_scan_args_7, rb_jt_scan_args_6, rb_jt_scan_args_5, rb_jt_scan_args_4, rb_jt_scan_args_3, rb_jt_scan_args_2, rb_jt_scan_args_1)(ARGC, ARGV, FORMAT, __VA_ARGS__)
 
 // Calls
 

--- a/truffleruby/src/main/c/cext/ruby.c
+++ b/truffleruby/src/main/c/cext/ruby.c
@@ -1600,11 +1600,6 @@ void rb_warning(const char *format, ...) {
   }
 }
 
-int rb_scan_args(int argc, VALUE *argv, const char *format, ...) {
-  rb_jt_error("generic rb_scan_args not implemented - use a specialisation such as rb_jt_scan_args_02");
-  abort();
-}
-
 VALUE rb_enumeratorize(VALUE obj, VALUE meth, int argc, const VALUE *argv) {
   rb_jt_error("rb_funrb_enumeratorizecallv not implemented");
   abort();

--- a/truffleruby/src/main/ruby/core/rbconfig.rb
+++ b/truffleruby/src/main/ruby/core/rbconfig.rb
@@ -178,13 +178,16 @@ module RbConfig
   if Truffle::Safe.memory_safe? && Truffle::Safe.processes_safe?
     clang = ENV['JT_CLANG'] || 'clang'
     opt = ENV['JT_OPT'] || 'opt'
+    
+    # Sulong's passes, plus -always-inline
+    opt_passes = ['-always-inline', '-mem2reg', '-globalopt', '-simplifycfg', '-constprop', '-instcombine', '-dse', '-loop-simplify', '-reassociate', '-licm', '-gvn']
     cc = "#{clang} -I#{ENV['SULONG_HOME']}/include"
     cpp = cc
 
     CONFIG.merge!({
         'CC' => cc,
         'CPP' => cpp,
-        'COMPILE_C' => "ruby #{libdir}/cext/preprocess.rb < $< | #{cc} $(INCFLAGS) #{cppflags} #{cflags} $(COUTFLAG) -xc - -o $@ && #{opt} -always-inline -mem2reg $@ -o $@",
+        'COMPILE_C' => "ruby #{libdir}/cext/preprocess.rb < $< | #{cc} $(INCFLAGS) #{cppflags} #{cflags} $(COUTFLAG) -xc - -o $@ && #{opt} #{opt_passes.join(' ')} $@ -o $@",
         'CFLAGS' => cflags,
         'LINK_SO' => "mx -v -p #{ENV['SULONG_HOME']} su-link -o $@ $(OBJS) #{libs}",
         'TRY_LINK' => "#{clang} $(src) $(INCFLAGS) #{cflags} -I#{ENV['SULONG_HOME']}/include #{libs}"
@@ -193,7 +196,7 @@ module RbConfig
     MAKEFILE_CONFIG.merge!({
         'CC' => cc,
         'CPP' => cpp,
-        'COMPILE_C' => "ruby #{libdir}/cext/preprocess.rb < $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{opt} -always-inline -mem2reg $@ -o $@",
+        'COMPILE_C' => "ruby #{libdir}/cext/preprocess.rb < $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{opt} #{opt_passes.join(' ')} $@ -o $@",
         'CFLAGS' => cflags,
         'LINK_SO' => "mx -v -p #{ENV['SULONG_HOME']} su-link -o $@ $(OBJS) $(LIBS)",
         'TRY_LINK' => "#{clang} $(src) $(INCFLAGS) $(CFLAGS) -I#{ENV['SULONG_HOME']}/include $(LIBS)"


### PR DESCRIPTION
I managed to implemented `rb_scan_args` as a macro using help from Benoit. But I've left the preprocessor in for now - the code generated by the macro version is huge and will get larger when I cover more format cases. The preprocessor can generate small code in most cases. The macro version does work for cases where the string is dynamic, which is the main advantage.

I've allowed for up to ten arguments, as that's how many `openssl` needs.

Doesn't help us run the `util` specs any more though - `VALUE args[6]` is still `alloca`!