### PR TITLE
Prepopulate the String shape with common hidden properties.

### DIFF
--- a/src/main/java/org/truffleruby/Layouts.java
+++ b/src/main/java/org/truffleruby/Layouts.java
@@ -101,6 +101,14 @@ import org.truffleruby.stdlib.psych.EmitterLayoutImpl;
 
 public abstract class Layouts {
 
+    // Standard identifiers
+    // These must appear before the generated layout list so the identifiers have been initialized by the time
+    // the layout singletons are created.
+
+    public static final HiddenKey OBJECT_ID_IDENTIFIER = new HiddenKey("object_id");
+    public static final HiddenKey TAINTED_IDENTIFIER = new HiddenKey("tainted?");
+    public static final HiddenKey FROZEN_IDENTIFIER = new HiddenKey("frozen?");
+
     // Generated layouts
 
     public static final ArrayLayout ARRAY = ArrayLayoutImpl.INSTANCE;
@@ -147,10 +155,4 @@ public abstract class Layouts {
     public static final DigestLayout DIGEST = DigestLayoutImpl.INSTANCE;
     public static final StatLayout STAT = StatLayoutImpl.INSTANCE;
     public static final SystemCallErrorLayout SYSTEM_CALL_ERROR = SystemCallErrorLayoutImpl.INSTANCE;
-
-    // Other standard identifiers
-
-    public static final HiddenKey OBJECT_ID_IDENTIFIER = new HiddenKey("object_id");
-    public static final HiddenKey TAINTED_IDENTIFIER = new HiddenKey("tainted?");
-    public static final HiddenKey FROZEN_IDENTIFIER = new HiddenKey("frozen?");
 }

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -215,7 +215,6 @@ public class CoreLibrary {
     private final DynamicObject standardErrorClass;
     private final DynamicObject stringClass;
     private final DynamicObjectFactory stringFactory;
-    private final DynamicObjectFactory frozenStringFactory;
     private final DynamicObject symbolClass;
     private final DynamicObjectFactory symbolFactory;
     private final DynamicObject syntaxErrorClass;
@@ -537,7 +536,6 @@ public class CoreLibrary {
         stringClass = defineClass("String");
         stringFactory = Layouts.STRING.createStringShape(stringClass, stringClass);
         Layouts.CLASS.setInstanceFactoryUnsafe(stringClass, stringFactory);
-        frozenStringFactory = alwaysShared(alwaysFrozen(stringFactory));
         symbolClass = defineClass("Symbol");
         symbolFactory = alwaysShared(alwaysFrozen(Layouts.SYMBOL.createSymbolShape(symbolClass, symbolClass)));
         Layouts.CLASS.setInstanceFactoryUnsafe(symbolClass, symbolFactory);
@@ -876,7 +874,7 @@ public class CoreLibrary {
 
     private DynamicObject frozenUSASCIIString(String string) {
         final Rope rope = StringOperations.encodeRope(string, USASCIIEncoding.INSTANCE);
-        return Layouts.STRING.createString(context.getCoreLibrary().getFrozenStringFactory(), rope);
+        return StringOperations.createFrozenString(context, rope);
     }
 
     private DynamicObject defineClass(String name) {
@@ -1405,10 +1403,6 @@ public class CoreLibrary {
 
     public DynamicObjectFactory getStringFactory() {
         return stringFactory;
-    }
-
-    public DynamicObjectFactory getFrozenStringFactory() {
-        return frozenStringFactory;
     }
 
     public DynamicObjectFactory getHashFactory() {

--- a/src/main/java/org/truffleruby/core/adapters/OutputStreamAdapter.java
+++ b/src/main/java/org/truffleruby/core/adapters/OutputStreamAdapter.java
@@ -16,6 +16,7 @@ import org.truffleruby.RubyContext;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.RopeBuilder;
 import org.truffleruby.core.rope.RopeOperations;
+import org.truffleruby.core.string.StringOperations;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -34,8 +35,9 @@ public class OutputStreamAdapter extends OutputStream {
 
     @Override
     public void write(int bite) throws IOException {
-        context.send(object, "write", null, Layouts.STRING.createString(context.getCoreLibrary().getStringFactory(),
-                RopeOperations.ropeFromByteList(RopeBuilder.createRopeBuilder(new byte[]{(byte) bite}, encoding), CodeRange.CR_VALID)));
+        context.send(object, "write", null,
+                StringOperations.createString(context, RopeOperations.ropeFromByteList(
+                        RopeBuilder.createRopeBuilder(new byte[]{(byte) bite}, encoding), CodeRange.CR_VALID)));
     }
 
 }

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadBase64StringNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadBase64StringNode.java
@@ -57,6 +57,7 @@ import org.truffleruby.core.format.exceptions.InvalidFormatException;
 import org.truffleruby.core.format.read.SourceNode;
 import org.truffleruby.core.format.write.bytes.EncodeUM;
 import org.truffleruby.core.rope.AsciiOnlyLeafRope;
+import org.truffleruby.core.string.StringOperations;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -77,8 +78,7 @@ public abstract class ReadBase64StringNode extends FormatNode {
 
         setSourcePosition(frame, encode.position());
 
-        return Layouts.STRING.createString(getContext().getCoreLibrary().getStringFactory(),
-                new AsciiOnlyLeafRope(result, ASCIIEncoding.INSTANCE));
+        return StringOperations.createString(getContext(), new AsciiOnlyLeafRope(result, ASCIIEncoding.INSTANCE));
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadBinaryStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadBinaryStringNode.java
@@ -19,6 +19,7 @@ import org.truffleruby.Layouts;
 import org.truffleruby.core.format.FormatNode;
 import org.truffleruby.core.format.read.SourceNode;
 import org.truffleruby.core.rope.AsciiOnlyLeafRope;
+import org.truffleruby.core.string.StringOperations;
 
 import java.util.Arrays;
 
@@ -107,7 +108,7 @@ public abstract class ReadBinaryStringNode extends FormatNode {
 
         setSourcePosition(frame, start + length);
 
-        return Layouts.STRING.createString(getContext().getCoreLibrary().getStringFactory(),
+        return StringOperations.createString(getContext(),
                 new AsciiOnlyLeafRope(Arrays.copyOfRange(source, start, start + usedLength), ASCIIEncoding.INSTANCE));
     }
 

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadBitStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadBitStringNode.java
@@ -54,6 +54,7 @@ import org.truffleruby.Layouts;
 import org.truffleruby.core.format.FormatNode;
 import org.truffleruby.core.format.read.SourceNode;
 import org.truffleruby.core.rope.AsciiOnlyLeafRope;
+import org.truffleruby.core.string.StringOperations;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -115,7 +116,7 @@ public abstract class ReadBitStringNode extends FormatNode {
 
         setSourcePosition(frame, encode.position());
 
-        return Layouts.STRING.createString(getContext().getCoreLibrary().getStringFactory(),
+        return StringOperations.createString(getContext(),
                 new AsciiOnlyLeafRope(lElem, USASCIIEncoding.INSTANCE));
     }
 

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadHexStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadHexStringNode.java
@@ -55,6 +55,7 @@ import org.truffleruby.core.format.FormatNode;
 import org.truffleruby.core.format.read.SourceNode;
 import org.truffleruby.core.format.write.bytes.EncodeUM;
 import org.truffleruby.core.rope.AsciiOnlyLeafRope;
+import org.truffleruby.core.string.StringOperations;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -114,7 +115,7 @@ public abstract class ReadHexStringNode extends FormatNode {
 
         setSourcePosition(frame, encode.position());
 
-        return Layouts.STRING.createString(getContext().getCoreLibrary().getStringFactory(),
+        return StringOperations.createString(getContext(),
                 new AsciiOnlyLeafRope(lElem, USASCIIEncoding.INSTANCE));
     }
 

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadMIMEStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadMIMEStringNode.java
@@ -54,6 +54,7 @@ import org.truffleruby.Layouts;
 import org.truffleruby.core.format.FormatNode;
 import org.truffleruby.core.format.read.SourceNode;
 import org.truffleruby.core.rope.AsciiOnlyLeafRope;
+import org.truffleruby.core.string.StringOperations;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -120,7 +121,7 @@ public abstract class ReadMIMEStringNode extends FormatNode {
 
         setSourcePosition(frame, encode.position());
 
-        return Layouts.STRING.createString(getContext().getCoreLibrary().getStringFactory(),
+        return StringOperations.createString(getContext(),
                 new AsciiOnlyLeafRope(Arrays.copyOfRange(lElem, 0, index), USASCIIEncoding.INSTANCE));
     }
 

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadUUStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadUUStringNode.java
@@ -54,6 +54,7 @@ import org.truffleruby.Layouts;
 import org.truffleruby.core.format.FormatNode;
 import org.truffleruby.core.format.read.SourceNode;
 import org.truffleruby.core.rope.AsciiOnlyLeafRope;
+import org.truffleruby.core.string.StringOperations;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -148,7 +149,7 @@ public abstract class ReadUUStringNode extends FormatNode {
 
         setSourcePosition(frame, encode.position());
 
-        return Layouts.STRING.createString(getContext().getCoreLibrary().getStringFactory(),
+        return StringOperations.createString(getContext(),
                 new AsciiOnlyLeafRope(Arrays.copyOfRange(lElem, 0, index), USASCIIEncoding.INSTANCE));
     }
 

--- a/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -203,7 +203,7 @@ public abstract class RegexpNodes {
         final Rope sourceRope = StringOperations.rope(source);
         final Rope substringRope = makeSubstringNode.executeMake(sourceRope, start, length);
 
-        final DynamicObject ret = Layouts.STRING.createString(Layouts.CLASS.getInstanceFactory(Layouts.BASIC_OBJECT.getLogicalClass(source)), substringRope);
+        final DynamicObject ret = Layouts.CLASS.getInstanceFactory(Layouts.BASIC_OBJECT.getLogicalClass(source)).newInstance(Layouts.STRING.build(false, false, substringRope));
 
         return ret;
     }

--- a/src/main/java/org/truffleruby/core/string/FrozenStrings.java
+++ b/src/main/java/org/truffleruby/core/string/FrozenStrings.java
@@ -34,7 +34,7 @@ public class FrozenStrings {
         DynamicObject string = frozenStrings.get(holder);
 
         if (string == null) {
-            string = Layouts.STRING.createString(context.getCoreLibrary().getFrozenStringFactory(), rope);
+            string = StringOperations.createFrozenString(context, rope);
             frozenStrings.put(holder, string);
         }
 

--- a/src/main/java/org/truffleruby/core/string/StringLayout.java
+++ b/src/main/java/org/truffleruby/core/string/StringLayout.java
@@ -11,23 +11,33 @@ package org.truffleruby.core.string;
 
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.DynamicObjectFactory;
+import com.oracle.truffle.api.object.HiddenKey;
 import com.oracle.truffle.api.object.ObjectType;
 import com.oracle.truffle.api.object.dsl.Layout;
+import org.truffleruby.Layouts;
 import org.truffleruby.core.basicobject.BasicObjectLayout;
 import org.truffleruby.core.rope.Rope;
 
 @Layout
 public interface StringLayout extends BasicObjectLayout {
 
+    HiddenKey TAINTED_IDENTIFIER = Layouts.TAINTED_IDENTIFIER;
+    HiddenKey FROZEN_IDENTIFIER = Layouts.FROZEN_IDENTIFIER;
+
     DynamicObjectFactory createStringShape(DynamicObject logicalClass,
                                            DynamicObject metaClass);
 
-    DynamicObject createString(DynamicObjectFactory factory,
-                               Rope rope);
+    Object[] build(boolean frozen, boolean tainted, Rope rope);
 
     boolean isString(ObjectType objectType);
     boolean isString(DynamicObject object);
     boolean isString(Object object);
+
+    boolean getFrozen(DynamicObject object);
+    void setFrozen(DynamicObject object, boolean value);
+
+    boolean getTainted(DynamicObject object);
+    void setTainted(DynamicObject object, boolean value);
 
     Rope getRope(DynamicObject object);
     void setRope(DynamicObject object, Rope value);

--- a/src/main/java/org/truffleruby/core/string/StringOperations.java
+++ b/src/main/java/org/truffleruby/core/string/StringOperations.java
@@ -53,11 +53,15 @@ import java.nio.charset.StandardCharsets;
 public abstract class StringOperations {
 
     public static DynamicObject createString(RubyContext context, RopeBuilder bytes) {
-        return Layouts.STRING.createString(context.getCoreLibrary().getStringFactory(), RopeOperations.ropeFromBuilder(bytes, CodeRange.CR_UNKNOWN));
+        return context.getCoreLibrary().getStringFactory().newInstance(Layouts.STRING.build(false, false, RopeOperations.ropeFromBuilder(bytes, CodeRange.CR_UNKNOWN)));
     }
 
     public static DynamicObject createString(RubyContext context, Rope rope) {
-        return Layouts.STRING.createString(context.getCoreLibrary().getStringFactory(), rope);
+        return context.getCoreLibrary().getStringFactory().newInstance(Layouts.STRING.build(false, false, rope));
+    }
+
+    public static DynamicObject createFrozenString(RubyContext context, Rope rope) {
+        return context.getCoreLibrary().getStringFactory().newInstance(Layouts.STRING.build(true, false, rope));
     }
 
     public static String getString(DynamicObject string) {

--- a/src/main/java/org/truffleruby/language/literal/StringLiteralNode.java
+++ b/src/main/java/org/truffleruby/language/literal/StringLiteralNode.java
@@ -22,6 +22,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.Layouts;
 import org.truffleruby.core.rope.Rope;
+import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.language.RubyNode;
 
 public class StringLiteralNode extends RubyNode {
@@ -34,7 +35,7 @@ public class StringLiteralNode extends RubyNode {
 
     @Override
     public DynamicObject execute(VirtualFrame frame) {
-        return Layouts.STRING.createString(coreLibrary().getStringFactory(), rope);
+        return StringOperations.createString(getContext(), rope);
     }
 
 }

--- a/src/main/java/org/truffleruby/language/objects/IsFrozenNode.java
+++ b/src/main/java/org/truffleruby/language/objects/IsFrozenNode.java
@@ -67,7 +67,7 @@ public abstract class IsFrozenNode extends RubyNode {
     @TruffleBoundary
     public static boolean isFrozen(Object object) {
         return !(object instanceof DynamicObject) ||
-                ((DynamicObject) object).containsKey(Layouts.FROZEN_IDENTIFIER);
+                (boolean) ((DynamicObject) object).get(Layouts.FROZEN_IDENTIFIER, false);
     }
 
 }

--- a/src/main/java/org/truffleruby/language/objects/ObjectIDOperations.java
+++ b/src/main/java/org/truffleruby/language/objects/ObjectIDOperations.java
@@ -116,7 +116,10 @@ public abstract class ObjectIDOperations {
         Property property = object.getShape().getProperty(Layouts.OBJECT_ID_IDENTIFIER);
 
         if (property != null) {
-            return (long) property.get(object, false);
+            long value = (long) property.get(object, false);
+            if (value != 0) {
+                return value;
+            }
         }
 
         final long objectID = context.getObjectSpaceManager().getNextObjectID();


### PR DESCRIPTION
During bootstrap we'll encounter Strings that are frozen and/or tainted as well as Strings that have their object_id calculated. Prior to this change we started with a base shape and transitioned it as each new property was encountered, meaning live Strings were apt to take on a small set of shapes. Currently our dispatch logic caches on the shape, so we could end up with multiple entries in the dispatch chain for each shape type seen. By prepopulating the properties in the shape, we ensure that all Strings we create have the same shape. Note that code elsewhere could still modify the shape after the String is created, in which case that new shape will get its own entry in the dispatch chain as before.