### PR TITLE
Add option for printing target commands in MSpec

### DIFF
--- a/spec/mspec/lib/mspec/commands/mspec.rb
+++ b/spec/mspec/lib/mspec/commands/mspec.rb
@@ -48,6 +48,10 @@ class MSpecMain < MSpecScript
       config[:multi] = true
       config[:options] << "-fy"
     end
+    
+    options.on("--print-target-cmd", "Print the target Ruby command") do
+      config[:print_target_cmd] = true
+    end
 
     options.version MSpec::VERSION do
       if config[:command]
@@ -157,9 +161,9 @@ class MSpecMain < MSpecScript
       else
         cmd, *rest = config[:target].split(/\s+/)
         argv = rest + argv unless rest.empty?
+        STDERR.puts "$ #{cmd} #{argv.join(' ')}" if config[:print_target_cmd]
         exec cmd, *argv
       end
     end
   end
 end
-

--- a/spec/mspec/lib/mspec/helpers/ruby_exe.rb
+++ b/spec/mspec/lib/mspec/helpers/ruby_exe.rb
@@ -144,6 +144,7 @@ class Object
 
       begin
         platform_is_not :opal do
+          puts "$ #{ruby_cmd(code, opts)}"
           `#{ruby_cmd(code, opts)}`
         end
       ensure

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -425,7 +425,7 @@ module ShellUtils
       command, *args = args
     end
 
-    sh env_vars, Utilities.find_ruby, 'spec/mspec/bin/mspec', command, '--config', 'spec/truffle.mspec', *args
+    sh env_vars, Utilities.find_ruby, 'spec/mspec/bin/mspec', command, '--config', 'spec/truffle.mspec', '--print-target-cmd', *args
   end
 
   def newer?(input, output)


### PR DESCRIPTION
What do you think of this general idea? I'll add specs for it if you are happy with the approach.

Printing commands aaalll the way down:

```
chrisseaton@Chriss-MacBook-Pro-3 ~/Documents/ruby/truffleruby $ jt test fast -T-J-cmd
$ ruby spec/mspec/bin/mspec run --config spec/truffle.mspec --print-target-cmd --excl-tag fails --excl-tag slow -T-J-cmd
$ /Users/chrisseaton/Documents/ruby/truffleruby/bin/truffleruby -J-ea -J-esa -J-Xmx2G -Xgraal.warn_unless=false -Xcore.load_path=/Users/chrisseaton/Documents/ruby/truffleruby/truffleruby/src/main/ruby -Xbacktraces.hide_core_files=false -J-cmd -v /Users/chrisseaton/Documents/ruby/truffleruby/spec/mspec/bin/mspec-run -B spec/truffle.mspec --excl-tag fails --excl-tag slow
/Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/bin/java -Dfile.encoding=UTF-8 -Xbootclasspath/a:/Users/chrisseaton/Documents/ruby/truffleruby/lib/truffleruby.jar -ea -esa -Xmx2G org.truffleruby.Main -Xhome=/Users/chrisseaton/Documents/ruby/truffleruby -Xlauncher=/Users/chrisseaton/Documents/ruby/truffleruby/bin/truffleruby -Xgraal.warn_unless=false -Xcore.load_path=/Users/chrisseaton/Documents/ruby/truffleruby/truffleruby/src/main/ruby -Xbacktraces.hide_core_files=false -v /Users/chrisseaton/Documents/ruby/truffleruby/spec/mspec/bin/mspec-run -B spec/truffle.mspec --excl-tag fails --excl-tag slow
truffleruby 0.SNAPSHOT, like ruby 2.3.3 <Java HotSpot(TM) 64-Bit Server VM 1.8.0_121-b13 without Graal> [darwin-x86_64]
[| | ==================100%================== | 00:00:00]      0F      0E.

Finished in 76.419000 seconds

3175 files, 22874 examples, 73631 expectations, 0 failures, 0 errors, 1233 tagged
```

This would let you take that final command and run it in `mx vm` or something else, or add whatever flags you want.

By the way, do you think `-J-cmd` should print a `$` at the start? It's a bit of a wall of characters otherwise - I think `$` makes the command stand out really well.