### PR TITLE
Eval and binding performance

### DIFF
--- a/test/truffle/compiler/pe/core/binding_pe.rb
+++ b/test/truffle/compiler/pe/core/binding_pe.rb
@@ -12,7 +12,7 @@ example "x = 14; binding.local_variable_get(:x)", 14
 # TODO DM 12-Apr-17 Proc creation is not constant, so bindings on procs cannot be yet.
 
 # Proc#binding
-tagged example "x = 14; p = Proc.new { }; p.binding.local_variable_get(:x)", 14
+example "x = 14; p = Proc.new { }; p.binding.local_variable_get(:x)", 14
 
 # set + get
 tagged example "b = binding; b.local_variable_set(:x, 14); b.local_variable_get(:x)", 14

--- a/test/truffle/compiler/pe/core/eval_pe.rb
+++ b/test/truffle/compiler/pe/core/eval_pe.rb
@@ -6,12 +6,12 @@
 # GNU General Public License version 2
 # GNU Lesser General Public License version 2.1
 
-tagged example "eval('14')", 14
+example "eval('14')", 14
 
-tagged example "eval('14 + 2')", 16
+example "eval('14 + 2')", 16
 
-tagged example "eval('[1, 2, 3]')[1]", 2
+example "eval('[1, 2, 3]')[1]", 2
 
-tagged example "eval([1, 2, 3].inspect)[1]", 2
+example "eval([1, 2, 3].inspect)[1]", 2
 
-tagged counter example "eval(rand.to_s)"
+counter example "eval(rand.to_s)"

--- a/truffleruby/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -54,6 +54,10 @@ public abstract class BindingNodes {
         return Layouts.BINDING.createBinding(context.getCoreLibrary().getBindingFactory(), frame, null);
     }
 
