### PR TITLE
Native Launcher for macOS

### DIFF
--- a/spec/truffle/boot/ruby_launcher_spec.rb
+++ b/spec/truffle/boot/ruby_launcher_spec.rb
@@ -19,7 +19,7 @@ describe "Truffle::Boot.ruby_launcher" do
 
   it "can be used to run a TruffleRuby subprocess" do
     launcher = Truffle::Boot.ruby_launcher
-    `#{launcher} -e "puts RUBY_ENGINE"`.chomp.should == RUBY_ENGINE
+    `#{launcher} -e "puts RUBY_ENGINE" 2>&1`.lines.last.chomp.should == RUBY_ENGINE
     $?.success?.should == true
   end
 end

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1654,6 +1654,16 @@ module Commands
     puts `cat spec/tags/core/**/**.txt | grep 'fails:'`.lines.sample
   end
 
+  def native_launcher
+    Dir.chdir("#{TRUFFLERUBY_DIR}/bin") do
+      sh = "truffleruby.sh"
+      raw_sh "git", "checkout", "HEAD", "truffleruby"
+      raw_sh "mv", "truffleruby", sh
+      raw_sh "cc", "-o", "truffleruby", "../tool/native_launcher.c"
+    end
+  end
+  alias :'native-launcher' :native_launcher
+
   def check_dsl_usage
     mx(TRUFFLERUBY_DIR, 'clean')
     # We need to build with -parameters to get parameter names

--- a/tool/native_launcher.c
+++ b/tool/native_launcher.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+
+/* Necessary for realpath() */
+#define _XOPEN_SOURCE 500
+
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[], char* envp[]) {
+    if (argc < 1) {
+        fprintf(stderr, "argc < 1\n");
+        return EXIT_FAILURE;
+    }
+
+    char exec[PATH_MAX+3];
+    if (realpath(argv[0], exec) == NULL) {
+        perror("realpath");
+        fprintf(stderr, "argv[0]=%s\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    size_t len = strlen(exec);
+    exec[len++] = '.';
+    exec[len++] = 's';
+    exec[len++] = 'h';
+    exec[len] = '\0';
+
+    char** args = argv;
+    args[0] = exec;
+
+    execve(exec, args, envp);
+
+    /* execve only returns on failure */
+    perror("execve");
+    fprintf(stderr, "%s\n", exec);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
* Solves the problem that macOS only allows one level of interpreter with `execve()`.
  If some gem binary is invoked, it has `.../bin/truffleruby` in its shebang,
  but `.../bin/truffleruby` is itself a Bash script with `/usr/bin/env bash` in its shebang,
  making two levels of interpreters, which is not allowed by macOS `execve()`.

Currently, the launcher is generated manually with `jt native-launcher`.
@pitr-ch Could you test it?
I guess we could even put the binary in the repository since it's so small and afaik only needed on one platform (macOS).