### PR TITLE
Run some basic Rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,6 @@ AllCops:
 Style/CaseIndentation:
   Enabled: true
   EnforcedStyle: 'end'
+
+Style/IndentationConsistency:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+AllCops:
+  DisabledByDefault: true
+  Exclude:
+    - 'bin/**/*'
+    - 'lib/bin/**/*'
+    - 'lib/json/**/*'
+    - 'lib/mri/**/*'
+    - 'lib/patches/**/*'
+    - 'lib/pr-zlib/**/*'
+    - 'lib/ruby/**/*'
+    - 'lib/rubysl/**/*'
+    - 'lib/truffleruby-tool/**/*'
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'tool/**/*'
+
+Style/CaseIndentation:
+  Enabled: true
+  EnforcedStyle: 'end'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
     - 'test/**/*'
     - 'tool/**/*'
 
+Style/IndentationWidth:
+  Enabled: true
+
 Style/CaseIndentation:
   Enabled: true
   EnforcedStyle: 'end'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   - env: JT='test integration'
   - env: JT='test gems' COMMAND=test/truffle/gems/install-gems.sh
   - env: JT='test tck'
-  - env: JT='check_dsl_usage' SKIP_BUILD=true V=1
+  - env: JT='lint' SKIP_BUILD=true V=1
   - env: JT='test mri'
   - env: JT='test bundle'
   - env: JT='test ecosystem actionpack actionview' JAVA_OPTS="$JAVA_OPTS -Xmx512m" COMMAND=test/truffle/ecosystem-travis-install.sh

--- a/lib/truffle/digest/sha2.rb
+++ b/lib/truffle/digest/sha2.rb
@@ -25,14 +25,14 @@ module Digest
     # Valid bit lengths are 256, 384 and 512.
     def initialize(bitlen = 256)
       case bitlen
-        when 256
-          @sha2 = Digest::SHA256.new
-        when 384
-          @sha2 = Digest::SHA384.new
-        when 512
-          @sha2 = Digest::SHA512.new
-        else
-          raise ArgumentError, "unsupported bit length: %s" % bitlen.inspect
+      when 256
+        @sha2 = Digest::SHA256.new
+      when 384
+        @sha2 = Digest::SHA384.new
+      when 512
+        @sha2 = Digest::SHA512.new
+      else
+        raise ArgumentError, "unsupported bit length: %s" % bitlen.inspect
       end
       @bitlen = bitlen
     end
@@ -111,4 +111,3 @@ module Digest
     end
   end
 end
-

--- a/lib/truffle/java/core_ext/module.rb
+++ b/lib/truffle/java/core_ext/module.rb
@@ -51,13 +51,13 @@ class Module
       last_error = nil
 
       @included_packages.each do |package|
-          begin
-            java_class = JavaUtilities.get_java_class("#{package}.#{real_name}")
-          rescue NameError
-            # we only rescue NameError, since other errors should bubble out
-            last_error = $!
-          end
-          break if java_class
+        begin
+          java_class = JavaUtilities.get_java_class("#{package}.#{real_name}")
+        rescue NameError
+          # we only rescue NameError, since other errors should bubble out
+          last_error = $!
+        end
+        break if java_class
       end
 
       if java_class

--- a/lib/truffle/java/java.rb
+++ b/lib/truffle/java/java.rb
@@ -123,7 +123,7 @@ module Java
     end
 
     def const_missing(name)
-       method_missing(name)
+      method_missing(name)
     end
 
     def add_child(package, name)

--- a/lib/truffle/java/java_utilities.rb
+++ b/lib/truffle/java/java_utilities.rb
@@ -228,7 +228,7 @@ module JavaUtilities
     else
       a_proxy = existing_proxy
     end
- 
+
     a_proxy
   end
 
@@ -332,7 +332,7 @@ module JavaUtilities
   ARRAY_SETTER_GETTER = Java.get_java_method(
     JAVA_METHODHANDLES_CLASS, "arrayElementSetter", true, JAVA_METHODHANDLE_CLASS, JAVA_CLASS_CLASS)
   ARRAY_GETTER = Java.invoke_java_method(ARRAY_GETTER_GETTER, JAVA_OBJECT_ARRAY)
-  
+
   def self.java_array_size(an_array)
     Java.invoke_java_method(REFLECT_ARRAY_LENGTH, an_array)
   end
@@ -342,9 +342,9 @@ module JavaUtilities
   end
 
   def self.get_java_class(obj)
-      Java.invoke_java_method(OBJECT_GET_CLASS, obj)
+    Java.invoke_java_method(OBJECT_GET_CLASS, obj)
   end
-  
+
   def self.add_array_accessors(a_proxy, a_class)
     array_getter = Java.invoke_java_method(ARRAY_GETTER_GETTER, a_class)
     array_setter = Java.invoke_java_method(ARRAY_SETTER_GETTER, a_class)
@@ -356,12 +356,12 @@ module JavaUtilities
                         array_setter, self.java_object, i,
                         ::JavaUtilities.unwrap_java_value(v)) }
     size = lambda { Java.invoke_java_method(REFLECT_ARRAY_LENGTH, self.java_object) }
-    
+
     a_proxy.__send__(:define_method, "[]", getter)
     a_proxy.__send__(:define_method, "[]=", setter)
     a_proxy.__send__(:define_method, "size", size)
   end
-  
+
   def self.add_static_fields(a_proxy)
     fields = Java.invoke_java_method(CLASS_GET_DECLARED_FIELDS, a_proxy.java_class)
     # Not using idiomatic Ruby here as we might not have bootstrapped that at this point.

--- a/lib/truffle/objspace.rb
+++ b/lib/truffle/objspace.rb
@@ -84,69 +84,69 @@ module ObjectSpace
 
   def dump(object, output: :string)
     case output