+    public static DynamicObject createBinding(RubyContext context, MaterializedFrame frame, FrameDescriptor extrasDescriptor) {
+        return Layouts.BINDING.createBinding(context.getCoreLibrary().getBindingFactory(), frame, newExtrasFrame(frame, extrasDescriptor));
+    }
+
     @TruffleBoundary
     public static FrameDescriptor newFrameDescriptor(RubyContext context) {
         return new FrameDescriptor(context.getCoreLibrary().getNilObject());
@@ -85,6 +89,11 @@ public abstract class BindingNodes {
     }
 
     public static MaterializedFrame newExtrasFrame(RubyContext context, MaterializedFrame parent) {
+        FrameDescriptor descriptor = newFrameDescriptor(context);
+        return newExtrasFrame(parent, descriptor);
+    }
+
+    private static MaterializedFrame newExtrasFrame(MaterializedFrame parent, FrameDescriptor descriptor) {
         final MaterializedFrame frame = Truffle.getRuntime().createMaterializedFrame(
                 RubyArguments.pack(
                         parent,
@@ -95,7 +104,7 @@ public abstract class BindingNodes {
                         RubyArguments.getSelf(parent),
                         RubyArguments.getBlock(parent),
                         RubyArguments.getArguments(parent)),
-                newFrameDescriptor(context));
+                descriptor);
         return frame;
     }
 

--- a/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -527,12 +527,9 @@ public abstract class KernelNodes {
                 @Cached("compileSource(frame, source)") RootNodeWrapper cachedRootNode,
                 @Cached("createCallTarget(cachedRootNode)") CallTarget cachedCallTarget,
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode,
-                @Cached("callerFrameNode.execute(frame).getFrameDescriptor()") FrameDescriptor callerDescriptor,
-                @Cached("newFrameDescriptor(getContext())") FrameDescriptor extrasDescriptor
+                @Cached("callerFrameNode.execute(frame).getFrameDescriptor()") FrameDescriptor callerDescriptor
         ) {
-            final DynamicObject callerBinding = BindingNodes.createBinding(getContext(), callerFrameNode.execute(frame).materialize(), extrasDescriptor);
-
-            final MaterializedFrame parentFrame = Layouts.BINDING.getExtras(callerBinding);
+            final MaterializedFrame parentFrame = callerFrameNode.execute(frame).materialize();
             final Object callerSelf = RubyArguments.getSelf(frame);
 
             final InternalMethod method = new InternalMethod(
@@ -561,13 +558,10 @@ public abstract class KernelNodes {
                 NotProvided line,
                 @Cached("privatizeRope(source)") Rope cachedSource,
                 @Cached("callerFrameNode.execute(frame).getFrameDescriptor()") FrameDescriptor callerDescriptor,
-                @Cached("newFrameDescriptor(getContext())") FrameDescriptor extrasDescriptor,
-                @Cached("compileSource(frame, source, callerFrameNode.execute(frame).materialize(), extrasDescriptor)") RootNodeWrapper cachedRootNode,
+                @Cached("compileSource(frame, source, callerFrameNode.execute(frame).materialize())") RootNodeWrapper cachedRootNode,
                 @Cached("createCallTarget(cachedRootNode)") CallTarget cachedCallTarget,
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
-            final DynamicObject callerBinding = BindingNodes.createBinding(getContext(), callerFrameNode.execute(frame).materialize(), extrasDescriptor);
-
-            final MaterializedFrame parentFrame = Layouts.BINDING.getExtras(callerBinding);
+            final MaterializedFrame parentFrame = callerFrameNode.execute(frame).materialize();
             final Object callerSelf = RubyArguments.getSelf(frame);
 
             final InternalMethod method = new InternalMethod(
@@ -700,11 +694,8 @@ public abstract class KernelNodes {
             return new RootNodeWrapper(translator.parse(source, encoding, ParserContext.EVAL, null, null, parentFrame, true, this));
         }
 
-        protected RootNodeWrapper compileSource(VirtualFrame frame, DynamicObject sourceText, MaterializedFrame caller, FrameDescriptor extrasDescriptor) {
+        protected RootNodeWrapper compileSource(VirtualFrame frame, DynamicObject sourceText, MaterializedFrame parentFrame) {
             assert RubyGuards.isRubyString(sourceText);
-
-            final DynamicObject callerBinding = BindingNodes.createBinding(getContext(), caller, extrasDescriptor);
-            final MaterializedFrame parentFrame = Layouts.BINDING.getExtras(callerBinding);
 
             final Encoding encoding = Layouts.STRING.getRope(sourceText).getEncoding();
             final Source source = Source.newBuilder(sourceText.toString()).name("(eval)").mimeType(RubyLanguage.MIME_TYPE).build();

--- a/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -590,7 +590,7 @@ public abstract class KernelNodes {
                 @Cached("createCallTarget(cachedRootNode)") CallTarget cachedCallTarget,
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
             final MaterializedFrame parentFrame = BindingNodes.getTopFrame(binding);
-            final Object callerSelf = RubyArguments.getSelf(frame);
+            final Object bindingSelf = RubyArguments.getSelf(parentFrame);
 
             final InternalMethod method = new InternalMethod(
                     getContext(),
@@ -601,7 +601,7 @@ public abstract class KernelNodes {
                     Visibility.PUBLIC,
                     cachedCallTarget);
 
-            return callNode.call(RubyArguments.pack(parentFrame, null, method, RubyArguments.getDeclarationContext(parentFrame), null, callerSelf, null, new Object[]{}));
+            return callNode.call(RubyArguments.pack(parentFrame, null, method, RubyArguments.getDeclarationContext(parentFrame), null, bindingSelf, null, new Object[]{}));
         }
 
         @Specialization(guards = {


### PR DESCRIPTION
Refactors eval to be more easily optimised when a binding is not passed in and the evaluated string depends on the declaration context. Tested with an adapted version of the Mandelbrot benchmark which replaced
```
zr = tr
zi = ti
```
with
```
eval "zr = tr"
eval "zi = ti"
```
and verified that performance was unaffected.