### PR TITLE
Rb protect and rb_jump_tag

### DIFF
--- a/spec/ruby/optional/capi/ext/kernel_spec.c
+++ b/spec/ruby/optional/capi/ext/kernel_spec.c
@@ -183,6 +183,18 @@ VALUE kernel_spec_rb_rescue2(int argc, VALUE *args, VALUE self) {
 }
 #endif
 
+#ifdef HAVE_RB_PROTECT
+static VALUE kernel_spec_rb_protect_yield(VALUE self, VALUE obj, VALUE ary) {
+  int status = 0;
+  VALUE res = rb_protect(rb_yield, obj, &status);
+  rb_ary_store(ary, 0, INT2NUM(23));
+  if (status) {
+    rb_jump_tag(status);
+  }
+  return res;
+}
+#endif
+
 #ifdef HAVE_RB_SYS_FAIL
 VALUE kernel_spec_rb_sys_fail(VALUE self, VALUE msg) {
   errno = 1;
@@ -216,6 +228,21 @@ VALUE kernel_spec_rb_warn(VALUE self, VALUE msg) {
 #ifdef HAVE_RB_YIELD
 static VALUE kernel_spec_rb_yield(VALUE self, VALUE obj) {
   return rb_yield(obj);
+}
+
+static int kernel_cb(const int *a, const int *b) {
+  rb_yield(Qtrue);
+  return 0;
+}
+
+static VALUE kernel_indirected(void *(*func)(int)) {
+  int bob[] = { 1, 1, 2, 3, 5, 8, 13 };
+  qsort(bob, 7, sizeof(int), kernel_cb);
+  return Qfalse;
+}
+
+static VALUE kernel_spec_rb_yield_indirected(VALUE self, VALUE obj) {
+  return kernel_indirected(kernel_cb);
 }
 #endif
 
@@ -338,6 +365,10 @@ void Init_kernel_spec(void) {
   rb_define_method(cls, "rb_rescue2", kernel_spec_rb_rescue2, -1);
 #endif
 
+#ifdef HAVE_RB_PROTECT
+  rb_define_method(cls, "rb_protect_yield", kernel_spec_rb_protect_yield, 2);
+#endif
+
 #ifdef HAVE_RB_CATCH
   rb_define_method(cls, "rb_catch", kernel_spec_rb_catch, 2);
 #endif
@@ -360,6 +391,7 @@ void Init_kernel_spec(void) {
 
 #ifdef HAVE_RB_YIELD
   rb_define_method(cls, "rb_yield", kernel_spec_rb_yield, 1);
+  rb_define_method(cls, "rb_yield_indirected", kernel_spec_rb_yield_indirected, 1);
 #endif
 
 #ifdef HAVE_RB_YIELD_VALUES

--- a/spec/ruby/optional/capi/ext/rubyspec.h
+++ b/spec/ruby/optional/capi/ext/rubyspec.h
@@ -366,6 +366,7 @@
 #define HAVE_RB_YIELD_VALUES               1
 #define HAVE_RB_FUNCALL3                   1
 #define HAVE_RB_FUNCALL_WITH_BLOCK         1
+#define HAVE_RB_PROTECT                    1
 
 /* GC */
 #define HAVE_RB_GC_REGISTER_ADDRESS        1

--- a/spec/ruby/optional/capi/kernel_spec.rb
+++ b/spec/ruby/optional/capi/kernel_spec.rb
@@ -184,6 +184,18 @@ describe "C-API Kernel function" do
     it "raises LocalJumpError when no block is given" do
       lambda { @s.rb_yield(1) }.should raise_error(LocalJumpError)
     end
+
+    it "rb_yield to a block that breaks does not raise an error" do
+      @s.rb_yield(1) { break }.should == nil
+    end
+
+    it "rb_yield to a block that breaks with a value returns the value" do
+      @s.rb_yield(1) { break 73 }.should == 73
+    end
+
+    it "rb_yield through a callback to a block that breaks with a value returns the value" do
+      @s.rb_yield_indirected(1) { break 73 }.should == 73
+    end
   end
 
   describe "rb_yield_values" do
@@ -217,6 +229,36 @@ describe "C-API Kernel function" do
       lambda { @s.rb_yield_splat([1, 2]) }.should raise_error(LocalJumpError)
     end
   end
+
+  describe "rb_protect" do
+    it "will run a function with an argument" do
+      proof = [] # Hold proof of work performed after the yield.
+      res = @s.rb_protect_yield(7, proof) { |x| x + 1 }
+      res.should == 8
+      proof[0].should == 23
+    end
+
+    it "will allow cleanup code to run after break" do
+      proof = [] # Hold proof of work performed after the yield.
+      @s.rb_protect_yield(7, proof) { |x| break }
+      proof[0].should == 23
+    end
+
+    it "will allow cleanup code to run after break with value" do
+      proof = [] # Hold proof of work performed after the yield.
+      res = @s.rb_protect_yield(7, proof) { |x| break x + 1 }
+      res.should == 8
+      proof[0].should == 23
+    end
+
+    it "will allow cleanup code to run after a raise" do
+      proof = [] # Hold proof of work performed after the yield.
+      lambda do
+        @s.rb_protect_yield(7, proof) { |x| raise NameError}
+      end.should raise_error(NameError)
+      proof[0].should == 23
+    end
+end
 
   describe "rb_rescue" do
     before :each do

--- a/truffleruby/src/main/c/cext/ruby.c
+++ b/truffleruby/src/main/c/cext/ruby.c
@@ -1872,13 +1872,19 @@ void rb_exc_raise(VALUE exception) {
 }
 
 VALUE rb_protect(VALUE (*function)(VALUE), VALUE data, int *status) {
-  // TODO CS 23-Jul-16
-  return function(data);
+  VALUE ary;
+  if (rb_block_given_p()) {
+    ary = truffle_invoke(RUBY_CEXT, "rb_protect_with_block", truffle_address_to_function(function), data, rb_block_proc());
+  } else {
+    ary = truffle_invoke(RUBY_CEXT, "rb_protect", truffle_address_to_function(function), data);
+  }    
+  *status = NUM2INT(truffle_read_idx(ary, 1));
+  return truffle_read_idx(ary, 0);
 }
 
 void rb_jump_tag(int status) {
   if (status) {
-    rb_tr_error("rb_jump_tag not implemented");
+    truffle_invoke(RUBY_CEXT, "rb_jump_tag", status);
   }
 }
 

--- a/truffleruby/src/main/c/cext/ruby.c
+++ b/truffleruby/src/main/c/cext/ruby.c
@@ -1872,12 +1872,8 @@ void rb_exc_raise(VALUE exception) {
 }
 
 VALUE rb_protect(VALUE (*function)(VALUE), VALUE data, int *status) {
-  VALUE ary;
-  if (rb_block_given_p()) {
-    ary = truffle_invoke(RUBY_CEXT, "rb_protect_with_block", truffle_address_to_function(function), data, rb_block_proc());
-  } else {
-    ary = truffle_invoke(RUBY_CEXT, "rb_protect", truffle_address_to_function(function), data);
-  }    
+  VALUE ary = truffle_invoke(RUBY_CEXT, "rb_protect_with_block",
+                             truffle_address_to_function(function), data, rb_block_proc());
   *status = NUM2INT(truffle_read_idx(ary, 1));
   return truffle_read_idx(ary, 0);
 }

--- a/truffleruby/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -1104,7 +1104,7 @@ public class CExtNodes {
         public Object executeWithProtect(VirtualFrame frame, DynamicObject block,
                 @Cached("create()") BranchProfile exceptionProfile) {
             try {
-                yield(frame, block);
+                yield(block);
                 return nil();
             } catch (Throwable e) {
                 exceptionProfile.enter();

--- a/truffleruby/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -1102,9 +1102,11 @@ public class CExtNodes {
 
         @Specialization
         public Object executeWithProtect(DynamicObject block,
-                @Cached("create()") BranchProfile exceptionProfile) {
+                @Cached("create()") BranchProfile exceptionProfile,
+                @Cached("create()") BranchProfile noExceptionProfile) {
             try {
                 yield(block);
+                noExceptionProfile.enter();
                 return nil();
             } catch (Throwable e) {
                 exceptionProfile.enter();

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -1141,6 +1141,25 @@ class << Truffle::CExt
     Truffle::Interop.execute(function, *args)
   end
 
+  # The idea of rb_protect and rb_jump_tag is to avoid unwinding the
+  # native stack in an uncontrolled manner. To do this we need to be
+  # able to run a piece of code and capture both its result (if it
+  # produces one), and any exception it generates. This is done by
+  # running the requested code in a block as follows
+  #
+  #   e = store_exception { res = requested_function(...) }
+  #
+  # leaving us with e containing any exception thrown from the block,
+  # and res containing the result of the function if it completed
+  # successfully. Since Ruby's API only allows us to use a number to
+  # indicate there was an exception we have to store it in a thread
+  # local array and provide a 1-based index into that array. Then once
+  # the native library has unwound its own stack by whatever method,
+  # and can allow the ruby error to propagate, it can call rb_jump_tag
+  # with the integer produced by rb_protect. rb_jump_tag then gets the
+  # exception out of the thread local and calls raise exception to
+  # throw it and allow normal error handling to continue.
+
   def rb_protect_with_block(function, arg, block)
     res = nil
     pos = 0

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -1137,6 +1137,53 @@ class << Truffle::CExt
     end
   end
 
+  def foreign_call_with_block(function, *args, &block)
+    Truffle::Interop.execute(function, *args)
+  end
+
+  def rb_protect_with_block(function, arg, block)
+    res = nil;
+    pos = 0;
+    e = store_exception do
+      puts "Block is #{block}"
+      res = foreign_call_with_block(function, arg, &block)
+    end
+    unless e == nil
+      store = Thread.current[:__stored_exceptions__]
+      store = Thread.current[:__stored_exceptions__] = [] unless store
+      pos = store.push(e).size
+    end
+    [res, pos]
+  end
+
+  def rb_protect(function, arg)
+    res = nil;
+    pos = 0;
+    e = store_exception do
+      res = Truffle::Interop.execute(function, arg)
+    end
+    unless e == nil
+      store = Thread.current[:__stored_exceptions__]
+      store = Thread.current[:__stored_exceptions__] = [] unless store
+      pos = store.push(e).size
+    end
+    [res, pos]
+  end
+
+  def rb_jump_tag(pos)
+    if (pos > 0)
+      store = Thread.current[:__stored_exceptions__]
+      if (pos = store.size)
+        e = store.pop
+      else
+        # Can't disturb other positions or other rb_jump_tag calls might fail.
+        e = store[pos - 1]
+        store[pos] = nil
+      end
+      raise_exception(e)
+    end
+  end
+
   def rb_yield(value)
     block = get_block
     Truffle::CExt.execute_with_mutex(block, value)

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -1166,7 +1166,7 @@ class << Truffle::CExt
       else
         # Can't disturb other positions or other rb_jump_tag calls might fail.
         e = store[pos - 1]
-        store[pos] = nil
+        store[pos - 1] = nil
       end
       raise_exception(e)
     end


### PR DESCRIPTION
Adds support for rb_protect and rb_jump_tag. Not perfect as some exception types have to be checked and we cannot simply add throws declarations to specialisations, so they end up wrapped in RuntimeExceptions.