### PR TITLE
Show that we can use the new TNFI to implement Fiddle

### DIFF
--- a/doc/user/interop.md
+++ b/doc/user/interop.md
@@ -249,3 +249,7 @@ an integer, or anything else
 `value = Truffle::Interop.import(:name)`
 
 `Truffle::Interop.import_method(:name)` (defines `name` in `Object`)
+
+## Interop Eval
+
+`Truffle::Interop.eval(mime_type, source)`

--- a/lib/truffle/fiddle.rb
+++ b/lib/truffle/fiddle.rb
@@ -1,0 +1,11 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+require 'fiddle/fiddle'
+require 'fiddle/handle'
+require 'fiddle/function'

--- a/lib/truffle/fiddle/fiddle.rb
+++ b/lib/truffle/fiddle/fiddle.rb
@@ -1,0 +1,17 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+module Fiddle
+  
+  TYPE_DOUBLE = 'DOUBLE'
+  
+  def self.dlopen(name=nil)
+    Handle.new(name)
+  end
+  
+end

--- a/lib/truffle/fiddle/function.rb
+++ b/lib/truffle/fiddle/function.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+module Fiddle
+  class Function
+    
+    DEFAULT = :default
+  
+    def initialize(ptr, args, ret_type, abi=DEFAULT)
+      @function = ptr.bind(Truffle::Interop.to_java_string("(#{args.join(',')}):#{ret_type}"))
+    end
+    
+    def call(*args)
+      @function.call(*args)
+    end
+  
+  end
+end

--- a/lib/truffle/fiddle/handle.rb
+++ b/lib/truffle/fiddle/handle.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+module Fiddle
+  class Handle
+    
+    def initialize(library=nil)
+      @handle = Truffle::Interop.eval('application/x-native', library ? "load #{library}" : 'default')
+    end
+    
+    def sym(symbol)
+      @handle[symbol]
+    end
+    
+    alias_method :[], :sym
+  
+  end
+end


### PR DESCRIPTION
Fiddle is MRI's FFI. There's also the more commonly used (I think) FFI gem, but this was simple to experiment with.

```ruby
require 'fiddle'

libm = Fiddle.dlopen('/usr/lib/libm.dylib') # libm.so.6 if on Linux

floor = Fiddle::Function.new(
  libm['floor'],
  [Fiddle::TYPE_DOUBLE],
  Fiddle::TYPE_DOUBLE
)

puts floor.call(3.14159) #=> 3.0
```

I could implement all of this in just Ruby!

Run with `--sulong` for now, due to issues with the NFI dependency.

Not ready to be merged - we have some issues with dependencies and enabling tests that I need to work through.

@grimmerm @rschatz @aardvark179 @bjfish @graalvm/truffleruby 