-      when :string
-        json = {
-          address: "0x" + object.object_id.to_s(16),
-          class: "0x" + object.class.object_id.to_s(16),
-          memsize: memsize_of(object),
-          flags: { }
-        }
-        case object
-          when String
-            json.merge!({
-              type: "STRING",
-              bytesize: object.bytesize,
-              value: object,
-              encoding: object.encoding.name
-            })
-          when Array
-            json.merge!({
-              type: "ARRAY",
-              length: object.size
-            })
-          when Hash
-            json.merge!({
-              type: "HASH",
-              size: object.size
-            })
-          else
-            json.merge!({
-              type: "OBJECT",
-              length: object.instance_variables.size
-            })
-        end
-        JSON.generate(json)
-      when :file
-        f = Tempfile.new(['rubyobj', '.json'])
-        f.write dump(object, output: :string)
-        f.close
-        f.path
-      when :stdout
-        puts dump(object, output: :string)
-        nil
+    when :string
+      json = {
+        address: "0x" + object.object_id.to_s(16),
+        class: "0x" + object.class.object_id.to_s(16),
+        memsize: memsize_of(object),
+        flags: { }
+      }
+      case object
+      when String
+        json.merge!({
+          type: "STRING",
+          bytesize: object.bytesize,
+          value: object,
+          encoding: object.encoding.name
+        })
+      when Array
+        json.merge!({
+          type: "ARRAY",
+          length: object.size
+        })
+      when Hash
+        json.merge!({
+          type: "HASH",
+          size: object.size
+        })
+      else
+        json.merge!({
+          type: "OBJECT",
+          length: object.instance_variables.size
+        })
+      end
+      JSON.generate(json)
+    when :file
+      f = Tempfile.new(['rubyobj', '.json'])
+      f.write dump(object, output: :string)
+      f.close
+      f.path
+    when :stdout
+      puts dump(object, output: :string)
+      nil
     end
   end
   module_function :dump
 
   def dump_all(output: :file)
     case output
-      when :string
-        objects = []
-        ObjectSpace.each_object do |object|
-          objects.push dump(object)
-        end
-        objects.join("\n")
-      when :file
-        f = Tempfile.new(['ruby', '.json'])
-        f.write dump_all(output: :string)
-        f.close
-        f.path
-      when :stdout
-        puts dump_all(output: :string)
-        nil
-      when IO
-        output.write dump_all(output: :string)
-        nil
+    when :string
+      objects = []
+      ObjectSpace.each_object do |object|
+        objects.push dump(object)
+      end
+      objects.join("\n")
+    when :file
+      f = Tempfile.new(['ruby', '.json'])
+      f.write dump_all(output: :string)
+      f.close
+      f.path
+    when :stdout
+      puts dump_all(output: :string)
+      nil
+    when IO
+      output.write dump_all(output: :string)
+      nil
     end
   end
   module_function :dump_all

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1475,6 +1475,20 @@ module Commands
     run({ "TRUFFLE_CHECK_DSL_USAGE" => "true" }, '-e', 'exit')
   end
 
+  def rubocop
+    begin
+      require 'rubocop'
+    rescue LoadError
+      sh "gem", "install", "rubocop"
+    end
+    sh "rubocop"
+  end
+
+  def lint
+    check_dsl_usage
+    rubocop
+  end
+
   def verify_aot_bin!
     unless File.exist?(ENV['AOT_BIN'].to_s)
       raise "AOT_BIN must point at an AOT build of TruffleRuby"

--- a/truffleruby/src/main/ruby/core/array.rb
+++ b/truffleruby/src/main/ruby/core/array.rb
@@ -241,19 +241,19 @@ class Array
       return i if x == 0
 
       case x
-        when Numeric
-          if x > 0
-            min = i + 1
-          else
-            max = i - 1
-          end
-        when true
-          last_true = i
-          max = i - 1
-        when false, nil
+      when Numeric
+        if x > 0
           min = i + 1
         else
-          raise TypeError, "wrong argument type (must be numeric, true, false or nil)"
+          max = i - 1
+        end
+      when true
+        last_true = i
+        max = i - 1
+      when false, nil
+        min = i + 1
+      else
+        raise TypeError, "wrong argument type (must be numeric, true, false or nil)"
       end
 
       i = min + (max - min) / 2

--- a/truffleruby/src/main/ruby/core/array.rb
+++ b/truffleruby/src/main/ruby/core/array.rb
@@ -348,13 +348,13 @@ class Array
   end
 
   def dig(idx, *more)
-     result = self.at(idx)
-     if result.nil? || more.empty?
-       result
-     else
-       raise TypeError, "#{result.class} does not have #dig method" unless result.respond_to?(:dig)
-       result.dig(*more)
-     end
+    result = self.at(idx)
+    if result.nil? || more.empty?
+      result
+    else
+      raise TypeError, "#{result.class} does not have #dig method" unless result.respond_to?(:dig)
+      result.dig(*more)
+    end
   end
 
   def each_index

--- a/truffleruby/src/main/ruby/core/complex.rb
+++ b/truffleruby/src/main/ruby/core/complex.rb
@@ -184,10 +184,9 @@ class Complex < Numeric
         z = x
         n = other - 1
         while n != 0
-          while (div, mod = n.divmod(2)
-           mod == 0)
+          while n.even?
             x = Complex(x.real*x.real - x.imag*x.imag, 2*x.real*x.imag)
-            n = div
+            n /= 2
           end
           z *= x
           n -= 1

--- a/truffleruby/src/main/ruby/core/enumerable.rb
+++ b/truffleruby/src/main/ruby/core/enumerable.rb
@@ -36,11 +36,11 @@ module Enumerable
     ::Enumerator.new do |yielder|
       previous = nil
       accumulate = []
-      block = if initial_state.nil?
-        original_block
+      if initial_state.nil?
+        block = original_block
       else
         duplicated_initial_state = initial_state.dup
-        Proc.new{ |val| original_block.yield(val, duplicated_initial_state)}
+        block = Proc.new{ |val| original_block.yield(val, duplicated_initial_state)}
       end
       each do |val|
         key = block.yield(val)
