### PR TITLE
Handle macOS spawn missing command case

### DIFF
--- a/truffleruby/src/main/java/org/truffleruby/core/TruffleProcessNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/TruffleProcessNodes.java
@@ -50,13 +50,12 @@ public abstract class TruffleProcessNodes {
             Collection<SpawnAttribute> spawnAttributes = new ArrayList<>();
             parseOptions(options, fileActions, spawnAttributes);
 
-            int pid = call(
-                    StringOperations.getString(command),
-                    toStringArray(arguments),
-                    toStringArray(environmentVariables),
-                    fileActions,
-                    spawnAttributes);
-            return pid;
+            return call(
+                StringOperations.getString(command),
+                toStringArray(arguments),
+                toStringArray(environmentVariables),
+                fileActions,
+                spawnAttributes);
         }
 
         private String[] toStringArray(DynamicObject rubyStrings) {

--- a/truffleruby/src/main/java/org/truffleruby/core/TruffleProcessNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/TruffleProcessNodes.java
@@ -56,12 +56,6 @@ public abstract class TruffleProcessNodes {
                     toStringArray(environmentVariables),
                     fileActions,
                     spawnAttributes);
-
-            if (pid == -1) {
-                // TODO (pitr 07-Sep-2015): needs compatibility improvements
-                throw new RaiseException(coreExceptions().errnoError(getContext().getNativePlatform().getPosix().errno(), this));
-            }
-
             return pid;
         }
 

--- a/truffleruby/src/main/ruby/core/process_mirror.rb
+++ b/truffleruby/src/main/ruby/core/process_mirror.rb
@@ -390,6 +390,10 @@ module Rubinius
           pid = Truffle::Process.spawn command, arguments, env_array, options
           # Check if the command exists *after* invoking posix_spawn so we have a pid
           unless resolve_in_path(command)
+            if pid < 0
+              $? = ::Process::Status.new(pid, 127, nil, nil)
+              Errno.handle
+            end
             # the subprocess will fail, just wait for it
             ::Process.wait(pid) # Sets $? and avoids a zombie process
             unless $?.exitstatus == 127


### PR DESCRIPTION
Fixes system spec on macOS, set the process status after failing to run a missing command

```
`missing_command`
$?
```