### PR TITLE
Split nodes that read caller frames and tidy up.

### DIFF
--- a/truffleruby/src/main/java/org/truffleruby/builtins/CoreMethod.java
+++ b/truffleruby/src/main/java/org/truffleruby/builtins/CoreMethod.java
@@ -42,8 +42,6 @@ public @interface CoreMethod {
      */
     boolean isModuleFunction() default false;
 
-    CallerFrameAccess needsCallerFrame() default CallerFrameAccess.NONE;
-
     boolean needsSelf() default true;
 
     int required() default 0;

--- a/truffleruby/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/truffleruby/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -179,7 +179,6 @@ public class CoreMethodNodeManager {
     private static SharedMethodInfo makeSharedMethodInfo(RubyContext context, DynamicObject module, MethodDetails methodDetails) {
         final CoreMethod method = methodDetails.getMethodAnnotation();
         final LexicalScope lexicalScope = new LexicalScope(context.getRootLexicalScope(), module);
-        final boolean needsCallerFrame = method.needsCallerFrame() != CallerFrameAccess.NONE;
 
         return new SharedMethodInfo(
                 context.getCoreLibrary().getSourceSection(),
@@ -189,9 +188,7 @@ public class CoreMethodNodeManager {
                 methodDetails.getPrimaryName(),
                 "builtin",
                 null,
-                context.getOptions().CORE_ALWAYS_CLONE,
-                needsCallerFrame && context.getOptions().INLINE_NEEDS_CALLER_FRAME,
-                needsCallerFrame);
+                context.getOptions().CORE_ALWAYS_CLONE);
     }
 
     private static CallTarget makeGenericMethod(RubyContext context, MethodDetails methodDetails, SharedMethodInfo sharedMethodInfo) {

--- a/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -249,7 +249,7 @@ public abstract class KernelNodes {
         }
     }
 
-    @CoreMethod(names = "block_given?", isModuleFunction = true, needsCallerFrame = CallerFrameAccess.ARGUMENTS)
+    @CoreMethod(names = "block_given?", isModuleFunction = true)
     public abstract static class BlockGivenNode extends CoreMethodArrayArgumentsNode {
 
         @Child ReadCallerFrameNode callerFrameNode = new ReadCallerFrameNode(CallerFrameAccess.ARGUMENTS);

--- a/truffleruby/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -380,8 +380,6 @@ public abstract class ModuleNodes {
                     accessorName,
                     "attr_" + (isGetter ? "reader" : "writer"),
                     null,
-                    false,
-                    false,
                     false);
 
             final RubyNode self = new ProfileArgumentNode(new ReadSelfNode());

--- a/truffleruby/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
@@ -109,8 +109,6 @@ public abstract class SymbolNodes {
                     Layouts.SYMBOL.getString(symbol),
                     "proc",
                     ArgumentDescriptor.ANON_REST,
-                    false,
-                    false,
                     false);
 
             final RubyRootNode rootNode = new RubyRootNode(getContext(), sourceSection, new FrameDescriptor(nil()), sharedMethodInfo, Translator.sequence(sourceIndexLength, Arrays.asList(Translator.createCheckArityNode(Arity.AT_LEAST_ONE), new SymbolProcNode(Layouts.SYMBOL.getString(symbol)))), false);

--- a/truffleruby/src/main/java/org/truffleruby/language/RubyRootNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/RubyRootNode.java
@@ -9,6 +9,10 @@
  */
 package org.truffleruby.language;
 
+import org.truffleruby.RubyContext;
+import org.truffleruby.RubyLanguage;
+import org.truffleruby.language.methods.SharedMethodInfo;
+
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.ExecutionContext;
 import com.oracle.truffle.api.Truffle;
@@ -17,12 +21,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.SourceSection;
-
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.truffleruby.RubyContext;
-import org.truffleruby.RubyLanguage;
-import org.truffleruby.language.methods.SharedMethodInfo;
 
 public class RubyRootNode extends RootNode {
 

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
@@ -51,9 +51,9 @@ public class ReadCallerFrameNode extends RubyNode {
             Node parent = callerNode.getParent();
             if (parent instanceof CachedDispatchNode) {
                 if (getContext().getCallStack().callerIsSend()) {
-                    ((CachedDispatchNode) parent).replaceSendingCallerFrame(accessMode);
+                    ((CachedDispatchNode) parent).startSendingCallerFrame(accessMode);
                 } else {
-                    ((CachedDispatchNode) parent).replaceSendingFrame();
+                    ((CachedDispatchNode) parent).startSendingOwnFrame();
                 }
             }
         }

--- a/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/arguments/ReadCallerFrameNode.java
@@ -50,11 +50,7 @@ public class ReadCallerFrameNode extends RubyNode {
         if (callerNode instanceof DirectCallNode) {
             Node parent = callerNode.getParent();
             if (parent instanceof CachedDispatchNode) {
-                if (getContext().getCallStack().callerIsSend()) {
-                    ((CachedDispatchNode) parent).startSendingCallerFrame(accessMode);
-                } else {
-                    ((CachedDispatchNode) parent).startSendingOwnFrame();
-                }
+                ((CachedDispatchNode) parent).startSendingOwnFrame();
             }
         }
     }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBooleanDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBooleanDispatchNode.java
@@ -62,6 +62,17 @@ public class CachedBooleanDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        if (falseCallDirect != null) {
+            applySplittingInliningStrategy(falseCallDirect, falseMethod);
+        }
+
+        if (falseCallDirect != null) {
+            applySplittingInliningStrategy(trueCallDirect, trueMethod);
+        }
+    }
+
+    @Override
     protected boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) && (receiver instanceof Boolean);
     }
@@ -123,5 +134,4 @@ public class CachedBooleanDispatchNode extends CachedDispatchNode {
             }
         }
     }