@@ -191,7 +191,7 @@ module Enumerable
   def slice_after(arg = undefined, &block)
     has_arg = !(undefined.equal? arg)
     if block_given?
-        raise ArgumentError, "both pattern and block are given" if has_arg
+      raise ArgumentError, "both pattern and block are given" if has_arg
     else
       raise ArgumentError, "wrong number of arguments (0 for 1)" unless has_arg
       block = Proc.new{ |elem| arg === elem }
@@ -676,7 +676,7 @@ module Enumerable
     self.sort(&block).first(n)
   end
   private :min_n
-  
+
   alias_method :min_internal, :min
 
   def max(n = undefined, &block)
@@ -708,7 +708,7 @@ module Enumerable
     self.sort(&block).reverse.first(n)
   end
   private :max_n
-  
+
   alias_method :max_internal, :max
 
   def max_by

--- a/truffleruby/src/main/ruby/core/enumerator.rb
+++ b/truffleruby/src/main/ruby/core/enumerator.rb
@@ -282,10 +282,10 @@ module Enumerable
         raise ArgumentError, "attempt to take negative size" if n < 0
 
         current_size = enumerator_size
-        set_size = if current_size.kind_of?(Numeric)
-          n < current_size ? n : current_size
+        if current_size.kind_of?(Numeric)
+          set_size = n < current_size ? n : current_size
         else
-          current_size
+          set_size = current_size
         end
 
         return to_enum(:cycle, 0).lazy if n.zero?
@@ -307,10 +307,10 @@ module Enumerable
         raise ArgumentError, "attempt to drop negative size" if n < 0
 
         current_size = enumerator_size
-        set_size = if current_size.kind_of?(Integer)
-          n < current_size ? current_size - n : 0
+        if current_size.kind_of?(Integer)
+          set_size = n < current_size ? current_size - n : 0
         else
-          current_size
+          set_size = current_size
         end
 
         dropped = 0

--- a/truffleruby/src/main/ruby/core/env.rb
+++ b/truffleruby/src/main/ruby/core/env.rb
@@ -294,12 +294,10 @@ module Rubinius
     def set_encoding(value)
       return unless value.kind_of? String
       locale = Encoding.find("locale")
-      value = if Encoding.default_internal && value.ascii_only?
-        value.encode Encoding.default_internal, locale
+      if Encoding.default_internal && value.ascii_only?
+        value = value.encode Encoding.default_internal, locale
       elsif value.encoding != locale
-        value.dup.force_encoding(locale)
-      else
-        value
+        value = value.dup.force_encoding(locale)
       end
       value.taint unless value.tainted?
       value.freeze

--- a/truffleruby/src/main/ruby/core/file.rb
+++ b/truffleruby/src/main/ruby/core/file.rb
@@ -32,15 +32,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-module Rubinius
 module Truffle::POSIX
   #--
   # Internal class for accessing timevals
   #++
-  class TimeVal < FFI::Struct
+  class TimeVal < Rubinius::FFI::Struct
     config 'rbx.platform.timeval', :tv_sec, :tv_usec
   end
-end
 end
 
 class File < IO

--- a/truffleruby/src/main/ruby/core/hash.rb
+++ b/truffleruby/src/main/ruby/core/hash.rb
@@ -101,9 +101,9 @@ class Hash
   alias_method :__store__, :[]=
 
   def <(other)
-     other = Rubinius::Type.coerce_to(other, Hash, :to_hash)
-     return false if self.size >= other.size
-     self.class.contains_all_internal(self, other)
+    other = Rubinius::Type.coerce_to(other, Hash, :to_hash)
+    return false if self.size >= other.size
+    self.class.contains_all_internal(self, other)
   end
 
   def <=(other)

--- a/truffleruby/src/main/ruby/core/kernel.rb
+++ b/truffleruby/src/main/ruby/core/kernel.rb
@@ -358,7 +358,7 @@ module Kernel
         yield
       end
     rescue StopIteration => si
-       result = si.result
+      result = si.result
     end
     result
   end

--- a/truffleruby/src/main/ruby/core/marshal.rb
+++ b/truffleruby/src/main/ruby/core/marshal.rb
@@ -170,12 +170,12 @@ module Marshal
 
     def serialize_encoding(obj)
       case enc = Rubinius::Type.object_encoding(obj)
-        when Encoding::US_ASCII
-          :E.__marshal__(self) + false.__marshal__(self)
-        when Encoding::UTF_8
-          :E.__marshal__(self) + true.__marshal__(self)
-        else
-          :encoding.__marshal__(self) + serialize_string(enc.name)
+      when Encoding::US_ASCII
+        :E.__marshal__(self) + false.__marshal__(self)
+      when Encoding::UTF_8
+        :E.__marshal__(self) + true.__marshal__(self)
+      else
+        :encoding.__marshal__(self) + serialize_string(enc.name)
       end
     end
 
@@ -1198,10 +1198,10 @@ module Marshal
         value = construct
 
         case ivar
-          when :@begin then range_begin = value
-          when :@end then range_end = value
-          when :@excl then range_exclude_end = value
-          else ivars[ivar] = value
+        when :@begin then range_begin = value
+        when :@end then range_end = value
+        when :@excl then range_exclude_end = value
+        else ivars[ivar] = value
         end
       end
 

--- a/truffleruby/src/main/ruby/core/mirror.rb
+++ b/truffleruby/src/main/ruby/core/mirror.rb
@@ -40,27 +40,27 @@ module Rubinius
 
     def self.module_mirror(obj)
       case obj
