### PR TITLE
Ensure TruffleRuby gem home is always the default one for development

### DIFF
--- a/bin/truffleruby
+++ b/bin/truffleruby
@@ -52,6 +52,10 @@ else
     fi
 fi
 
+if [ -n "$TRUFFLERUBY_RESILIENT_GEM_HOME" ]; then
+    unset GEM_HOME GEM_PATH GEM_ROOT
+fi
+
 if [ -z "$JAVACMD" ]; then
     if [ -z "$JAVA_HOME" ]; then
         JAVACMD='java'


### PR DESCRIPTION
* No risk of polluting other gem homes.
* Allows to have a default Ruby in PATH and still use TruffleRuby.
* Bulletproof against fragile environment variables like GEM_HOME.

This my scenario:
I am developing TruffleRuby and I want a custom-installed Ruby as default, with `chruby` (because the one from the operating system is old/badly configured/etc).
Due to that, I get at every single execution of TruffleRuby the warnings:
```
[ruby] WARN A nonstandard GEM_HOME is set /home/eregon/.gem/ruby/2.3.0
[ruby] WARN The bad GEM_HOME may come from a ruby manager, make sure you've called one of: `rvm use system`, `rbenv system`, or `chruby system` to clear the environment.
```

Unsetting variables breaks chruby and the default Ruby, so it's not an option.
Adding my development TruffleRuby to a version manager is not an option either: it's slow to switch and it cannot run jt.rb and I cannot use anything from my default Ruby like `ri` for documentation.

Therefore my only recourse if you guys still think it's a good idea to have TruffleRuby working with *gems only if the user is lucky* enough to have none of `GEM_*` set, or patient enough to additionally set it up in his Ruby manager (but the user will also need to re-switch at every new open terminal...) is to add something system-dependent.

So here it is, I propose to add `TRUFFLERUBY_RESILIENT_GEM_HOME` which explicitly gives a deterministic GEM_HOME and Gem path to TruffleRuby.

I am of the opinion this should always be enabled. Less than 0.01% of users explicitly set GEM_HOME themselves (= it's not a use-case). A majority of Rubyists have some Ruby manager, and those set the GEM_* variables (or need a manual rehash), and I believe they just want to try TruffleRuby without any extra steps than running path/to/graalvm/bin/ruby. But this PR let you be non-deterministic on whether gems will work on TruffleRuby, if this is what you want.