### PR TITLE
Disable RubyGems in specs for faster startup

### DIFF
--- a/spec/truffle.mspec
+++ b/spec/truffle.mspec
@@ -25,6 +25,7 @@ class MSpecScript
       -J-da:com.oracle.truffle.api.interop.ForeignAccess
       -J-Xmx2G
       -Xgraal.warn_unless=false
+      --disable-gems
     ]
     core_path = "#{TRUFFLERUBY_DIR}/src/main/ruby"
     if File.directory?(core_path)

--- a/spec/truffle/specs/truffle/kernel/gem_spec.rb
+++ b/spec/truffle/specs/truffle/kernel/gem_spec.rb
@@ -10,6 +10,7 @@ require_relative '../../../../ruby/spec_helper'
 
 describe "Kernel#gem" do
   it "returns true for included gems" do
+    require "rubygems"
     gem("json").should == true
     gem("minitest").should == true
     gem("power_assert").should == true


### PR DESCRIPTION
* ruby/spec specs do not need RubyGems.