-
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
@@ -50,6 +50,11 @@ public class CachedBoxedDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        applySplittingInliningStrategy(callNode, method);
+    }
+
+    @Override
     public boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) &&
                 (receiver instanceof DynamicObject) &&

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedSymbolDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedBoxedSymbolDispatchNode.java
@@ -43,6 +43,11 @@ public class CachedBoxedSymbolDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        applySplittingInliningStrategy(callNode, method);
+    }
+
+    @Override
     protected boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) && (RubyGuards.isRubySymbol(receiver));
     }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -23,6 +23,7 @@ import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.profiles.BranchProfile;
+import com.oracle.truffle.api.utilities.AlwaysValidAssumption;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -37,8 +38,6 @@ import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.InternalMethod;
 
 public abstract class CachedDispatchNode extends DispatchNode {
-
-    private static final Assumption DUMMY_ASSUMPTION = Truffle.getRuntime().createAssumption();
 
     private final Object cachedName;
     private final DynamicObject cachedNameAsSymbol;
@@ -84,7 +83,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
         if (root instanceof RubyRootNode && !sendingFrames()) {
             needsCallerAssumption = ((RubyRootNode) root).getNeedsCallerAssumption();
         } else {
-            needsCallerAssumption = DUMMY_ASSUMPTION;
+            needsCallerAssumption = AlwaysValidAssumption.INSTANCE;
         }
     }
 
