### PR TITLE
Get rb_num2dbl and other remaining numerics functions working.

### DIFF
--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -70,7 +70,7 @@ extern "C" {
 // Basic types
 
 typedef void *VALUE;
-typedef VALUE SIGNED_VALUE;
+typedef long SIGNED_VALUE;
 
 typedef VALUE ID;
 

--- a/spec/tags/optional/capi/numeric_tags.txt
+++ b/spec/tags/optional/capi/numeric_tags.txt
@@ -1,8 +1,0 @@
-fails:CApiNumericSpecs rb_ll2inum creates a new Fixnum from a small signed long long
-fails:CApiNumericSpecs rb_int2inum creates a new Fixnum from a long
-fails:CApiNumericSpecs rb_num2dbl raises a TypeError if passed nil
-fails:CApiNumericSpecs rb_num2dbl raises a TypeError if passed a String
-fails:CApiNumericSpecs rb_num2dbl converts a Float
-fails:CApiNumericSpecs rb_num2dbl converts a Bignum
-fails:CApiNumericSpecs rb_num2dbl converts a Fixnum
-fails:CApiNumericSpecs rb_num2dbl calls #to_f to coerce the value

--- a/truffleruby/src/main/c/cext/ruby.c
+++ b/truffleruby/src/main/c/cext/ruby.c
@@ -469,15 +469,16 @@ int rb_cmpint(VALUE val, VALUE a, VALUE b) {
 }
 
 VALUE rb_int2inum(SIGNED_VALUE n) {
-  rb_tr_error("rb_int2inum not implemented");
+  return (VALUE) truffle_invoke(RUBY_CEXT, "LONG2NUM", n);
 }
 
 VALUE rb_ll2inum(LONG_LONG n) {
-  rb_tr_error("rb_ll2inum not implemented");
+  /* Long and long long are both 64-bits with clang x86-64. */
+  return (VALUE) truffle_invoke(RUBY_CEXT, "LONG2NUM", n);
 }
 
 double rb_num2dbl(VALUE val) {
-  rb_tr_error("rb_num2dbl not implemented");
+  return truffle_invoke_d(RUBY_CEXT, "rb_num2dbl", val);
 }
 
 long rb_num2int(VALUE val) {

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -565,6 +565,10 @@ module Truffle::CExt
     Rubinius::Type.rb_num2ulong(val)
   end
 
+  def rb_num2dbl(val)
+    Rubinius::Type.rb_num2dbl(val)
+  end
+
   def rb_Integer(value)
     Integer(value)
   end

--- a/truffleruby/src/main/ruby/core/type.rb
+++ b/truffleruby/src/main/ruby/core/type.rb
@@ -263,6 +263,22 @@ module Rubinius
       end
     end
 
+    def self.rb_num2dbl(val)
+      raise TypeError, "no implicit conversion from nil to float" if val.nil?
+
+      if object_kind_of?(val, Float)
+        return val
+      elsif object_kind_of?(val, Fixnum)
+        return val.to_f
+      elsif object_kind_of?(val, Bignum)
+        return val.to_f
+      elsif object_kind_of?(val, String)
+        raise TypeError, "no implicit conversion from to float from string"
+      else
+        rb_num2dbl(rb_to_f(val))
+      end
+    end
+
     def self.rb_big2long(val)
       raise RangeError, "bignum too big to convert into `long'"
     end
@@ -270,6 +286,10 @@ module Rubinius
     def self.rb_big2ulong(val)
       check_ulong(val)
       Truffle.invoke_primitive(:fixnum_ulong_from_bignum, val)
+    end
+
+    def self.rb_to_f(val)
+      rb_to_float(val, :to_f);
     end
 
     def self.rb_to_int(val)
@@ -281,6 +301,15 @@ module Rubinius
       res = convert_type(val, Integer, meth, true)
       unless object_kind_of?(res, Integer)
         conversion_mismatch(val, Integer, meth, res)
+      end
+      res
+    end
+
+    def self.rb_to_float(val, meth)
+      return val if object_kind_of?(val, Float)
+      res = convert_type(val, Float, meth, true)
+      unless object_kind_of?(res, Float)
+        conversion_mismatch(val, Float, meth, res)
       end
       res
     end


### PR DESCRIPTION
Enabled `rb_num2dbl`
Also removed type punning for `SIGNED_VALUE` (we're not using tagged pointers so it might as well be an explicit `long`), and made `ll2inum` call `LONG2NUM` as `long long` and `long` are equivalent with clang on x86 64.