### PR TITLE
Remove custom execute methods

### DIFF
--- a/truffleruby/src/main/java/org/truffleruby/core/IsNilNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/IsNilNode.java
@@ -21,13 +21,8 @@ public class IsNilNode extends RubyNode {
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame frame) {
-        return child.execute(frame) == nil();
-    }
-
-    @Override
     public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
+        return child.execute(frame) == nil();
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/core/IsRubiniusUndefinedNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/IsRubiniusUndefinedNode.java
@@ -22,13 +22,8 @@ public class IsRubiniusUndefinedNode extends RubyNode {
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame frame) {
-        return child.execute(frame) == NotProvided.INSTANCE;
-    }
-
-    @Override
     public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
+        return child.execute(frame) == NotProvided.INSTANCE;
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
@@ -13,7 +13,6 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.Layouts;
 import org.truffleruby.core.CoreLibrary;
@@ -118,9 +117,11 @@ public abstract class ArrayLiteralNode extends RubyNode {
             final double[] executedValues = new double[values.length];
 
             for (int n = 0; n < values.length; n++) {
-                try {
-                    executedValues[n] = values[n].executeDouble(frame);
-                } catch (UnexpectedResultException e) {
+                final Object value = values[n].execute(frame);
+                if (value instanceof Double) {
+                    executedValues[n] = (double) value;
+                } else {
+                    CompilerDirectives.transferToInterpreterAndInvalidate();
                     return makeGeneric(frame, executedValues, n);
                 }
             }
@@ -152,9 +153,11 @@ public abstract class ArrayLiteralNode extends RubyNode {
             final int[] executedValues = new int[values.length];
 
             for (int n = 0; n < values.length; n++) {
-                try {
-                    executedValues[n] = values[n].executeInteger(frame);
-                } catch (UnexpectedResultException e) {
+                final Object value = values[n].execute(frame);
+                if (value instanceof Integer) {
+                    executedValues[n] = (int) value;
+                } else {
+                    CompilerDirectives.transferToInterpreterAndInvalidate();
                     return makeGeneric(frame, executedValues, n);
                 }
             }
@@ -186,9 +189,11 @@ public abstract class ArrayLiteralNode extends RubyNode {
             final long[] executedValues = new long[values.length];
 
             for (int n = 0; n < values.length; n++) {
-                try {
-                    executedValues[n] = values[n].executeLong(frame);
-                } catch (UnexpectedResultException e) {
+                final Object value = values[n].execute(frame);
+                if (value instanceof Long) {
+                    executedValues[n] = (long) value;
+                } else {
+                    CompilerDirectives.transferToInterpreterAndInvalidate();
                     return makeGeneric(frame, executedValues, n);
                 }
             }

--- a/truffleruby/src/main/java/org/truffleruby/core/cast/BooleanCastNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/cast/BooleanCastNode.java
@@ -29,6 +29,10 @@ public abstract class BooleanCastNode extends RubyNode {
     public BooleanCastNode(BooleanCastNode node) {
     }
 
+    /** Execute with child node */
+    public abstract boolean executeBoolean(VirtualFrame frame);
+
+    /** Execute with given value */
     public abstract boolean executeToBoolean(Object value);
 
     @Specialization(guards = "isNil(nil)")
@@ -60,8 +64,5 @@ public abstract class BooleanCastNode extends RubyNode {
     public boolean doBasicObject(DynamicObject object) {
         return true;
     }
-
-    @Override
-    public abstract boolean executeBoolean(VirtualFrame frame);
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/core/cast/BooleanCastWithDefaultNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/cast/BooleanCastWithDefaultNode.java
@@ -11,7 +11,6 @@ package org.truffleruby.core.cast;
 
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyNode;
@@ -27,8 +26,6 @@ public abstract class BooleanCastWithDefaultNode extends RubyNode {
     public BooleanCastWithDefaultNode(boolean defaultValue) {
         this.defaultValue = defaultValue;
     }
-
-    public abstract boolean executeBoolean(VirtualFrame frame, Object value);
 
     @Specialization
     public boolean doDefault(NotProvided value) {
@@ -64,8 +61,5 @@ public abstract class BooleanCastWithDefaultNode extends RubyNode {
     public boolean doBasicObject(DynamicObject object) {
         return true;
     }
-
-    @Override
-    public abstract boolean executeBoolean(VirtualFrame frame);
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/core/cast/IntegerCastNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/cast/IntegerCastNode.java
@@ -13,7 +13,6 @@ import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.control.RaiseException;
 
@@ -25,9 +24,6 @@ import org.truffleruby.language.control.RaiseException;
 public abstract class IntegerCastNode extends RubyNode {
 
     public abstract int executeCastInt(Object value);
-
-    @Override
-    public abstract int executeInteger(VirtualFrame frame);
 
     @Specialization
     public int doInt(int value) {

--- a/truffleruby/src/main/java/org/truffleruby/core/cast/TaintResultNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/cast/TaintResultNode.java
@@ -13,7 +13,6 @@ package org.truffleruby.core.cast;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ControlFlowException;
-import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.truffleruby.language.RubyNode;
@@ -59,14 +58,12 @@ public class TaintResultNode extends RubyNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        final DynamicObject result;
+        final Object result;
 
         try {
-            result = method.executeDynamicObject(frame);
+            result = method.execute(frame);
         } catch (DoNotTaint e) {
             return e.getResult();
-        } catch (UnexpectedResultException e) {
-            throw new UnsupportedOperationException(e);
         }
 
         if (result != nil()) {

--- a/truffleruby/src/main/java/org/truffleruby/core/hash/ConcatHashLiteralNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/hash/ConcatHashLiteralNode.java
@@ -12,7 +12,6 @@ package org.truffleruby.core.hash;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.language.RubyNode;
 
@@ -49,12 +48,8 @@ public class ConcatHashLiteralNode extends RubyNode {
     protected DynamicObject[] executeChildren(VirtualFrame frame) {
         DynamicObject[] values = new DynamicObject[children.length];
         for (int i = 0; i < children.length; i++) {
-            try {
-                DynamicObject hash = children[i].executeDynamicObject(frame);
-                values[i] = hash;
-            } catch (UnexpectedResultException e) {
-                throw new UnsupportedOperationException(children[i].getClass() + " " + e.getResult().getClass());
-            }
+            DynamicObject hash = (DynamicObject) children[i].execute(frame);
+            values[i] = hash;
         }
         return values;
     }

--- a/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -236,6 +236,8 @@ public abstract class KernelNodes {
     @CoreMethod(names = "binding", isModuleFunction = true)
     public abstract static class BindingNode extends CoreMethodArrayArgumentsNode {
 
+        public abstract DynamicObject executeBinding();
+
         @TruffleBoundary
         @Specialization
         public DynamicObject binding() {
@@ -434,11 +436,7 @@ public abstract class KernelNodes {
                 bindingNode = insert(KernelNodesFactory.BindingNodeFactory.create(null));
             }
 
-            try {
-                return bindingNode.executeDynamicObject(frame);
-            } catch (UnexpectedResultException e) {
-                throw new UnsupportedOperationException(e);
-            }
+            return bindingNode.executeBinding();
         }
 
         protected static class RootNodeWrapper {

--- a/truffleruby/src/main/java/org/truffleruby/language/RubyNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/RubyNode.java
@@ -12,8 +12,6 @@ package org.truffleruby.language;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.nodes.UnexpectedResultException;
-import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.source.SourceSection;
 
 @Instrumentable(factory = RubyNodeWrapper.class)
@@ -29,78 +27,6 @@ public abstract class RubyNode extends RubyBaseNode {
 
     public Object isDefined(VirtualFrame frame) {
         return coreStrings().EXPRESSION.createInstance();
-    }
-
-    // Utility methods to execute and expect a particular type
-
-    public NotProvided executeNotProvided(VirtualFrame frame) throws UnexpectedResultException {
-        final Object value = execute(frame);
-
-        if (value instanceof NotProvided) {
-            return (NotProvided) value;
-        } else {
-            throw new UnexpectedResultException(value);
-        }
-    }
-
-    public boolean executeBoolean(VirtualFrame frame) throws UnexpectedResultException {
-        final Object value = execute(frame);
-
-        if (value instanceof Boolean) {
-            return (boolean) value;
-        } else {
-            throw new UnexpectedResultException(value);
-        }
-    }
-
-    public int executeInteger(VirtualFrame frame) throws UnexpectedResultException {
-        final Object value = execute(frame);
-
-        if (value instanceof Integer) {
-            return (int) value;
-        } else {
-            throw new UnexpectedResultException(value);
-        }
-    }
-
-    public long executeLong(VirtualFrame frame) throws UnexpectedResultException {
-        final Object value = execute(frame);
-
-        if (value instanceof Long) {
-            return (long) value;
-        } else {
-            throw new UnexpectedResultException(value);
-        }
-    }
-
-    public double executeDouble(VirtualFrame frame) throws UnexpectedResultException {
-        final Object value = execute(frame);
-
-        if (value instanceof Double) {
-            return (double) value;
-        } else {
-            throw new UnexpectedResultException(value);
-        }
-    }
-
-    public DynamicObject executeDynamicObject(VirtualFrame frame) throws UnexpectedResultException {
-        final Object value = execute(frame);
-
-        if (value instanceof DynamicObject) {
-            return (DynamicObject) value;
-        } else {
-            throw new UnexpectedResultException(value);
-        }
-    }
-
-    public Object[] executeObjectArray(VirtualFrame frame) throws UnexpectedResultException {
-        final Object value = execute(frame);
-
-        if (value.getClass() == Object[].class) {
-            return (Object[]) value;
-        } else {
-            throw new UnexpectedResultException(value);
-        }
     }
 
     // Boundaries

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ArrayIsAtLeastAsLargeAsNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ArrayIsAtLeastAsLargeAsNode.java
@@ -26,14 +26,9 @@ public class ArrayIsAtLeastAsLargeAsNode extends RubyNode {
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame frame) {
+    public Object execute(VirtualFrame frame) {
         final int actualSize = Layouts.ARRAY.getSize((DynamicObject) child.execute(frame));
         return actualSize >= requiredSize;
-    }
-
-    @Override
-    public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadAllArgumentsNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadAllArgumentsNode.java
@@ -15,13 +15,8 @@ import org.truffleruby.language.RubyNode;
 public class ReadAllArgumentsNode extends RubyNode {
 
     @Override
-    public Object[] executeObjectArray(VirtualFrame frame) {
-        return RubyArguments.getArguments(frame);
-    }
-
-    @Override
     public Object execute(VirtualFrame frame) {
-        return executeObjectArray(frame);
+        return RubyArguments.getArguments(frame);
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadRemainingArgumentsNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadRemainingArgumentsNode.java
@@ -23,7 +23,7 @@ public class ReadRemainingArgumentsNode extends RubyNode {
     }
 
     @Override
-    public Object[] executeObjectArray(VirtualFrame frame) {
+    public Object execute(VirtualFrame frame) {
         final int count = RubyArguments.getArgumentsCount(frame);
 
         if (remainingArguments.profile(start < count)) {
@@ -31,11 +31,6 @@ public class ReadRemainingArgumentsNode extends RubyNode {
         } else {
             return new Object[] {};
         }
-    }
-
-    @Override
-    public Object execute(VirtualFrame frame) {
-        return executeObjectArray(frame);
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ShouldDestructureNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ShouldDestructureNode.java
@@ -28,7 +28,7 @@ public class ShouldDestructureNode extends RubyNode {
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame frame) {
+    public Object execute(VirtualFrame frame) {
         if (RubyArguments.getArgumentsCount(frame) != 1) {
             return false;
         }
@@ -44,12 +44,7 @@ public class ShouldDestructureNode extends RubyNode {
             respondToCheck = insert(new RespondToNode(readArrayNode, "to_ary"));
         }
 
-        return respondToCheck.executeBoolean(frame);
-    }
-
-    @Override
-    public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
+        return respondToCheck.execute(frame);
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/control/NotNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/control/NotNode.java
@@ -23,13 +23,8 @@ public class NotNode extends RubyNode {
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame frame) {
-        return !child.executeBoolean(frame);
-    }
-
-    @Override
     public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
+        return !child.executeBoolean(frame);
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/RespondToNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/RespondToNode.java
@@ -24,19 +24,14 @@ public class RespondToNode extends RubyNode {
         this.child = child;
     }
 
-    @Override
-    public boolean executeBoolean(VirtualFrame frame) {
-        // TODO(cseaton): check this is actually a static "find if there is such method" and not a dynamic call to respond_to?
-        return dispatch.doesRespondTo(frame, methodName, child.execute(frame));
-    }
-
     public boolean executeBoolean(VirtualFrame frame, Object object) {
         return dispatch.doesRespondTo(frame, methodName, object);
     }
 
     @Override
     public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
+        // TODO(cseaton): check this is actually a static "find if there is such method" and not a dynamic call to respond_to?
+        return dispatch.doesRespondTo(frame, methodName, child.execute(frame));
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/literal/BooleanLiteralNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/literal/BooleanLiteralNode.java
@@ -24,13 +24,8 @@ public class BooleanLiteralNode extends RubyNode {
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame frame) {
-        return value;
-    }
-
-    @Override
     public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
+        return value;
     }
 
     @Override

--- a/truffleruby/src/main/java/org/truffleruby/language/literal/FloatLiteralNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/literal/FloatLiteralNode.java
@@ -24,13 +24,8 @@ public class FloatLiteralNode extends RubyNode {
     }
 
     @Override
-    public double executeDouble(VirtualFrame frame) {
-        return value;
-    }
-
-    @Override
     public Object execute(VirtualFrame frame) {
-        return executeDouble(frame);
+        return value;
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/literal/IntegerFixnumLiteralNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/literal/IntegerFixnumLiteralNode.java
@@ -25,11 +25,6 @@ public class IntegerFixnumLiteralNode extends RubyNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        return executeInteger(frame);
-    }
-
-    @Override
-    public int executeInteger(VirtualFrame frame) {
         return value;
     }
 

--- a/truffleruby/src/main/java/org/truffleruby/language/literal/LongFixnumLiteralNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/literal/LongFixnumLiteralNode.java
@@ -25,11 +25,6 @@ public class LongFixnumLiteralNode extends RubyNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        return executeLong(frame);
-    }
-
-    @Override
-    public long executeLong(VirtualFrame frame) {
         return value;
     }
 

--- a/truffleruby/src/main/java/org/truffleruby/language/locals/FlipFlopNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/locals/FlipFlopNode.java
@@ -31,7 +31,7 @@ public class FlipFlopNode extends RubyNode {
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame frame) {
+    public Object execute(VirtualFrame frame) {
         if (exclusive) {
             if (stateNode.getState(frame)) {
                 if (end.executeBoolean(frame)) {
@@ -60,11 +60,6 @@ public class FlipFlopNode extends RubyNode {
                 return false;
             }
         }
-    }
-
-    @Override
-    public Object execute(VirtualFrame frame) {
-        return executeBoolean(frame);
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/threadlocal/ThreadLocalObjectNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/threadlocal/ThreadLocalObjectNode.java
@@ -18,7 +18,6 @@ import org.truffleruby.language.RubyNode;
 
 public abstract class ThreadLocalObjectNode extends RubyNode {
 
-    @Override
     public abstract DynamicObject executeDynamicObject(VirtualFrame frame);
 
     @Specialization(


### PR DESCRIPTION
* Truffle DSL boxing elimination is not very interesting in
  Ruby as most operations are calls and calls box their arguments.
* Reduces generated code.

cc @chumer 