### PR TITLE
Mutex for c calls

### DIFF
--- a/truffleruby/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/truffleruby/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -737,7 +737,7 @@ public class CExtNodes {
             return createString(StringOperations.encodeRope(file, UTF8Encoding.INSTANCE));
         }
 
-        public static SourceSection getTopUserSourceSection(String...methodNames) {
+        public static SourceSection getTopUserSourceSection(String...  methodNames) {
             return Truffle.getRuntime().iterateFrames(frameInstance -> {
                 final Node callNode = frameInstance.getCallNode();
 
@@ -847,6 +847,7 @@ public class CExtNodes {
                 if (method == null) {
                     return null;
                 } else if (method.getName().equals(/* Truffle::Cext. */ "rb_call_super")
+                        || method.getName().equals(/* Truffle::CExt. */ "execute_with_mutex")
                         || method.getName().equals(/* Truffle::Interop. */ "execute")
                         || method.getName().equals(/* Truffle::Cext. */ "rb_call_super_splatted")) {
                     // TODO CS 11-Mar-17 must have a more precise check to skip these methods

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -23,15 +23,15 @@ module Truffle::CExt
 
   end
 
-  Sync = Mutex.new
+  SYNC = Mutex.new
 
   def self.execute_with_mutex(function, *args)
-    mine = Truffle::CExt::Sync.owned?
-    Truffle::CExt::Sync.lock unless mine
+    mine = Truffle::CExt::SYNC.owned?
+    Truffle::CExt::SYNC.lock unless mine
     begin
       Truffle::Interop.execute(function, *args)
     ensure
-      Truffle::CExt::Sync.unlock unless mine
+      Truffle::CExt::SYNC.unlock unless mine
     end
   end
 
@@ -1616,8 +1616,8 @@ class << Truffle::CExt
     Thread.current.unblock unblocker, runner
   end
 
-  def rb_iterate_call_block( iter_block, block_arg, arg2)
-    Truffle::CExt.execute_with_mutex iter_block, block_arg, arg2
+  def rb_iterate_call_block( iter_block, block_arg, arg2, &block)
+    Truffle::CExt.execute_with_mutex iter_block, block_arg, arg2, &block
   end
 
   def rb_iterate(function, arg1, iter_block, arg2, block)
@@ -1638,7 +1638,7 @@ class << Truffle::CExt
     old_c_block = Thread.current[:__C_BLOCK__]
     begin
       Thread.current[:__C_BLOCK__] = block
-      Truffle::CExt.execute_with_mutex function, arg
+      Truffle::CExt.execute_with_mutex function, arg, &block
     ensure
       Thread.current[:__C_BLOCK__] = old_c_block
     end

--- a/truffleruby/src/main/ruby/core/truffle/cext.rb
+++ b/truffleruby/src/main/ruby/core/truffle/cext.rb
@@ -1139,12 +1139,12 @@ class << Truffle::CExt
 
   def rb_yield(value)
     block = get_block
-    block.call(value)
+    Truffle::CExt.execute_with_mutex(block, value)
   end
 
   def rb_yield_splat(values)
     block = get_block
-    block.call(*values)
+    Truffle::CExt.execute_with_mutex(block, *values)
   end
 
   def rb_ivar_lookup(object, name, default_value)
@@ -1300,7 +1300,7 @@ class << Truffle::CExt
 
   def rb_define_alloc_func(ruby_class, function)
     ruby_class.singleton_class.send(:define_method, :__allocate__) do
-      function.call(self)
+      Truffle::CExt.execute_with_mutex(function, self)
     end
     class << ruby_class
       private :__allocate__


### PR DESCRIPTION
Since Sulong does not handle multiple threads at this point place an effective global lock round native calls to prevent problems. This is not intended as a permanent solution and should be removed as soon as possible once Sulong can support our threading requirements.