-        when ::Numeric then Rubinius::Mirror::Numeric
-        when ::String then Rubinius::Mirror::String
-        when ::Range then Rubinius::Mirror::Range
-        when ::Process then Rubinius::Mirror::Process
-        when ::Proc then Rubinius::Mirror::Proc
-        else
-          begin
-            Rubinius::Mirror.const_get(obj.class.name.to_sym, false)
-          rescue NameError
-            ancestor = obj.class.superclass
+      when ::Numeric then Rubinius::Mirror::Numeric
+      when ::String then Rubinius::Mirror::String
+      when ::Range then Rubinius::Mirror::Range
+      when ::Process then Rubinius::Mirror::Process
+      when ::Proc then Rubinius::Mirror::Proc
+      else
+        begin
+          Rubinius::Mirror.const_get(obj.class.name.to_sym, false)
+        rescue NameError
+          ancestor = obj.class.superclass
 
-            until ancestor.nil?
-              begin
-                return Rubinius::Mirror.const_get(ancestor.name.to_sym, false)
-              rescue NameError
-                ancestor = ancestor.superclass
-              end
+          until ancestor.nil?
+            begin
+              return Rubinius::Mirror.const_get(ancestor.name.to_sym, false)
+            rescue NameError
+              ancestor = ancestor.superclass
             end
-
-            nil
           end
+
+          nil
+        end
       end
     end
 

--- a/truffleruby/src/main/ruby/core/numeric.rb
+++ b/truffleruby/src/main/ruby/core/numeric.rb
@@ -240,7 +240,7 @@ class Numeric
   def bit_coerce(other)
     values = math_coerce(other)
     unless values[0].is_a?(Integer) && values[1].is_a?(Integer)
-         raise TypeError, "#{values[1].class} can't be coerced into #{self.class}"
+      raise TypeError, "#{values[1].class} can't be coerced into #{self.class}"
     end
     values
   end
@@ -337,8 +337,8 @@ class Numeric
   end
 
   def singleton_method_added(name)
-      self.singleton_class.send(:remove_method, name)
-      raise TypeError, "can't define singleton method #{name} for #{self.class}"
+    self.singleton_class.send(:remove_method, name)
+    raise TypeError, "can't define singleton method #{name} for #{self.class}"
   end
 
 end

--- a/truffleruby/src/main/ruby/core/process.rb
+++ b/truffleruby/src/main/ruby/core/process.rb
@@ -81,12 +81,12 @@ module Process
   #
   def self.exit(code=0)
     case code
-      when true
-        code = 0
-      when false
-        code = 1
-      else
-        code = Rubinius::Type.coerce_to code, Integer, :to_int
+    when true
+      code = 0
+    when false
+      code = 1
+    else
+      code = Rubinius::Type.coerce_to code, Integer, :to_int
     end
 
     raise SystemExit.new(code)
@@ -96,13 +96,14 @@ module Process
     Truffle.primitive :vm_exit
 
     case code
-      when true
-        exit! 0
-      when false
-        exit! 1
-      else
-        exit! Rubinius::Type.coerce_to(code, Integer, :to_int)
+    when true
+      code = 0
+    when false
+      code = 1
+    else
+      code = Rubinius::Type.coerce_to code, Integer, :to_int
     end
+    exit! code
   end
 
   def self.wait_pid_prim(pid, no_hang)

--- a/truffleruby/src/main/ruby/core/string.rb
+++ b/truffleruby/src/main/ruby/core/string.rb
@@ -131,14 +131,14 @@ class String
 
   def =~(pattern)
     case pattern
-      when Regexp
-        match_data = pattern.search_region(self, 0, bytesize, true)
-        Truffle.invoke_primitive(:regexp_set_last_match, match_data)
-        return match_data.begin(0) if match_data
-      when String
-        raise TypeError, "type mismatch: String given"
-      else
-        pattern =~ self
+    when Regexp
+      match_data = pattern.search_region(self, 0, bytesize, true)
+      Truffle.invoke_primitive(:regexp_set_last_match, match_data)
+      return match_data.begin(0) if match_data
+    when String
+      raise TypeError, "type mismatch: String given"
+    else
+      pattern =~ self
     end
   end
 
@@ -353,39 +353,39 @@ class String
       cap = data[index]
 
       additional = case cap
-                     when 38   # ?&
-                       match[0]
-                     when 96   # ?`
-                       match.pre_match
-                     when 39   # ?'
-                       match.post_match
-                     when 43   # ?+
-                       match.captures.compact[-1].to_s
-                     when 48..57   # ?0..?9
-                       match[cap - 48].to_s
-                     when 92 # ?\\ escaped backslash
-                       '\\'
-                     when 107 # \k named capture
-                       if data[index + 1] == 60
-                         name = ""
-                         i = index + 2
-                         while i < bytesize && data[i] != 62
-                           name << data[i]
-                           i += 1
-                         end
-                         if i >= bytesize
-                           '\\'.append(cap.chr)
-                           index += 1
-                           next
-                         end
-                         index = i
-                         name.force_encoding result.encoding
-                         match[name]
-                       else
-                         '\\'.append(cap.chr)
+                   when 38   # ?&
+                     match[0]
+                   when 96   # ?`
+                     match.pre_match
+                   when 39   # ?'
+                     match.post_match
+                   when 43   # ?+
+                     match.captures.compact[-1].to_s
+                   when 48..57   # ?0..?9
+                     match[cap - 48].to_s
+                   when 92 # ?\\ escaped backslash
+                     '\\'
+                   when 107 # \k named capture
+                     if data[index + 1] == 60
+                       name = ""
+                       i = index + 2
+                       while i < bytesize && data[i] != 62
+                         name << data[i]
+                         i += 1
                        end
-                     else     # unknown escape
+                       if i >= bytesize
+                         '\\'.append(cap.chr)
+                         index += 1
+                         next
+                       end
+                       index = i
+                       name.force_encoding result.encoding
+                       match[name]
+                     else
                        '\\'.append(cap.chr)
+                     end
+                   else     # unknown escape
+                     '\\'.append(cap.chr)
                    end
       result.append(additional)
       index += 1
@@ -516,20 +516,20 @@ class String
     # TODO: replace this hack with transcoders
     if options.kind_of? Hash
       case invalid = options[:invalid]
-        when :replace
-          self.scrub!
+      when :replace
+        self.scrub!
       end
       case xml = options[:xml]
