### PR TITLE
Implement Kernel#yield_self

### DIFF
--- a/spec/ruby/core/kernel/yield_self_spec.rb
+++ b/spec/ruby/core/kernel/yield_self_spec.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.5" do
+  describe "Kernel#yield_self" do
+    it "yields self" do
+      object = Object.new
+      object.yield_self { |o| o.should equal object }
+    end
+
+    it "returns the block return value" do
+      object = Object.new
+      object.yield_self { 42 }.should equal 42
+    end
+
+    it "returns a sized Enumerator when no block given" do
+      object = Object.new
+      enum = object.yield_self
+      enum.should be_an_instance_of Enumerator
+      enum.size.should equal 1
+      enum.peek.should equal object
+      enum.first.should equal object
+    end
+  end
+end

--- a/src/main/ruby/core/kernel.rb
+++ b/src/main/ruby/core/kernel.rb
@@ -464,6 +464,14 @@ module Kernel
     self
   end
 
+  def yield_self
+    if block_given?
+      yield self
+    else
+      [self].to_enum { 1 }
+    end
+  end
+
   def test(cmd, file1, file2=nil)
     case cmd
     when ?d


### PR DESCRIPTION
 I took a stab at implementing Kernel#yield_self from #142 since CRuby discussion relating to naming seems to have died down.

This PR reflects the latest CRuby [implementation of #yield_self](https://github.com/ruby/ruby/commit/dc6d7cc58e78903e8309ff94c9e7112d661646ee), which returns a sized Enumerator when called without a block.