### PR TITLE
Thread unblock actions

### DIFF
--- a/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadLayout.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadLayout.java
@@ -46,8 +46,7 @@ public interface ThreadLayout extends BasicObjectLayout {
             AtomicBoolean wakeUp,
             @Volatile int priority,
             DynamicObject threadGroup,
-            DynamicObject name,
-            @Nullable DynamicObject unblocker);
+            DynamicObject name);
 
     boolean isThread(ObjectType objectType);
     boolean isThread(DynamicObject object);
@@ -89,8 +88,5 @@ public interface ThreadLayout extends BasicObjectLayout {
 
     DynamicObject getName(DynamicObject object);
     void setName(DynamicObject object, DynamicObject value);
-
-    DynamicObject getUnblocker(DynamicObject object);
-    void setUnblocker(DynamicObject object, DynamicObject value);
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -76,8 +76,7 @@ public class ThreadManager {
                 new AtomicBoolean(false),
                 Thread.NORM_PRIORITY,
                 context.getCoreLibrary().getNilObject(),
-                context.getCoreLibrary().getNilObject(),
-                null);
+                context.getCoreLibrary().getNilObject());
 
         Layouts.THREAD.setFiberManagerUnsafe(object, new FiberManager(context, object)); // Because it is cyclic
 
@@ -432,5 +431,10 @@ public class ThreadManager {
         }
 
         thread.interrupt();
+    }
+
+    @TruffleBoundary
+    public UnblockingAction getUnblockingAction(Thread thread) {
+        return unblockingActions.get(thread);
     }
 }

--- a/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -50,6 +50,8 @@ public class ThreadManager {
     private final Set<DynamicObject> runningRubyThreads
             = Collections.newSetFromMap(new ConcurrentHashMap<DynamicObject, Boolean>());
 
+    private final ConcurrentHashMap<Thread, UnblockingAction> unblockingActions = new ConcurrentHashMap<>();
+
     public ThreadManager(RubyContext context) {
         this.context = context;
         this.rootThread = createRubyThread(context);
@@ -206,6 +208,10 @@ public class ThreadManager {
         T block(Timeval timeoutToUse) throws InterruptedException;
     }
 
+    public interface UnblockingAction {
+        void unblock();
+    }
+
     /**
      * Runs {@code action} until it returns a non-null value.
      * The action might be {@link Thread#interrupted()}, for instance by
@@ -216,20 +222,47 @@ public class ThreadManager {
      */
     @TruffleBoundary
     public <T> T runUntilResult(Node currentNode, BlockingAction<T> action) {
+        return runUntilResult(currentNode, action, null);
+    }
+
+    /**
+     * Runs {@code action} until it returns a non-null value.
+     * The blocking action might be {@link Thread#interrupted()}, for instance by
+     * the {@link SafepointManager}, in which case it will be run again.
+     * The unblocking action is registered with the thread manager and will be invoked
+     * if the thread manager interrupts the thread. If the blocking action is making a
+     * native call, simply interrupting the thread will not unblock the action. It is the
+     * responsibility of the unblocking action to break out of the native call so the thread
+     * can be interrupted.
+     *
+     * @param blockingAction must not touch any Ruby state
+     * @param unblockingAction must not touch any Ruby state
+     * @return the first non-null return value from {@code action}
+     */
+    @TruffleBoundary
+    public <T> T runUntilResult(Node currentNode, BlockingAction<T> blockingAction, UnblockingAction unblockingAction) {
         final DynamicObject runningThread = getCurrentThread();
         T result = null;
+
+        if (unblockingAction != null) {
+            unblockingActions.put(Layouts.THREAD.getThread(runningThread), unblockingAction);
+        }
 
         do {
             Layouts.THREAD.setStatus(runningThread, ThreadStatus.SLEEP);
 
             try {
                 try {
-                    result = action.block();
+                    result = blockingAction.block();
                 } finally {
                     Layouts.THREAD.setStatus(runningThread, ThreadStatus.RUN);
                 }
             } catch (InterruptedException e) {
                 // We were interrupted, possibly by the SafepointManager.
+                if (unblockingAction != null) {
+                    unblockingActions.put(Layouts.THREAD.getThread(runningThread), unblockingAction);
+                }
+
                 context.getSafepointManager().pollFromBlockingCall(currentNode);
             }
         } while (result == null);
@@ -389,4 +422,15 @@ public class ThreadManager {
         }
     }
 
+    @TruffleBoundary
+    public void interrupt(Thread thread) {
+        final UnblockingAction action = unblockingActions.get(thread);
+
+        if (action != null) {
+            action.unblock();
+            unblockingActions.remove(thread);
+        }
+
+        thread.interrupt();
+    }
 }

--- a/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
@@ -389,10 +389,10 @@ public abstract class ThreadNodes {
                 throw new RaiseException(coreExceptions().threadErrorKilledThread(this));
             }
 
-            final DynamicObject unblocker = Layouts.THREAD.getUnblocker(thread);
+            final ThreadManager.UnblockingAction unblocker = getContext().getThreadManager().getUnblockingAction(Layouts.THREAD.getThread(thread));
 
             if (unblocker != null) {
-                yieldNode.dispatch(null, unblocker);
+                unblocker.unblock();
             }
 
             Layouts.THREAD.getWakeUp(thread).set(true);
@@ -415,15 +415,9 @@ public abstract class ThreadNodes {
 
         @Specialization(guards = {"isRubyProc(unblocker)", "isRubyProc(runner)"})
         public Object unblock(VirtualFrame frame, DynamicObject thread, DynamicObject unblocker, DynamicObject runner) {
-            Layouts.THREAD.setUnblocker(thread, unblocker);
-            Layouts.THREAD.setStatus(thread, ThreadStatus.SLEEP);
-
-            try {
-                return yield(frame, runner);
-            } finally {
-                Layouts.THREAD.setUnblocker(thread, null);
-                Layouts.THREAD.setStatus(thread, ThreadStatus.RUN);
-            }
+            return getContext().getThreadManager().runUntilResult(this,
+                    () -> yield(frame, runner),
+                    () -> yield(null, unblocker));
         }
 
     }
@@ -474,8 +468,7 @@ public abstract class ThreadNodes {
                     new AtomicBoolean(false),
                     new AtomicInteger(Thread.NORM_PRIORITY),
                     currentGroup,
-                    nil(),
-                    null);
+                    nil());
 
             Layouts.THREAD.setFiberManagerUnsafe(object, new FiberManager(getContext(), object)); // Because it is cyclic
 

--- a/truffleruby/src/main/java/org/truffleruby/language/SafepointManager.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/SafepointManager.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.InterruptMode;
+import org.truffleruby.core.thread.ThreadManager;
 import org.truffleruby.core.thread.ThreadStatus;
 
 import java.util.Collections;
@@ -238,7 +239,7 @@ public class SafepointManager {
         Thread current = Thread.currentThread();
         for (Thread thread : runningThreads) {
             if (thread != current) {
-                thread.interrupt();
+                context.getThreadManager().interrupt(thread);
             }
         }
     }


### PR DESCRIPTION
This is the basic mechanism I came up with for registering unblocking actions. I haven't worked out yet if this would need to occur in other places, or just the interrupt case I've handled here. But I wanted to get your input on the approach in general.

Unfortunately, this will only work if you can naturally unblock the action in some way. MRI seems to rely on the ability to signal the underlying thread. It looks like Rubinius does the same. Given our limitations, we'll have to be more creative.