@@ -107,7 +106,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
     }
 
     private void replaceSendingFrame(boolean sendsFrame, ReadCallerFrameNode readCaller) {
-        assert needsCallerAssumption != DUMMY_ASSUMPTION;
+        assert needsCallerAssumption != AlwaysValidAssumption.INSTANCE;
         this.sendsFrame = sendsFrame;
         this.readCaller = readCaller;
         Node root = getRootNode();

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -74,12 +74,6 @@ public abstract class CachedDispatchNode extends DispatchNode {
         this.next = next;
     }
 
-    @Override
-    public void setupForReplacement(Node oldNode, CharSequence reason) {
-        super.setupForReplacement(oldNode, reason);
-        resetNeedsCallerAssumption();
-    }
-
     private void resetNeedsCallerAssumption() {
         Node root = getRootNode();
         if (root instanceof RubyRootNode && !sendingFrames()) {
@@ -171,6 +165,10 @@ public abstract class CachedDispatchNode extends DispatchNode {
     }
 
     protected Object call(DirectCallNode callNode, VirtualFrame frame, InternalMethod method, Object receiver, DynamicObject block, Object[] arguments) {
+        if (needsCallerAssumption == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            resetNeedsCallerAssumption();
+        }
         try {
             needsCallerAssumption.check();
         } catch (InvalidAssumptionException e) {

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -88,20 +88,19 @@ public abstract class CachedDispatchNode extends DispatchNode {
     }
 
     public void startSendingOwnFrame() {
-        assert sendsFrame != SendsFrame.CALLER_FRAME;
-        if (sendsFrame == SendsFrame.NO_FRAME) {
+        if (getContext().getCallStack().callerIsSend()) {
+            assert sendsFrame != SendsFrame.MY_FRAME;
+            startSendingFrame(SendsFrame.CALLER_FRAME);
+        } else {
+            assert sendsFrame != SendsFrame.CALLER_FRAME;
             startSendingFrame(SendsFrame.MY_FRAME);
         }
     }
 
-    public void startSendingCallerFrame(CallerFrameAccess access) {
-        assert sendsFrame != SendsFrame.MY_FRAME;
-        if (sendsFrame == SendsFrame.NO_FRAME) {
-            startSendingFrame(SendsFrame.CALLER_FRAME);
-        }
-    }
-
     private void startSendingFrame(SendsFrame frameToSend) {
+        if (sendsFrame != SendsFrame.NO_FRAME) {
+            return;
+        }
         assert needsCallerAssumption != AlwaysValidAssumption.INSTANCE;
         this.sendsFrame = frameToSend;
         if (frameToSend == SendsFrame.CALLER_FRAME) {

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedForeignDispatchNode.java
@@ -31,6 +31,11 @@ public final class CachedForeignDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        // Do nothing, this node doesn't split or inline.
+    }
+
+    @Override
     protected boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) && RubyGuards.isForeignObject(receiver);
     }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
@@ -56,13 +56,18 @@ public class CachedMethodMissingDispatchNode extends CachedDispatchNode {
          * to manually clone the call target and to inline it.
          */
 
+        applySplittingInliningStrategy(callNode, methodMissing);
+    }
+
+    @Override
+    protected void applySplittingInliningStrategy(DirectCallNode callNode, InternalMethod method) {
         if (callNode.isCallTargetCloningAllowed()
-                && (context.getOptions().METHODMISSING_ALWAYS_CLONE || methodMissing.getSharedMethodInfo().shouldAlwaysClone())) {
+                && (getContext().getOptions().METHODMISSING_ALWAYS_CLONE || method.getSharedMethodInfo().shouldAlwaysClone())) {
             insert(callNode);
             callNode.cloneCallTarget();
         }
 
-        if (callNode.isInlinable() && context.getOptions().METHODMISSING_ALWAYS_INLINE) {
+        if (callNode.isInlinable() && getContext().getOptions().METHODMISSING_ALWAYS_INLINE) {
             insert(callNode);
             callNode.forceInlining();
         }
@@ -70,7 +75,7 @@ public class CachedMethodMissingDispatchNode extends CachedDispatchNode {
 
     @Override
     protected void reassessSplittingInliningStrategy() {
-        // Do nothing, this node does not split or inline.
+        applySplittingInliningStrategy(callNode, methodMissing);
     }
 
     @Override

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedMethodMissingDispatchNode.java
@@ -69,6 +69,11 @@ public class CachedMethodMissingDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        // Do nothing, this node does not split or inline.
+    }
+
+    @Override
     protected boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) &&
                 metaClassNode.executeMetaClass(receiver) == expectedClass;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedReturnMissingDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedReturnMissingDispatchNode.java
@@ -42,6 +42,11 @@ public class CachedReturnMissingDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        // Do nothing, this node does not split or inline.
+    }
+
+    @Override
     protected boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) &&
                 metaClassNode.executeMetaClass(receiver) == expectedClass;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedSingletonDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedSingletonDispatchNode.java
@@ -51,6 +51,11 @@ public class CachedSingletonDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        applySplittingInliningStrategy(callNode, method);
+    }
+
+    @Override
     public boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) &&
                 receiver == expectedReceiver;

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedUnboxedDispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/CachedUnboxedDispatchNode.java
@@ -46,6 +46,11 @@ public class CachedUnboxedDispatchNode extends CachedDispatchNode {
     }
 
     @Override
+    protected void reassessSplittingInliningStrategy() {
+        applySplittingInliningStrategy(callNode, method);
+    }
+
+    @Override
     protected boolean guard(Object methodName, Object receiver) {
         return guardName(methodName) &&
                 !(receiver instanceof DynamicObject) &&

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -92,14 +92,4 @@ public abstract class DispatchNode extends RubyNode {
     public DispatchAction getDispatchAction() {
         return dispatchAction;
     }
-
-    public void setupForReplacement(Node oldNode, CharSequence reason) {
-    }
-
-    @Override
-    public final void onReplace(Node newNode, CharSequence reason) {
-        if (newNode instanceof DispatchNode) {
-            ((DispatchNode) newNode).setupForReplacement(this, reason);
-        }
-    }
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -93,4 +93,13 @@ public abstract class DispatchNode extends RubyNode {
         return dispatchAction;
     }
 
+    public void setupForReplacement(Node oldNode, CharSequence reason) {
+    }
+
+    @Override
+    public final void onReplace(Node newNode, CharSequence reason) {
+        if (newNode instanceof DispatchNode) {
+            ((DispatchNode) newNode).setupForReplacement(this, reason);
+        }
+    }
 }

--- a/truffleruby/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
+++ b/truffleruby/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
@@ -31,8 +31,6 @@ public class SharedMethodInfo {
     private final String notes;
     private final ArgumentDescriptor[] argumentDescriptors;
     private boolean alwaysClone;
-    private final boolean alwaysInline;
-    private final boolean needsCallerFrame;
     private String descriptiveNameAndSource;
 
     public SharedMethodInfo(
@@ -43,9 +41,7 @@ public class SharedMethodInfo {
             String name,
             String notes,
             ArgumentDescriptor[] argumentDescriptors,
-            boolean alwaysClone,
-            boolean alwaysInline,
-            boolean needsCallerFrame) {
+            boolean alwaysClone) {
         if (argumentDescriptors == null) {
             argumentDescriptors = new ArgumentDescriptor[]{};
         }
@@ -59,8 +55,6 @@ public class SharedMethodInfo {
         this.notes = notes;
         this.argumentDescriptors = argumentDescriptors;
         this.alwaysClone = alwaysClone;
-        this.alwaysInline = alwaysInline;
-        this.needsCallerFrame = needsCallerFrame;
     }
 
     public SourceSection getSourceSection() {
@@ -91,14 +85,6 @@ public class SharedMethodInfo {
         return alwaysClone;
     }
 
-    public boolean shouldAlwaysInline() {
-        return alwaysInline;
-    }
-
-    public boolean needsCallerFrame() {
-        return needsCallerFrame;
-    }
-
     public void setAlwaysClone(boolean alwaysClone) {
         this.alwaysClone = alwaysClone;
     }
@@ -112,9 +98,7 @@ public class SharedMethodInfo {
                 newName,
                 notes,
                 argumentDescriptors,
-                alwaysClone,
-                alwaysInline,
-                needsCallerFrame);
+                alwaysClone);
     }
 
     public String getDescriptiveName() {

--- a/truffleruby/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/truffleruby/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -989,8 +989,6 @@ public class BodyTranslator extends Translator {
                     name,
                     sclass ? "class body" : "module body",
                     null,
-                    false,
-                    false,
                     false);
 
             final ReturnID returnId;
@@ -1394,9 +1392,7 @@ public class BodyTranslator extends Translator {
                 methodName,
                 null,
                 argumentDescriptors,
-                alwaysClone,
-                false,
-                false);
+                alwaysClone);
 
         final TranslatorEnvironment newEnvironment = new TranslatorEnvironment(
                         context, environment, environment.getParseEnvironment(), environment.getParseEnvironment().allocateReturnID(), true, true, false, sharedMethodInfo, methodName, 0, null);
@@ -1956,8 +1952,6 @@ public class BodyTranslator extends Translator {
                 null,
                 isLambda ? "lambda" : getIdentifierInNewEnvironment(true, currentCallMethodName),
                 Helpers.argsNodeToArgumentDescriptors(argsNode),
-                false,
-                false,
                 false);
 
         final String namedMethodName = isLambda ? sharedMethodInfo.getName(): environment.getNamedMethodName();

--- a/truffleruby/src/main/java/org/truffleruby/parser/TranslatorDriver.java
+++ b/truffleruby/src/main/java/org/truffleruby/parser/TranslatorDriver.java
@@ -187,8 +187,6 @@ public class TranslatorDriver {
                 "<main>",
                 null,
                 null,
-                false,
-                false,
                 false);
 
         final boolean topLevel = parserContext == ParserContext.TOP_LEVEL_FIRST || parserContext == ParserContext.TOP_LEVEL;
@@ -322,8 +320,6 @@ public class TranslatorDriver {
                 null,
                 "external",
                 null,
-                false,
-                false,
                 false);
             // TODO(CS): how do we know if the frame is a block or not?
             return new TranslatorEnvironment(context, null, parseEnvironment,
@@ -342,8 +338,6 @@ public class TranslatorDriver {
                     null,
                     "external",
                     null,
-                    false,
-                    false,
                     false);
             final MaterializedFrame parent = RubyArguments.getDeclarationFrame(frame);
             // TODO(CS): how do we know if the frame is a block or not?


### PR DESCRIPTION
Tidy up CoreMethod and SharedMethodInfo round the changes to reading caller frames, and ensure that dispatch nodes are properly replaced and method splitting & inlining reassessed when a caller frame must be read.