### PR TITLE
Use POSIX's -- to prevent the launcher to parse the remaining part of…

### DIFF
--- a/bin/truffleruby
+++ b/bin/truffleruby
@@ -151,6 +151,7 @@ else
         $JAVA_OPTS
         "${java_args[@]}"
         com.oracle.graalvm.Main
+        --
     )
 fi
 


### PR DESCRIPTION
… the command line. This may need a support from GraalVM side to recognize "--" being integrated first. Proposing just to adjust to such changes.