### PR TITLE
Fix $? for Kernel#system

### DIFF
--- a/spec/ruby/core/kernel/system_spec.rb
+++ b/spec/ruby/core/kernel/system_spec.rb
@@ -4,18 +4,33 @@ require File.expand_path('../fixtures/classes', __FILE__)
 describe :kernel_system, shared: true do
   it "executes the specified command in a subprocess" do
     lambda { @object.system("echo a") }.should output_to_fd("a\n")
+
+    $?.should be_an_instance_of Process::Status
+    $?.success?.should == true
   end
 
   it "returns true when the command exits with a zero exit status" do
     @object.system(ruby_cmd('exit 0')).should == true
+
+    $?.should be_an_instance_of Process::Status
+    $?.success?.should == true
+    $?.exitstatus.should == 0
   end
 
   it "returns false when the command exits with a non-zero exit status" do
     @object.system(ruby_cmd('exit 1')).should == false
+
+    $?.should be_an_instance_of Process::Status
+    $?.success?.should == false
+    $?.exitstatus.should == 1
   end
 
   it "returns nil when command execution fails" do
     @object.system("sad").should be_nil
+
+    $?.should be_an_instance_of Process::Status
+    $?.pid.should be_kind_of(Integer)
+    $?.exitstatus.should == 127
   end
 
   it "does not write to stderr when command execution fails" do


### PR DESCRIPTION
From https://github.com/graalvm/truffleruby/commit/f9b0dd8eb1557871e4d1e7d7bbd051b5f6f2185c#commitcomment-21059151

@nirvdrum It seems more consistent for me to not do any shell execution at all if the command does not have meta characters. The `PATH` lookup is automatically done by `posix_spawnp` (that's the trailing `p`).
Do you have an counter-example showing we should invoke the shell for that case?