### PR TITLE
Refactor reading of caller frames.

### DIFF
--- a/spec/tags/core/kernel/block_given_tags.txt
+++ b/spec/tags/core/kernel/block_given_tags.txt
@@ -1,3 +1,3 @@
 fails:Kernel#block_given? returns false when a method defined by define_method is called with a block
 fails:Kernel.block_given? returns false when a method defined by define_method is called with a block
-fails:self.send(:block_given?) returns true if and only if a block is supplied
+fails:self.send(:block_given?) returns false when a method defined by define_method is called with a block

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -105,3 +105,6 @@ OPTIONS_LOG: [options.log, boolean, false, Log the final value of all options]
 
 LOG_LOAD: [log.load, boolean, false, Log loading files]
 LOG_FEATURE_LOCATION: [log.feature_location, boolean, false, Log the process of finding features]
+
+SET_LAST_MATCH_LIMIT: [set.last.match.limit, integer, 20, Maximum number of specialisations for set last match nodes]
+SET_BLOCK_LAST_MATCH_LIMIT: [set.block.last.match.limit, integer, 20, Maximum number of specialisations for set block last match nodes]

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -106,5 +106,5 @@ OPTIONS_LOG: [options.log, boolean, false, Log the final value of all options]
 LOG_LOAD: [log.load, boolean, false, Log loading files]
 LOG_FEATURE_LOCATION: [log.feature_location, boolean, false, Log the process of finding features]
 
-SET_LAST_MATCH_LIMIT: [set.last.match.limit, integer, 20, Maximum number of specialisations for set last match nodes]
-SET_BLOCK_LAST_MATCH_LIMIT: [set.block.last.match.limit, integer, 20, Maximum number of specialisations for set block last match nodes]
+SET_LAST_MATCH_LIMIT: [set.last.match.limit, integer, 5, Maximum number of specialisations for set last match nodes]
+SET_BLOCK_LAST_MATCH_LIMIT: [set.block.last.match.limit, integer, 5, Maximum number of specialisations for set block last match nodes]