-        when :text
-          gsub!(/[&><]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;')
-        when :attr
-          gsub!(/[&><"]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;', '"' => '&quot;')
-          insert(0, '"')
-          insert(-1, '"')
-        when nil
-          # nothing
-        else
-          raise ArgumentError, "unexpected value for xml option: #{xml.inspect}"
+      when :text
+        gsub!(/[&><]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;')
+      when :attr
+        gsub!(/[&><"]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;', '"' => '&quot;')
+        insert(0, '"')
+        insert(-1, '"')
+      when nil
+        # nothing
+      else
+        raise ArgumentError, "unexpected value for xml option: #{xml.inspect}"
       end
 
       if options[:universal_newline]
@@ -610,37 +610,37 @@ class String
           byte = getbyte(index)
           if byte >= 7 and byte <= 92
             case byte
-              when 7  # \a
-                escaped = '\a'
-              when 8  # \b
-                escaped = '\b'
-              when 9  # \t
-                escaped = '\t'
-              when 10 # \n
-                escaped = '\n'
-              when 11 # \v
-                escaped = '\v'
-              when 12 # \f
-                escaped = '\f'
-              when 13 # \r
-                escaped = '\r'
-              when 27 # \e
-                escaped = '\e'
-              when 34 # \"
-                escaped = '\"'
-              when 35 # #
-                case getbyte(index += 1)
-                  when 36   # $
-                    escaped = '\#$'
-                  when 64   # @
-                    escaped = '\#@'
-                  when 123  # {
-                    escaped = '\#{'
-                  else
-                    index -= 1
-                end
-              when 92 # \\
-                escaped = '\\\\'
+            when 7  # \a
+              escaped = '\a'
+            when 8  # \b
+              escaped = '\b'
+            when 9  # \t
+              escaped = '\t'
+            when 10 # \n
+              escaped = '\n'
+            when 11 # \v
+              escaped = '\v'
+            when 12 # \f
+              escaped = '\f'
+            when 13 # \r
+              escaped = '\r'
+            when 27 # \e
+              escaped = '\e'
+            when 34 # \"
+              escaped = '\"'
+            when 35 # #
+              case getbyte(index += 1)
+              when 36   # $
+                escaped = '\#$'
+              when 64   # @
+                escaped = '\#@'
+              when 123  # {
+                escaped = '\#{'
+              else
+                index -= 1
+              end
+            when 92 # \\
+              escaped = '\\\\'
             end
 
             if escaped
@@ -888,18 +888,18 @@ class String
       chr = chr_at bytes
 
       case chr.ord
-        when 13
-          # do nothing
-        when 10
-          if j = m.previous_byte_index(bytes)
-            chr = chr_at j
+      when 13
+        # do nothing
+      when 10
+        if j = m.previous_byte_index(bytes)
+          chr = chr_at j
 
-            if chr.ord == 13
-              bytes = j
-            end
+          if chr.ord == 13
+            bytes = j
           end
-        else
-          return
+        end
+      else
+        return
       end
     elsif sep.size == 0
       return if empty?
@@ -1237,113 +1237,113 @@ class String
     m = Rubinius::Mirror.reflect self
 
     case index
-      when Fixnum
-        index += size if index < 0
+    when Fixnum
+      index += size if index < 0
 
-        if index < 0 or index > size
-          raise IndexError, "index #{index} out of string"
+      if index < 0 or index > size
+        raise IndexError, "index #{index} out of string"
+      end
+
+      unless bi = m.byte_index(index)
+        raise IndexError, "unable to find character at: #{index}"
+      end
+
+      if count
+        count = Rubinius::Type.coerce_to count, Fixnum, :to_int
+
+        if count < 0
+          raise IndexError, "count is negative"
         end
 
-        unless bi = m.byte_index(index)
-          raise IndexError, "unable to find character at: #{index}"
-        end
-
-        if count
-          count = Rubinius::Type.coerce_to count, Fixnum, :to_int
-
-          if count < 0
-            raise IndexError, "count is negative"
-          end
-
-          total = index + count
-          if total >= size
-            bs = bytesize - bi
-          else
-            bs = m.byte_index(total) - bi
-          end
-        else
-          bs = index == size ? 0 : m.byte_index(index + 1) - bi
-        end
-
-        replacement = StringValue replacement
-        enc = Rubinius::Type.compatible_encoding self, replacement
-
-        m.splice bi, bs, replacement, enc
-      when String
-        unless start = m.byte_index(index)
-          raise IndexError, "string not matched"
-        end
-
-        replacement = StringValue replacement
-        enc = Rubinius::Type.compatible_encoding self, replacement
-
-        m.splice start, index.bytesize, replacement, enc
-      when Range
-        start = Rubinius::Type.coerce_to index.first, Fixnum, :to_int
-
-        start += size if start < 0
-
-        if start < 0 or start > size
-          raise RangeError, "#{index.first} is out of range"
-        end
-
-        unless bi = m.byte_index(start)
-          raise IndexError, "unable to find character at: #{start}"
-        end
-
-        stop = Rubinius::Type.coerce_to index.last, Fixnum, :to_int
-        stop += size if stop < 0
-        stop -= 1 if index.exclude_end?
-
-        if stop < start
-          bs = 0
-        elsif stop >= size
+        total = index + count
+        if total >= size
           bs = bytesize - bi
         else
-          bs = m.byte_index(stop + 1) - bi
+          bs = m.byte_index(total) - bi
         end
-
-        replacement = StringValue replacement
-        enc = Rubinius::Type.compatible_encoding self, replacement
-
-        m.splice bi, bs, replacement, enc
-      when Regexp
-        if count
-          count = Rubinius::Type.coerce_to count, Fixnum, :to_int
-        else
-          count = 0
-        end
-
-        if match = index.match(self)
-          ms = match.size
-        else
-          raise IndexError, "regexp does not match"
-        end
-
-        count += ms if count < 0 and -count < ms
-        unless count < ms and count >= 0
-          raise IndexError, "index #{count} out of match bounds"
-        end
-
-        unless match[count]
-          raise IndexError, "regexp group #{count} not matched"
-        end
-
-        replacement = StringValue replacement
-        enc = Rubinius::Type.compatible_encoding self, replacement
-
-        bi = m.byte_index match.begin(count)
-        bs = m.byte_index(match.end(count)) - bi
-
-        m.splice bi, bs, replacement, enc
       else
-        index = Rubinius::Type.coerce_to index, Fixnum, :to_int
+        bs = index == size ? 0 : m.byte_index(index + 1) - bi
+      end
 
-        if count
-          return self[index, count] = replacement
-        else
-          return self[index] = replacement
-        end
+      replacement = StringValue replacement
+      enc = Rubinius::Type.compatible_encoding self, replacement
+
+      m.splice bi, bs, replacement, enc
+    when String
+      unless start = m.byte_index(index)
+        raise IndexError, "string not matched"
+      end
+
+      replacement = StringValue replacement
+      enc = Rubinius::Type.compatible_encoding self, replacement
+
+      m.splice start, index.bytesize, replacement, enc
+    when Range
+      start = Rubinius::Type.coerce_to index.first, Fixnum, :to_int
+
+      start += size if start < 0
+
+      if start < 0 or start > size
+        raise RangeError, "#{index.first} is out of range"
+      end
+
+      unless bi = m.byte_index(start)
+        raise IndexError, "unable to find character at: #{start}"
+      end
+
+      stop = Rubinius::Type.coerce_to index.last, Fixnum, :to_int
+      stop += size if stop < 0
+      stop -= 1 if index.exclude_end?
+
+      if stop < start
+        bs = 0
+      elsif stop >= size
+        bs = bytesize - bi
+      else
+        bs = m.byte_index(stop + 1) - bi
+      end
+
+      replacement = StringValue replacement
+      enc = Rubinius::Type.compatible_encoding self, replacement
+
+      m.splice bi, bs, replacement, enc
+    when Regexp
+      if count
+        count = Rubinius::Type.coerce_to count, Fixnum, :to_int
+      else
+        count = 0
+      end
+
+      if match = index.match(self)
+        ms = match.size
+      else
+        raise IndexError, "regexp does not match"
+      end
+
+      count += ms if count < 0 and -count < ms
+      unless count < ms and count >= 0
+        raise IndexError, "index #{count} out of match bounds"
+      end
+
+      unless match[count]
+        raise IndexError, "regexp group #{count} not matched"
+      end
+
+      replacement = StringValue replacement
+      enc = Rubinius::Type.compatible_encoding self, replacement
+
+      bi = m.byte_index match.begin(count)
+      bs = m.byte_index(match.end(count)) - bi
+
+      m.splice bi, bs, replacement, enc
+    else
+      index = Rubinius::Type.coerce_to index, Fixnum, :to_int
+
+      if count
+        return self[index, count] = replacement
+      else
+        return self[index] = replacement
+      end
     end
 
     Rubinius::Type.infect self, replacement
@@ -1544,43 +1544,43 @@ class String
     byte_finish = m.character_to_byte_index finish
 
     case sub
-      when Fixnum
-        if finish == size
-          return nil if finish == 0
-          finish -= 1
-        end
+    when Fixnum
+      if finish == size
+        return nil if finish == 0
+        finish -= 1
+      end
 
-        begin
-          str = sub.chr
-        rescue RangeError
-          return nil
-        end
+      begin
+        str = sub.chr
+      rescue RangeError
+        return nil
+      end
 
-        if byte_index = find_string_reverse(str, byte_finish)
-          return m.byte_to_character_index byte_index
-        end
+      if byte_index = find_string_reverse(str, byte_finish)
+        return m.byte_to_character_index byte_index
+      end
 
-      when Regexp
-        Rubinius::Type.compatible_encoding self, sub
+    when Regexp
+      Rubinius::Type.compatible_encoding self, sub
 
-        match_data = sub.search_region(self, 0, byte_finish, false)
-        Truffle.invoke_primitive(:regexp_set_last_match, match_data)
-        return match_data.begin(0) if match_data
+      match_data = sub.search_region(self, 0, byte_finish, false)
+      Truffle.invoke_primitive(:regexp_set_last_match, match_data)
+      return match_data.begin(0) if match_data
 
-      else
-        needle = StringValue(sub)
-        needle_size = needle.size
+    else
+      needle = StringValue(sub)
+      needle_size = needle.size
 
-        # needle is bigger that haystack
-        return nil if size < needle_size
+      # needle is bigger that haystack
+      return nil if size < needle_size
 
-        # Boundary case
-        return finish if needle_size == 0
+      # Boundary case
+      return finish if needle_size == 0
 
-        Rubinius::Type.compatible_encoding self, needle
-        if byte_index = find_string_reverse(needle, byte_finish)
-          return m.byte_to_character_index byte_index
-        end
+      Rubinius::Type.compatible_encoding self, needle
+      if byte_index = find_string_reverse(needle, byte_finish)
+        return m.byte_to_character_index byte_index
+      end
     end
 
     return nil

--- a/truffleruby/src/main/ruby/core/string.rb
+++ b/truffleruby/src/main/ruby/core/string.rb
@@ -1205,11 +1205,11 @@ class String
       str
     }
 
-    replace_block = if replace
+    if replace
       replace = validate.call(replace)
-      Proc.new { |broken| replace }
+      replace_block = Proc.new { |broken| replace }
     else
-      Proc.new { |broken|
+      replace_block = Proc.new { |broken|
         validate.call(block.call(broken))
       }
     end

--- a/truffleruby/src/main/ruby/core/thread.rb
+++ b/truffleruby/src/main/ruby/core/thread.rb
@@ -95,43 +95,43 @@ class Thread
 
     case objects[id]
 
-      # Default case, we haven't seen +obj+ yet, so we add it and run the block.
-      when nil
-        objects[id] = pair_id
-        begin
-          yield
-        ensure
-          objects.delete id
-        end
+    # Default case, we haven't seen +obj+ yet, so we add it and run the block.
+    when nil
+      objects[id] = pair_id
+      begin
+        yield
+      ensure
+        objects.delete id
+      end
 
-      # We've seen +obj+ before and it's got multiple paired objects associated
-      # with it, so check the pair and yield if there is no recursion.
-      when Hash
-        return true if objects[id][pair_id]
-        objects[id][pair_id] = true
+    # We've seen +obj+ before and it's got multiple paired objects associated
+    # with it, so check the pair and yield if there is no recursion.
+    when Hash
+      return true if objects[id][pair_id]
+      objects[id][pair_id] = true
 
-        begin
-          yield
-        ensure
-          objects[id].delete pair_id
-        end
+      begin
+        yield
+      ensure
+        objects[id].delete pair_id
+      end
 
-      # We've seen +obj+ with one paired object, so check the stored one for
-      # recursion.
-      #
-      # This promotes the value to a Hash since there is another new paired
-      # object.
-      else
-        previous = objects[id]
-        return true if previous == pair_id
+    # We've seen +obj+ with one paired object, so check the stored one for
+    # recursion.
+    #
+    # This promotes the value to a Hash since there is another new paired
+    # object.
+    else
+      previous = objects[id]
+      return true if previous == pair_id
 
-        objects[id] = { previous => true, pair_id => true }
+      objects[id] = { previous => true, pair_id => true }
 
-        begin
-          yield
-        ensure
-          objects[id] = previous
-        end
+      begin
+        yield
+      ensure
+        objects[id] = previous
+      end
     end
 
     false
@@ -413,5 +413,3 @@ class ThreadGroup
 
 end
 Truffle.invoke_primitive :thread_set_group, Thread.current, ThreadGroup::Default
-
-

--- a/truffleruby/src/main/ruby/core/time.rb
+++ b/truffleruby/src/main/ruby/core/time.rb
@@ -354,16 +354,16 @@ class Time
     y = compose_deal_with_year(y)
 
     case offset
-      when :utc
-        is_dst = -1
-        is_utc = true
-        offset = nil
-      when :local
-        is_utc = false
-        offset = nil
-      else
-        is_dst = -1
-        is_utc = false
+    when :utc
+      is_dst = -1
+      is_utc = true
+      offset = nil
+    when :local
+      is_utc = false
+      offset = nil
+    else
+      is_dst = -1
+      is_utc = false
     end
 
     from_array(sec, min, hr, d, m, y, nsec, is_dst, is_utc, offset)
@@ -484,12 +484,12 @@ class Time
     raise TypeError, 'time + time?' if other.kind_of?(Time)
 
     case other = Rubinius::Type.coerce_to_exact_num(other)
-      when Integer
-        other_sec = other
-        other_nsec = 0
-      else
-        other_sec, nsec_frac = other.divmod(1)
-        other_nsec = (nsec_frac * 1_000_000_000).to_i
+    when Integer
+      other_sec = other
+      other_nsec = 0
+    else
+      other_sec, nsec_frac = other.divmod(1)
+      other_nsec = (nsec_frac * 1_000_000_000).to_i
     end
 
     # Don't use self.class, MRI doesn't honor subclasses here
@@ -502,12 +502,12 @@ class Time
     end
 
     case other = Rubinius::Type.coerce_to_exact_num(other)
-      when Integer
-        other_sec = other
-        other_nsec = 0
-      else
-        other_sec, nsec_frac = other.divmod(1)
-        other_nsec = (nsec_frac * 1_000_000_000 + 0.5).to_i
+    when Integer
+      other_sec = other
+      other_nsec = 0
+    else
+      other_sec, nsec_frac = other.divmod(1)
+      other_nsec = (nsec_frac * 1_000_000_000 + 0.5).to_i
     end
 
     # Don't use self.class, MRI doesn't honor subclasses here

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -513,8 +513,8 @@ module Truffle::CExt
   end
 
   def rb_num_coerce_bin(x, y, func)
-     a, b = do_coerce(x, y, true)
-     a.send(func, b)
+    a, b = do_coerce(x, y, true)
+    a.send(func, b)
   end
 
   def rb_num_coerce_cmp(x, y, func)
@@ -545,7 +545,7 @@ module Truffle::CExt
     end
 
     ary = begin
-       y.coerce(x)
+      y.coerce(x)
     rescue
       if raise_error
         raise TypeError, "#{y.class} can't be coerced to #{x.class}"
@@ -802,11 +802,11 @@ module Truffle::CExt
   end
 
   def RB_ENC_CODERANGE(obj)
-     if obj.is_a? String
-       rb_enc_str_coderange(obj)
-     else
-       raise "Unknown coderange for obj with class `#{obj.class}`"
-     end
+    if obj.is_a? String
+      rb_enc_str_coderange(obj)
+    else
+      raise "Unknown coderange for obj with class `#{obj.class}`"
+    end
   end
 
   def rb_enc_associate_index(obj, idx)
@@ -1062,7 +1062,7 @@ module Truffle::CExt
   end
 
   def rb_special_const_p(object)
-     object == nil || object == true || object == false || object.class == Symbol || object.class == Fixnum
+    object == nil || object == true || object == false || object.class == Symbol || object.class == Fixnum
   end
 
   def rb_id2str(sym)
@@ -1138,7 +1138,7 @@ module Truffle::CExt
   end
 
   def rb_enumeratorize(obj, meth, args)
-     obj.to_enum(meth, *args)
+    obj.to_enum(meth, *args)
   end
 
   def rb_eval_string(str)

--- a/truffleruby/src/main/ruby/core/truffle/ffi/ffi.rb
+++ b/truffleruby/src/main/ruby/core/truffle/ffi/ffi.rb
@@ -35,8 +35,9 @@
 ##
 # A Foreign Function Interface used to bind C libraries to ruby.
 
-module Rubinius
-module FFI
+module Rubinius::FFI
+  # Let FFI refer to Rubinius::FFI under Rubinius::FFI
+  FFI = self
 
   #  Specialised error classes
   class TypeError < RuntimeError; end
@@ -62,11 +63,11 @@ module FFI
         raise TypeError, "Unable to resolve type '#{current}'" unless code
       end
 
-      FFI::TypeDefs[add] = code
+      Rubinius::FFI::TypeDefs[add] = code
     end
 
     def find_type(name)
-      code = FFI::TypeDefs[name]
+      code = Rubinius::FFI::TypeDefs[name]
       raise TypeError, "Unable to resolve type '#{name}'" unless code
       return code
     end
@@ -83,7 +84,7 @@ module FFI
         return type_size(find_type(type))
       when Rubinius::NativeFunction
         return type_size(TYPE_PTR)
-      when FFI::Enum
+      when Rubinius::FFI::Enum
         return type_size(TYPE_ENUM)
       end
 
@@ -243,7 +244,7 @@ end
 ##
 # Namespace for holding platform-specific C constants.
 
-module FFI::Platform
+module Rubinius::FFI::Platform
   case
   when Rubinius.windows?
     LIBSUFFIX = "dll"
@@ -267,5 +268,4 @@ module FFI::Platform
   # ruby-ffi compatible
   LONG_SIZE = Rubinius::SIZEOF_LONG * 8
   ADDRESS_SIZE = Rubinius::WORDSIZE
-end
 end

--- a/truffleruby/src/main/ruby/core/truffle/ffi/ffi_file.rb
+++ b/truffleruby/src/main/ruby/core/truffle/ffi/ffi_file.rb
@@ -27,10 +27,8 @@
 ##
 # Platform specific behavior for the File class.
 
-module Rubinius
-module FFI::Platform::File
+module Rubinius::FFI::Platform::File
   SEPARATOR = '/'
   ALT_SEPARATOR = nil
   PATH_SEPARATOR = ':'
-end
 end

--- a/truffleruby/src/main/ruby/core/truffle/ffi/ffi_struct.rb
+++ b/truffleruby/src/main/ruby/core/truffle/ffi/ffi_struct.rb
@@ -24,8 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-module Rubinius
-module FFI
+module Rubinius::FFI
   ##
   # Represents a C struct as ruby class.
 
@@ -341,5 +340,4 @@ module FFI
 
   class Union < Struct
   end
-end
 end

--- a/truffleruby/src/main/ruby/core/truffle/ffi/pointer.rb
+++ b/truffleruby/src/main/ruby/core/truffle/ffi/pointer.rb
@@ -32,8 +32,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-module Rubinius
-module FFI
+module Rubinius::FFI
 
   ##
   # Pointer is Rubinius's "fat" pointer class. It represents an actual
@@ -1244,5 +1243,4 @@ module FFI
       raise PrimitiveFailure, "FFI::MemoryPointer#free primitive failed"
     end
   end
-end
 end

--- a/truffleruby/src/main/ruby/core/type.rb
+++ b/truffleruby/src/main/ruby/core/type.rb
@@ -695,14 +695,15 @@ module Rubinius
 
     def self.check_arity(arg_count, min, max)
       if arg_count < min || (max != -1 && arg_count > max)
-           error_message = if min == max
-                             "wrong number of arguments (given %d, expected %d)" % [arg_count, min]
-                           elsif max == -1
-                             "wrong number of arguments (given %d, expected %d+)" % [arg_count, min]
-                           else
-                             "wrong number of arguments (given %d, expected %d..%d)" %  [arg_count, min, max]
-                           end
-           raise ArgumentError, error_message
+        error_message = case
+        when min == max
+          "wrong number of arguments (given %d, expected %d)" % [arg_count, min]
+        when max == -1
+          "wrong number of arguments (given %d, expected %d+)" % [arg_count, min]
+        else
+          "wrong number of arguments (given %d, expected %d..%d)" % [arg_count, min, max]
+        end
+        raise ArgumentError, error_message
       end
     end
 

--- a/truffleruby/src/main/ruby/core/type.rb
+++ b/truffleruby/src/main/ruby/core/type.rb
@@ -107,11 +107,11 @@ module Rubinius
 
       if sc
         case sc
-          when Class, Module
-            name = "#<Class:#{module_inspect(sc)}>"
-          else
-            cls = object_class sc
-            name = "#<Class:#<#{module_name(cls)}:0x#{sc.object_id.to_s(16)}>>"
+        when Class, Module
+          name = "#<Class:#{module_inspect(sc)}>"
+        else
+          cls = object_class sc
+          name = "#<Class:#<#{module_name(cls)}:0x#{sc.object_id.to_s(16)}>>"
         end
       else
         name = module_name mod
@@ -131,18 +131,18 @@ module Rubinius
 
     def self.coerce_object_to_float(obj)
       case obj
-        when Float
-          obj
-        when nil
-          raise TypeError, "can't convert nil into Float"
-        when Complex
-          if obj.respond_to?(:imag) && obj.imag.equal?(0)
-            coerce_to obj, Float, :to_f
-          else
-            raise RangeError, "can't convert #{obj} into Float"
-          end
-        else
+      when Float
+        obj
+      when nil
+        raise TypeError, "can't convert nil into Float"
+      when Complex
+        if obj.respond_to?(:imag) && obj.imag.equal?(0)
           coerce_to obj, Float, :to_f
+        else
+          raise RangeError, "can't convert #{obj} into Float"
+        end
+      else
+        coerce_to obj, Float, :to_f
       end
     end
 


### PR DESCRIPTION
This adds support to run a few very basic Rubocop style rules ("cops").
I enabled the case/when indentation and general indentation checks.
Of course we can change it over time and enable more checks.
It caught a fair amount of bad indentation as you can see in the diff.

I think this can help to keep the code clean and consistent while not being too restrictive or pedantic.

@graalvm/truffleruby @bjfish @aardvark179 What do you think?