### PR TITLE
Show Ruby exceptions built from Java when -d is passed

### DIFF
--- a/truffleruby/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -288,6 +288,7 @@ public class CoreLibrary {
 
     @CompilationFinal private GlobalVariableStorage loadPathStorage;
     @CompilationFinal private GlobalVariableStorage loadedFeaturesStorage;
+    @CompilationFinal private GlobalVariableStorage debugStorage;
 
     private final String coreLoadPath;
 
@@ -739,7 +740,7 @@ public class CoreLibrary {
 
         globals.put("$0", dollarZeroValue);
 
-        globals.put("$DEBUG", context.getOptions().DEBUG);
+        debugStorage = globals.put("$DEBUG", context.getOptions().DEBUG);
 
         final Object verbose;
 
@@ -1258,6 +1259,10 @@ public class CoreLibrary {
 
     public DynamicObject getLoadedFeatures() {
         return (DynamicObject) loadedFeaturesStorage.getValue();
+    }
+
+    public Object getDebug() {
+        return debugStorage.getValue();
     }
 
     public DynamicObject getMainObject() {

--- a/truffleruby/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -43,6 +43,13 @@ public class CoreExceptions {
         this.debugBacktraceFormatter = new BacktraceFormatter(context, EnumSet.of(FormattingFlags.OMIT_EXCEPTION));
     }
 
+    public void showExceptionIfDebug(DynamicObject exception) {
+        showExceptionIfDebug(
+                Layouts.EXCEPTION.getLogicalClass(exception),
+                Layouts.EXCEPTION.getMessage(exception),
+                Layouts.EXCEPTION.getBacktrace(exception));
+    }
+
     public void showExceptionIfDebug(DynamicObject rubyClass, Object message, Backtrace backtrace) {
         if (context.getCoreLibrary().getDebug() == Boolean.TRUE) {
             final String exceptionClass = Layouts.MODULE.getFields(rubyClass).getName();

--- a/truffleruby/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
@@ -47,12 +47,16 @@ public abstract class ExceptionOperations {
     // because the factory is not constant
     @TruffleBoundary
     public static DynamicObject createRubyException(DynamicObject rubyClass, Object message, Backtrace backtrace) {
+        final RubyContext context = Layouts.MODULE.getFields(rubyClass).getContext();
+        context.getCoreExceptions().showExceptionIfDebug(rubyClass, message, backtrace);
         return Layouts.EXCEPTION.createException(Layouts.CLASS.getInstanceFactory(rubyClass), message, backtrace);
     }
 
     // because the factory is not constant
     @TruffleBoundary
     public static DynamicObject createSystemCallError(DynamicObject rubyClass, Object message, Backtrace backtrace, int errno) {
+        final RubyContext context = Layouts.MODULE.getFields(rubyClass).getContext();
+        context.getCoreExceptions().showExceptionIfDebug(rubyClass, message, backtrace);
         return Layouts.SYSTEM_CALL_ERROR.createSystemCallError(Layouts.CLASS.getInstanceFactory(rubyClass), message, backtrace, errno);
     }
 

--- a/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
@@ -282,8 +282,10 @@ public abstract class ThreadNodes {
 
             });
 
-            if (Layouts.THREAD.getException(thread) != null) {
-                throw new RaiseException(Layouts.THREAD.getException(thread));
+            final DynamicObject exception = Layouts.THREAD.getException(thread);
+            if (exception != null) {
+                currentNode.getContext().getCoreExceptions().showExceptionIfDebug(exception);
+                throw new RaiseException(exception);
             }
         }
 
@@ -301,8 +303,12 @@ public abstract class ThreadNodes {
                 return Layouts.THREAD.getFinishedLatch(thread).await(timeoutInMillis - waited, TimeUnit.MILLISECONDS);
             });
 
-            if (joined && Layouts.THREAD.getException(thread) != null) {
-                throw new RaiseException(Layouts.THREAD.getException(thread));
+            if (joined) {
+                final DynamicObject exception = Layouts.THREAD.getException(thread);
+                if (exception != null) {
+                    getContext().getCoreExceptions().showExceptionIfDebug(exception);
+                    throw new RaiseException(exception);
+                }
             }
 
             return joined;

--- a/truffleruby/src/main/ruby/core/kernel.rb
+++ b/truffleruby/src/main/ruby/core/kernel.rb
@@ -581,13 +581,12 @@ module Kernel
       exc.capture_backtrace!(2) unless exc.backtrace?
     end
 
-    if $DEBUG and $VERBOSE != nil
+    if $DEBUG
       if bt = exc.backtrace and !bt.empty?
         pos = bt.first
       else
         pos = caller.first
       end
-
       STDERR.puts "Exception: `#{exc.class}' #{pos} - #{exc.message}"
     end
 

--- a/truffleruby/src/main/ruby/core/thread.rb
+++ b/truffleruby/src/main/ruby/core/thread.rb
@@ -259,7 +259,7 @@ class Thread
     end
 
     if $DEBUG
-      STDERR.puts "Exception: #{exc.message} (#{exc.class})"
+      STDERR.puts "Exception: `#{exc.class}' - #{exc.message}"
     end
 
     if self == Thread.current


### PR DESCRIPTION
* Done when building the exception in CoreExceptions, as we cannot intercept Java throw and RaiseException's constructor should remain clean and fast.

I found back my patch to make `-d` show exceptions, even when those Ruby exception are thrown in Java with `throw new RaiseException(...)`.
This behaves like MRI:
```
$ jt ruby -d -e 'raise "foo"'
Exception `LoadError' at /home/eregon/code/jruby-dev/lib/mri/rubygems.rb:1241:in `require' - cannot load such file -- rubygems/defaults/operating_system
Exception `LoadError' at /home/eregon/code/jruby-dev/lib/mri/rubygems.rb:1250:in `require' - cannot load such file -- rubygems/defaults/truffleruby
Exception: `RuntimeError' -e:1:in `<main>' - foo
-e:1:in `<main>': foo (RuntimeError)
Exception: `SystemExit' /home/eregon/code/jruby-dev/truffleruby/src/main/ruby/core/process.rb:92:in `exit' - SystemExit

$ ruby -d -e 'raise "foo"'   
Exception `LoadError' at /home/eregon/.rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems.rb:1222 - cannot load such file -- rubygems/defaults/operating_system
Exception `LoadError' at /home/eregon/.rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems.rb:1231 - cannot load such file -- rubygems/defaults/ruby
Exception `RuntimeError' at -e:1 - foo
-e:1:in `<main>': foo (RuntimeError)
```

This adds an extra check while building an exception from Java, but this is all already beyond a `@TruffleBoundary`.