--- a/truffleruby/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/truffleruby/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -222,10 +222,6 @@ public class CoreMethodNodeManager {
     public static RubyNode createCoreMethodNode(RubyContext context, Source source, SourceIndexLength sourceSection, NodeFactory<? extends RubyNode> nodeFactory, CoreMethod method) {
         final List<RubyNode> argumentsNodes = new ArrayList<>();
 
-        if (method.needsCallerFrame() != CallerFrameAccess.NONE) {
-            argumentsNodes.add(new ReadCallerFrameNode(method.needsCallerFrame()));
-        }
-
         final boolean needsSelf = needsSelf(method);
 
         if (needsSelf) {

--- a/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -97,6 +97,7 @@ import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.Visibility;
+import org.truffleruby.language.arguments.ReadCallerFrameNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.backtrace.Activation;
 import org.truffleruby.language.backtrace.Backtrace;
@@ -258,10 +259,13 @@ public abstract class KernelNodes {
     @CoreMethod(names = "block_given?", isModuleFunction = true, needsCallerFrame = CallerFrameAccess.ARGUMENTS)
     public abstract static class BlockGivenNode extends CoreMethodArrayArgumentsNode {
 
+        @Child ReadCallerFrameNode callerFrameNode = new ReadCallerFrameNode(CallerFrameAccess.ARGUMENTS);
+
         @Specialization
-        public boolean blockGiven(Object callerFrame,
+        public boolean blockGiven(VirtualFrame frame,
                 @Cached("createBinaryProfile()") ConditionProfile blockProfile) {
-            return blockProfile.profile(RubyArguments.getBlock((Frame) callerFrame) != null);
+            Frame callerFrame = callerFrameNode.execute(frame);
+            return blockProfile.profile(RubyArguments.getBlock(callerFrame) != null);
         }
 
     }

--- a/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -58,6 +58,7 @@ import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.core.cast.ToStrNode;
 import org.truffleruby.core.cast.ToStrNodeGen;
 import org.truffleruby.core.regexp.RegexpNodesFactory.RegexpSetLastMatchPrimitiveNodeFactory;
+import org.truffleruby.core.regexp.RegexpNodesFactory.RegexpSetLastMatchPrimitiveNode2Factory;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeBuilder;
@@ -521,6 +522,28 @@ public abstract class RegexpNodes {
         @Specialization(guards = "isSuitableMatchDataType(getContext(), matchData)")
         public DynamicObject setLastMatchData(DynamicObject matchData) {
             Frame frame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameInstance.FrameAccess.READ_WRITE);
+            ThreadLocalObject lastMatch = getMatchDataThreadLocalSearchingDeclarations(
+                    getContext(), frame, true);
+            lastMatch.set(matchData);
+            return matchData;
+        }
+
+    }
+
+    @Primitive(name = "regexp_set_last_match2", needsSelf = false)
+    @ImportStatic(RegexpNodes.class)
+    public static abstract class RegexpSetLastMatchPrimitiveNode2 extends PrimitiveArrayArgumentsNode {
+
+        public static RegexpSetLastMatchPrimitiveNode2 create() {
+            return RegexpSetLastMatchPrimitiveNode2Factory.create(null);
+        }
+
+        public abstract DynamicObject executeSetLastMatch(Object callerFrame, Object matchData);
+
+        @TruffleBoundary
+        @Specialization(guards = "isSuitableMatchDataType(getContext(), matchData)")
+        public DynamicObject setLastMatchData(Object callerFrame, DynamicObject matchData) {
+            Frame frame = (Frame) callerFrame;
             ThreadLocalObject lastMatch = getMatchDataThreadLocalSearchingDeclarations(
                     getContext(), frame, true);
             lastMatch.set(matchData);

--- a/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -528,7 +528,7 @@ public abstract class RegexpNodes {
         }
 
         public boolean matches(Frame callerFrame) {
-            return callerFrame.getFrameDescriptor() == fd;
+            return callerFrame != null && callerFrame.getFrameDescriptor() == fd;
         }
 
         public boolean matchesBlock(DynamicObject block) {
@@ -542,7 +542,7 @@ public abstract class RegexpNodes {
         }
 
         public static SetLastMatchStrategy ofBlock(RubyContext context, DynamicObject block) {
-            Frame frame = (Frame) Layouts.PROC.getDeclarationFrame(block);
+            Frame frame = Layouts.PROC.getDeclarationFrame(block);
             if (frame == null) {
                 return NullStrategy.INSTANCE;
             }
@@ -572,12 +572,19 @@ public abstract class RegexpNodes {
             super(null, null, null);
         }
 
+        @Override
         public ThreadLocalObject getThreadLocal(RubyContext context, MaterializedFrame callerFrame) {
             return null;
         }
 
+        @Override
         public ThreadLocalObject getThreadLocalBlock(RubyContext context, DynamicObject block) {
             return null;
+        }
+
+        @Override
+        public boolean matches(Frame callerFrame) {
+            return callerFrame == null;
         }
     }
 
@@ -586,6 +593,7 @@ public abstract class RegexpNodes {
             super(fd, fs, defaultValue);
         }
 
+        @Override
         public ThreadLocalObject getThreadLocal(RubyContext context, MaterializedFrame callerFrame) {
             return getThreadLocalObjectFromFrame(context, callerFrame, fs, defaultValue, true);
         }
@@ -598,6 +606,7 @@ public abstract class RegexpNodes {
             this.depth = depth;
         }
 
+        @Override
         public ThreadLocalObject getThreadLocal(RubyContext context, MaterializedFrame callerFrame) {
             final MaterializedFrame frame = RubyArguments.getDeclarationFrame(callerFrame, depth);
             return getThreadLocalObjectFromFrame(context, frame, fs, defaultValue, true);

--- a/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -626,7 +626,8 @@ public abstract class RegexpNodes {
         public abstract DynamicObject executeSetLastMatch(VirtualFrame frame, Object matchData);
 
         @Specialization(guards = { "isSuitableMatchDataType(getContext(), matchData)",
-                "strategy.matches(readCallerFrame.execute(frame))" }, limit = "20")
+                                   "strategy.matches(readCallerFrame.execute(frame))" },
+                        limit = "getContext().getOptions().SET_LAST_MATCH_LIMIT" )
         public DynamicObject setLastMatchDataForFrame(VirtualFrame frame, DynamicObject matchData,
                 @Cached("of(getContext(), readCallerFrame.execute(frame))") SetLastMatchStrategy strategy) {
             MaterializedFrame callerFrame = readCallerFrame.execute(frame).materialize();
@@ -655,7 +656,8 @@ public abstract class RegexpNodes {
 
         @Specialization(guards = { "isRubyProc(block)",
                                    "isSuitableMatchDataType(getContext(), matchData)",
-                                   "strategy.matchesBlock(block)" }, limit = "20" )
+                                   "strategy.matchesBlock(block)" },
+                        limit = "getContext().getOptions().SET_BLOCK_LAST_MATCH_LIMIT" )
         public DynamicObject setBlockLastMatchDataForFrame(DynamicObject block, DynamicObject matchData,
                 @Cached("ofBlock(getContext(), block)") SetLastMatchStrategy strategy) {
             ThreadLocalObject lastMatch = strategy.getThreadLocalBlock(getContext(), block);

--- a/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -383,7 +383,7 @@ public abstract class RegexpNodes {
         return !context.getCoreLibrary().isSend(method);
     }
 
-    @CoreMethod(names = "=~", required = 1, needsCallerFrame = CallerFrameAccess.READ_WRITE)
+    @CoreMethod(names = "=~", required = 1)
     public abstract static class MatchOperatorNode extends CoreMethodArrayArgumentsNode {
 
         @Child private CallDispatchHeadNode dupNode = DispatchHeadNodeFactory.createMethodCall();

--- a/truffleruby/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -156,6 +156,7 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
@@ -496,15 +497,16 @@ public abstract class StringNodes {
                 @Cached("createMethodCallIgnoreVisibility()") CallDispatchHeadNode callNode,
                 @Cached("create()") RegexpSetLastMatchPrimitiveNode2 setLastMatchNode) {
             final Object matchStrPair = callNode.call(frame, string, "subpattern", regexp, capture);
+            MaterializedFrame mFrame = ((Frame)callerFrame).materialize();
 
             if (matchStrPair == nil()) {
-                setLastMatchNode.executeSetLastMatch(callerFrame, nil());
+                setLastMatchNode.executeSetLastMatch(mFrame, nil());
                 return nil();
             }
 
             final Object[] array = (Object[]) Layouts.ARRAY.getStore((DynamicObject) matchStrPair);
 
-            setLastMatchNode.executeSetLastMatch(callerFrame, array[0]);
+            setLastMatchNode.executeSetLastMatch(mFrame, array[0]);
 
             return array[1];
         }

--- a/truffleruby/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -62,22 +62,21 @@
  */
 package org.truffleruby.core.string;
 
-import com.oracle.truffle.api.CallTarget;
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CreateCast;
-import com.oracle.truffle.api.dsl.Fallback;
-import com.oracle.truffle.api.dsl.ImportStatic;
-import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeChildren;
-import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.nodes.IndirectCallNode;
-import com.oracle.truffle.api.object.DynamicObject;
-import com.oracle.truffle.api.profiles.BranchProfile;
-import com.oracle.truffle.api.profiles.ConditionProfile;
+import static org.truffleruby.core.rope.RopeConstants.EMPTY_ASCII_8BIT_ROPE;
+import static org.truffleruby.core.rope.RopeNodes.MakeConcatNode.commonCodeRange;
+import static org.truffleruby.core.string.StringOperations.encoding;
+import static org.truffleruby.core.string.StringOperations.rope;
+import static org.truffleruby.core.string.StringSupport.MBCLEN_CHARFOUND_LEN;
+import static org.truffleruby.core.string.StringSupport.MBCLEN_CHARFOUND_P;
+import static org.truffleruby.core.string.StringSupport.MBCLEN_INVALID_P;
+import static org.truffleruby.core.string.StringSupport.MBCLEN_NEEDMORE_P;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.jcodings.Encoding;
 import org.jcodings.exception.EncodingException;
 import org.jcodings.specific.ASCIIEncoding;
@@ -85,6 +84,7 @@ import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
+import org.truffleruby.builtins.CallerFrameAccess;
 import org.truffleruby.builtins.CoreClass;
 import org.truffleruby.builtins.CoreMethod;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
@@ -113,7 +113,7 @@ import org.truffleruby.core.kernel.KernelNodes;
 import org.truffleruby.core.kernel.KernelNodesFactory;
 import org.truffleruby.core.numeric.FixnumLowerNodeGen;
 import org.truffleruby.core.numeric.FixnumOrBignumNode;
-import org.truffleruby.core.regexp.RegexpNodes.RegexpSetLastMatchPrimitiveNode;
+import org.truffleruby.core.regexp.RegexpNodes.RegexpSetLastMatchPrimitiveNode2;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.ConcatRope;
 import org.truffleruby.core.rope.LeafRope;
@@ -145,20 +145,23 @@ import org.truffleruby.language.objects.TaintNode;
 import org.truffleruby.language.yield.YieldNode;
 import org.truffleruby.platform.posix.TrufflePosix;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.truffleruby.core.rope.RopeConstants.EMPTY_ASCII_8BIT_ROPE;
-import static org.truffleruby.core.rope.RopeNodes.MakeConcatNode.commonCodeRange;
-import static org.truffleruby.core.string.StringOperations.encoding;
-import static org.truffleruby.core.string.StringOperations.rope;
-import static org.truffleruby.core.string.StringSupport.MBCLEN_CHARFOUND_LEN;
-import static org.truffleruby.core.string.StringSupport.MBCLEN_CHARFOUND_P;
-import static org.truffleruby.core.string.StringSupport.MBCLEN_INVALID_P;
-import static org.truffleruby.core.string.StringSupport.MBCLEN_NEEDMORE_P;
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.CreateCast;
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.ImportStatic;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.IndirectCallNode;
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import com.oracle.truffle.api.profiles.ConditionProfile;
 
 @CoreClass("String")
 public abstract class StringNodes {
@@ -369,7 +372,7 @@ public abstract class StringNodes {
 
     }
 
-    @CoreMethod(names = { "[]", "slice" }, required = 1, optional = 1, lowerFixnum = { 1, 2 }, taintFrom = 0)
+    @CoreMethod(names = { "[]", "slice" }, required = 1, optional = 1, lowerFixnum = { 1, 2 }, taintFrom = 0, needsCallerFrame = CallerFrameAccess.READ_WRITE)
     public abstract static class GetIndexNode extends CoreMethodArrayArgumentsNode {
 
         @Child private AllocateObjectNode allocateObjectNode = AllocateObjectNode.create();
@@ -381,7 +384,7 @@ public abstract class StringNodes {
         private final BranchProfile outOfBounds = BranchProfile.create();
 
         @Specialization
-        public Object getIndex(VirtualFrame frame, DynamicObject string, int index, NotProvided length) {
+        public Object getIndex(VirtualFrame frame, Object callerFrame, DynamicObject string, int index, NotProvided length) {
             // Check for the only difference from str[index, 1]
             if (index == rope(string).characterLength()) {
                 outOfBounds.enter();
@@ -391,23 +394,23 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = { "!isRubyRange(index)", "!isRubyRegexp(index)", "!isRubyString(index)" })
-        public Object getIndex(VirtualFrame frame, DynamicObject string, Object index, NotProvided length, @Cached("new()") SnippetNode snippetNode) {
-            return getIndex(frame, string, (int)snippetNode.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", index), length);
+        public Object getIndex(VirtualFrame frame, Object callerFrame, DynamicObject string, Object index, NotProvided length, @Cached("new()") SnippetNode snippetNode) {
+            return getIndex(frame, callerFrame, string, (int)snippetNode.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", index), length);
         }
 
         @Specialization(guards = "isIntRange(range)")
-        public Object sliceIntegerRange(VirtualFrame frame, DynamicObject string, DynamicObject range, NotProvided length) {
+        public Object sliceIntegerRange(VirtualFrame frame, Object callerFrame, DynamicObject string, DynamicObject range, NotProvided length) {
             return sliceRange(frame, string, Layouts.INT_RANGE.getBegin(range), Layouts.INT_RANGE.getEnd(range), Layouts.INT_RANGE.getExcludedEnd(range));
         }
 
         @Specialization(guards = "isLongRange(range)")
-        public Object sliceLongRange(VirtualFrame frame, DynamicObject string, DynamicObject range, NotProvided length) {
+        public Object sliceLongRange(VirtualFrame frame, Object callerFrame, DynamicObject string, DynamicObject range, NotProvided length) {
             // TODO (nirvdrum 31-Mar-15) The begin and end values should be properly lowered, only if possible.
             return sliceRange(frame, string, (int) Layouts.LONG_RANGE.getBegin(range), (int) Layouts.LONG_RANGE.getEnd(range), Layouts.LONG_RANGE.getExcludedEnd(range));
         }
 
         @Specialization(guards = "isObjectRange(range)")
-        public Object sliceObjectRange(VirtualFrame frame, DynamicObject string, DynamicObject range, NotProvided length,
+        public Object sliceObjectRange(VirtualFrame frame, Object callerFrame, DynamicObject string, DynamicObject range, NotProvided length,
                 @Cached("new()") SnippetNode snippetNode1,
                 @Cached("new()") SnippetNode snippetNode2) {
             // TODO (nirvdrum 31-Mar-15) The begin and end values may return Fixnums beyond int boundaries and we should handle that -- Bignums are always errors.
@@ -457,55 +460,57 @@ public abstract class StringNodes {
         }
 
         @Specialization
-        public Object slice(VirtualFrame frame, DynamicObject string, int start, int length) {
+        public Object slice(VirtualFrame frame, Object callerFrame, DynamicObject string, int start, int length) {
             return getSubstringNode().execute(frame, string, start, length);
         }
 
         @Specialization(guards = "wasProvided(length)")
-        public Object slice(VirtualFrame frame, DynamicObject string, int start, Object length, @Cached("new()") SnippetNode snippetNode) {
-            return slice(frame, string, start, (int)snippetNode.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", length));
+        public Object slice(VirtualFrame frame, Object callerFrame, DynamicObject string, int start, Object length, @Cached("new()") SnippetNode snippetNode) {
+            return slice(frame, callerFrame, string, start, (int)snippetNode.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", length));
         }
 
         @Specialization(guards = { "!isRubyRange(start)", "!isRubyRegexp(start)", "!isRubyString(start)", "wasProvided(length)" })
-        public Object slice(VirtualFrame frame, DynamicObject string, Object start, Object length, @Cached("new()") SnippetNode snippetNode1, @Cached("new()") SnippetNode snippetNode2) {
-            return slice(frame, string, (int)snippetNode1.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", start), (int)snippetNode2.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", length));
+        public Object slice(VirtualFrame frame, Object callerFrame, DynamicObject string, Object start, Object length, @Cached("new()") SnippetNode snippetNode1, @Cached("new()") SnippetNode snippetNode2) {
+            return slice(frame, callerFrame, string, (int)snippetNode1.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", start), (int)snippetNode2.execute(frame, "Rubinius::Type.rb_num2int(v)", "v", length));
         }
 
         @Specialization(guards = "isRubyRegexp(regexp)")
         public Object slice1(
                 VirtualFrame frame,
+                Object callerFrame,
                 DynamicObject string,
                 DynamicObject regexp,
                 NotProvided capture,
                 @Cached("createMethodCallIgnoreVisibility()") CallDispatchHeadNode callNode,
-                @Cached("create()") RegexpSetLastMatchPrimitiveNode setLastMatchNode) {
-            return sliceCapture(frame, string, regexp, 0, callNode, setLastMatchNode);
+                @Cached("create()") RegexpSetLastMatchPrimitiveNode2 setLastMatchNode) {
+            return sliceCapture(frame, callerFrame, string, regexp, 0, callNode, setLastMatchNode);
         }
 
         @Specialization(guards = {"isRubyRegexp(regexp)", "wasProvided(capture)"})
         public Object sliceCapture(
                 VirtualFrame frame,
+                Object callerFrame,
                 DynamicObject string,
                 DynamicObject regexp,
                 Object capture,
                 @Cached("createMethodCallIgnoreVisibility()") CallDispatchHeadNode callNode,
-                @Cached("create()") RegexpSetLastMatchPrimitiveNode setLastMatchNode) {
+                @Cached("create()") RegexpSetLastMatchPrimitiveNode2 setLastMatchNode) {
             final Object matchStrPair = callNode.call(frame, string, "subpattern", regexp, capture);
 
             if (matchStrPair == nil()) {
-                setLastMatchNode.executeSetLastMatch(nil());
+                setLastMatchNode.executeSetLastMatch(callerFrame, nil());
                 return nil();
             }
 
             final Object[] array = (Object[]) Layouts.ARRAY.getStore((DynamicObject) matchStrPair);
 
-            setLastMatchNode.executeSetLastMatch(array[0]);
+            setLastMatchNode.executeSetLastMatch(callerFrame, array[0]);
 
             return array[1];
         }
 
         @Specialization(guards = "isRubyString(matchStr)")
-        public Object slice2(VirtualFrame frame, DynamicObject string, DynamicObject matchStr, NotProvided length) {
+        public Object slice2(VirtualFrame frame, Object callerFrame, DynamicObject string, DynamicObject matchStr, NotProvided length) {
             if (includeNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 includeNode = insert(DispatchHeadNodeFactory.createMethodCall());

--- a/truffleruby/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -374,7 +374,7 @@ public abstract class StringNodes {
 
     }
 
-    @CoreMethod(names = { "[]", "slice" }, required = 1, optional = 1, lowerFixnum = { 1, 2 }, taintFrom = 0, needsCallerFrame = CallerFrameAccess.READ_WRITE)
+    @CoreMethod(names = { "[]", "slice" }, required = 1, optional = 1, lowerFixnum = { 1, 2 }, taintFrom = 0)
     public abstract static class GetIndexNode extends CoreMethodArrayArgumentsNode {
 
         @Child private AllocateObjectNode allocateObjectNode = AllocateObjectNode.create();

--- a/truffleruby/src/main/java/org/truffleruby/language/CallStackManager.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/CallStackManager.java
@@ -88,6 +88,16 @@ public class CallStackManager {
     }
 
     @TruffleBoundary
+    public boolean callerIsSend() {
+        FrameInstance callerFrame = Truffle.getRuntime().getCallerFrame();
+        if (callerFrame == null) {
+            return false;
+        }
+        InternalMethod method = getMethod(callerFrame);
+        return context.getCoreLibrary().isSend(method);
+    }
+
+    @TruffleBoundary
     public FrameInstance getCallerFrameIgnoringSend(int skip) {
         // Try first using getCallerFrame() as it's the common case
         if (skip == 0) {

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
@@ -13,6 +13,7 @@ import org.truffleruby.builtins.CallerFrameAccess;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.dispatch.CachedDispatchNode;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.Frame;
@@ -45,6 +46,7 @@ public class ReadCallerFrameNode extends RubyNode {
     }
 
     private void replaceDispatchNode() {
+        CompilerAsserts.neverPartOfCompilation("Dispatch nodes should never be replaced after compilation.");
         if (!getContext().getCallStack().callerIsSend()) {
             Node callerNode = getContext().getCallStack().getCallerNode();
             if (callerNode instanceof DirectCallNode) {

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
@@ -45,11 +45,13 @@ public class ReadCallerFrameNode extends RubyNode {
     }
 
     private void replaceDispatchNode() {
-        Node callerNode = getContext().getCallStack().getCallerNode();
-        if (callerNode instanceof DirectCallNode) {
-            Node parent = callerNode.getParent();
-            if (parent instanceof CachedDispatchNode) {
-                ((CachedDispatchNode) parent).replaceSendingChild();
+        if (!getContext().getCallStack().callerIsSend()) {
+            Node callerNode = getContext().getCallStack().getCallerNode();
+            if (callerNode instanceof DirectCallNode) {
+                Node parent = callerNode.getParent();
+                if (parent instanceof CachedDispatchNode) {
+                    ((CachedDispatchNode) parent).replaceSendingChild();
+                }
             }
         }
     }

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
@@ -31,7 +31,7 @@ public class ReadCallerFrameNode extends RubyNode {
     }
 
     @Override
-    public Object execute(VirtualFrame frame) {
+    public Frame execute(VirtualFrame frame) {
         final MaterializedFrame callerFrame = RubyArguments.getCallerFrame(frame);
 
         if (callerFrameProfile.profile(callerFrame != null)) {
@@ -43,7 +43,7 @@ public class ReadCallerFrameNode extends RubyNode {
 
     @TruffleBoundary
     private Frame getCallerFrame() {
-        return Truffle.getRuntime().getCallerFrame().getFrame(accessMode);
+        return getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(accessMode);
     }
 
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBooleanDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBooleanDispatchNode.java
@@ -100,7 +100,7 @@ public class CachedBooleanDispatchNode extends CachedDispatchNode {
 
             switch (getDispatchAction()) {
                 case CALL_METHOD:
-                    return call(trueCallDirect, frame, trueMethod, receiverObject, blockObject, argumentsObjects);
+                    return call(trueCallDirect, frame, trueMethod, receiverObject, blockObject, argumentsObjects, needsCallerFrame);
                 case RESPOND_TO_METHOD:
                     return true;
 
@@ -112,7 +112,7 @@ public class CachedBooleanDispatchNode extends CachedDispatchNode {
 
             switch (getDispatchAction()) {
                 case CALL_METHOD:
-                    return call(falseCallDirect, frame, falseMethod, receiverObject, blockObject, argumentsObjects);
+                    return call(falseCallDirect, frame, falseMethod, receiverObject, blockObject, argumentsObjects, needsCallerFrame);
 
                 case RESPOND_TO_METHOD:
                     return true;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
@@ -87,7 +87,7 @@ public class CachedBoxedDispatchNode extends CachedDispatchNode {
 
         switch (getDispatchAction()) {
             case CALL_METHOD:
-                return call(callNode, frame, method, receiverObject, blockObject, argumentsObjects);
+                return call(callNode, frame, method, receiverObject, blockObject, argumentsObjects, needsCallerFrame);
 
             case RESPOND_TO_METHOD:
                 return true;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedSymbolDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedSymbolDispatchNode.java
@@ -77,7 +77,7 @@ public class CachedBoxedSymbolDispatchNode extends CachedDispatchNode {
 
         switch (getDispatchAction()) {
             case CALL_METHOD:
-                return call(callNode, frame, method, receiverObject, blockObject, argumentsObjects);
+                return call(callNode, frame, method, receiverObject, blockObject, argumentsObjects, needsCallerFrame);
 
             case RESPOND_TO_METHOD:
                 return true;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -11,6 +11,7 @@ package org.truffleruby.language.dispatch;
 
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -33,7 +34,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
     @Child protected DispatchNode next;
 
     private final BranchProfile moreThanReferenceCompare = BranchProfile.create();
-    protected boolean needsCallerFrame = false;
+    @CompilationFinal protected boolean needsCallerFrame = false;
 
     public CachedDispatchNode(
             RubyContext context,
@@ -59,10 +60,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
     }
 
     public void replaceSendingChild() {
-        assert (!needsCallerFrame);
-        CachedDispatchNode newNode = (CachedDispatchNode) this.deepCopy();
-        newNode.needsCallerFrame = true;
-        replace(newNode);
+        needsCallerFrame = true;
     }
 
     @Override

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -11,6 +11,7 @@ package org.truffleruby.language.dispatch;
 
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -60,7 +61,10 @@ public abstract class CachedDispatchNode extends DispatchNode {
     }
 
     public void replaceSendingChild() {
-        needsCallerFrame = true;
+        if (!needsCallerFrame) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            needsCallerFrame = true;
+        }
     }
 
     @Override

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -61,8 +61,8 @@ public abstract class CachedDispatchNode extends DispatchNode {
     }
 
     public void replaceSendingChild() {
+        CompilerAsserts.neverPartOfCompilation("Dispatch nodes should not be altered after compilation.");
         if (!needsCallerFrame) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
             needsCallerFrame = true;
         }
     }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
@@ -108,7 +108,7 @@ public class CachedMethodMissingDispatchNode extends CachedDispatchNode {
                 // When calling #method_missing we need to prepend the symbol
                 final Object[] modifiedArgumentsObjects = ArrayUtils.unshift(argumentsObjects, getCachedNameAsSymbol());
 
-                return call(callNode, frame, methodMissing, receiverObject, blockObject, modifiedArgumentsObjects);
+                return call(callNode, frame, methodMissing, receiverObject, blockObject, modifiedArgumentsObjects, needsCallerFrame);
 
             case RESPOND_TO_METHOD:
                 return false;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedSingletonDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedSingletonDispatchNode.java
@@ -86,7 +86,7 @@ public class CachedSingletonDispatchNode extends CachedDispatchNode {
 
         switch (getDispatchAction()) {
             case CALL_METHOD:
-                return call(callNode, frame, method, expectedReceiver, blockObject, argumentsObjects);
+                return call(callNode, frame, method, expectedReceiver, blockObject, argumentsObjects, needsCallerFrame);
 
             case RESPOND_TO_METHOD:
                 return true;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedUnboxedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedUnboxedDispatchNode.java
@@ -82,7 +82,7 @@ public class CachedUnboxedDispatchNode extends CachedDispatchNode {
 
         switch (getDispatchAction()) {
             case CALL_METHOD:
-                return call(callNode, frame, method, receiverObject, blockObject, argumentsObjects);
+                return call(callNode, frame, method, receiverObject, blockObject, argumentsObjects, needsCallerFrame);
 
             case RESPOND_TO_METHOD:
                 return true;

--- a/truffleruby/src/main/java/org/truffleruby/options/Options.java
+++ b/truffleruby/src/main/java/org/truffleruby/options/Options.java
@@ -104,6 +104,8 @@ public class Options {
     public final boolean OPTIONS_LOG;
     public final boolean LOG_LOAD;
     public final boolean LOG_FEATURE_LOCATION;
+    public final int SET_LAST_MATCH_LIMIT;
+    public final int SET_BLOCK_LAST_MATCH_LIMIT;
     
     Options(OptionsBuilder builder) {
         HOME = builder.getOrDefault(OptionsCatalog.HOME);
@@ -192,6 +194,8 @@ public class Options {
         OPTIONS_LOG = builder.getOrDefault(OptionsCatalog.OPTIONS_LOG);
         LOG_LOAD = builder.getOrDefault(OptionsCatalog.LOG_LOAD);
         LOG_FEATURE_LOCATION = builder.getOrDefault(OptionsCatalog.LOG_FEATURE_LOCATION);
+        SET_LAST_MATCH_LIMIT = builder.getOrDefault(OptionsCatalog.SET_LAST_MATCH_LIMIT);
+        SET_BLOCK_LAST_MATCH_LIMIT = builder.getOrDefault(OptionsCatalog.SET_BLOCK_LAST_MATCH_LIMIT);
     }
 
     public Object fromDescription(OptionDescription<?> description) {
@@ -368,6 +372,10 @@ public class Options {
                 return LOG_LOAD;
             case "log.feature_location":
                 return LOG_FEATURE_LOCATION;
+            case "set.last.match.limit":
+                return SET_LAST_MATCH_LIMIT;
+            case "set.block.last.match.limit":
+                return SET_BLOCK_LAST_MATCH_LIMIT;
             default:
                 return null;
         }

--- a/truffleruby/src/main/java/org/truffleruby/options/OptionsCatalog.java
+++ b/truffleruby/src/main/java/org/truffleruby/options/OptionsCatalog.java
@@ -102,6 +102,8 @@ public class OptionsCatalog {
     public static final BooleanOptionDescription OPTIONS_LOG = new BooleanOptionDescription("options.log", "Log the final value of all options", false);
     public static final BooleanOptionDescription LOG_LOAD = new BooleanOptionDescription("log.load", "Log loading files", false);
     public static final BooleanOptionDescription LOG_FEATURE_LOCATION = new BooleanOptionDescription("log.feature_location", "Log the process of finding features", false);
+    public static final IntegerOptionDescription SET_LAST_MATCH_LIMIT = new IntegerOptionDescription("set.last.match.limit", "Maximum number of specialisations for set last match nodes", 20);
+    public static final IntegerOptionDescription SET_BLOCK_LAST_MATCH_LIMIT = new IntegerOptionDescription("set.block.last.match.limit", "Maximum number of specialisations for set block last match nodes", 20);
     
     public static OptionDescription<?> fromName(String name) {
         switch (name) {
@@ -277,6 +279,10 @@ public class OptionsCatalog {
                 return LOG_LOAD;
             case "log.feature_location":
                 return LOG_FEATURE_LOCATION;
+            case "set.last.match.limit":
+                return SET_LAST_MATCH_LIMIT;
+            case "set.block.last.match.limit":
+                return SET_BLOCK_LAST_MATCH_LIMIT;
             default:
                 return null;
         }
@@ -370,6 +376,8 @@ public class OptionsCatalog {
             OPTIONS_LOG,
             LOG_LOAD,
             LOG_FEATURE_LOCATION,
+            SET_LAST_MATCH_LIMIT,
+            SET_BLOCK_LAST_MATCH_LIMIT,
         };
     }
 

--- a/truffleruby/src/main/java/org/truffleruby/options/OptionsCatalog.java
+++ b/truffleruby/src/main/java/org/truffleruby/options/OptionsCatalog.java
@@ -102,8 +102,8 @@ public class OptionsCatalog {
     public static final BooleanOptionDescription OPTIONS_LOG = new BooleanOptionDescription("options.log", "Log the final value of all options", false);
     public static final BooleanOptionDescription LOG_LOAD = new BooleanOptionDescription("log.load", "Log loading files", false);
     public static final BooleanOptionDescription LOG_FEATURE_LOCATION = new BooleanOptionDescription("log.feature_location", "Log the process of finding features", false);
-    public static final IntegerOptionDescription SET_LAST_MATCH_LIMIT = new IntegerOptionDescription("set.last.match.limit", "Maximum number of specialisations for set last match nodes", 20);
-    public static final IntegerOptionDescription SET_BLOCK_LAST_MATCH_LIMIT = new IntegerOptionDescription("set.block.last.match.limit", "Maximum number of specialisations for set block last match nodes", 20);
+    public static final IntegerOptionDescription SET_LAST_MATCH_LIMIT = new IntegerOptionDescription("set.last.match.limit", "Maximum number of specialisations for set last match nodes", 5);
+    public static final IntegerOptionDescription SET_BLOCK_LAST_MATCH_LIMIT = new IntegerOptionDescription("set.block.last.match.limit", "Maximum number of specialisations for set block last match nodes", 5);
     
     public static OptionDescription<?> fromName(String name) {
         switch (name) {


### PR DESCRIPTION
Refactors caller frame reading so that methods need not be explicitly marks as needing a caller frame, but may simply use a ReadCallerFrameNode. This set of changes does not rewrite send nodes, which still use the call stack API to get the caller frame.