### PR TITLE
Dockerfiles for testing and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ test/truffle/cexts/**/mkmf.log
 # Tests
 /test/truffle/integration/gem-testing
 /truffleruby-gem-test-pack-*
+/test/truffle/docker/*/graalvm-*.tar.gz
 
 # Findbugs
 truffle-findbugs-report.html

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -143,6 +143,14 @@ that on-stack-replacement works and so on.
 $ jt test compiler
 ```
 
+## Using Docker
+
+Docker can be a useful tool for creating isolated environments for development
+and testing. Dockerfiles can also serve as executable documentation of how to
+set up a development environment. See `test/truffle/docker` and `tool/docker`.
+
+For end-users, see `../user/docker.md`.
+
 ## How to fix a failing spec
 
 We usually use the `jt untag` command to work on failing specs. It runs only

--- a/test/truffle/docker/README.md
+++ b/test/truffle/docker/README.md
@@ -1,0 +1,21 @@
+# Docker Test Images
+
+These are Dockerfiles to test TruffleRuby builds on different Linux
+distributions. They could also serve as sources on which to base a deployment
+image, but we'd recommend the official GraalVM Dockerfile for that.
+
+https://github.com/oracle/docker-images/tree/master/GraalVM
+
+We have images for OracleLinux, which should translate to other distributions
+based on the RedHat architecture, and Ubuntu, which should translate to other
+distributions based on the Debian architecture.
+
+These Dockerfiles run the tests as part of the build, so if the image
+successfully builds then the tests have all passed.
+
+You need to put the built GraalVM binary tarball into the same directory as the
+Dockerfile, and update the Dockerfile for the version.
+
+```
+$ docker build -t truffleruby-test-oraclelinux .
+```

--- a/test/truffle/docker/oraclelinux/Dockerfile
+++ b/test/truffle/docker/oraclelinux/Dockerfile
@@ -1,0 +1,42 @@
+FROM oraclelinux:7.3
+
+MAINTAINER chris.seaton@oracle.com
+
+# We need a conventional locale for testing
+ENV LANG=en_US.UTF-8
+
+# Tools we will need to get and run our tests
+RUN yum install -y git-1.8.3.1 which-2.20
+
+# Create a user and working directory
+WORKDIR /test
+RUN useradd -ms /bin/bash test
+RUN chown test /test
+USER test
+
+# Extract the GraalVM binary tarball
+ENV GRAALVM_VERSION=0.24
+ADD graalvm-$GRAALVM_VERSION-linux-amd64-jdk8.tar.gz /test
+ENV PATH=/test/graalvm-$GRAALVM_VERSION/bin:$PATH
+
+# Straight away, just run the ruby executable as the most basic test
+RUN ruby --version
+
+# Clone the TruffleRuby source code to get tests
+RUN git clone --depth 1 https://github.com/graalvm/truffleruby.git
+
+# We just want specs and tests - we don't want to accidentally use anything else so we're actually going to delete the rest
+RUN cp -r truffleruby/spec .
+RUN cp -r truffleruby/test .
+RUN rm -rf truffleruby
+
+# Run language specs with compilation disabled as another basic test
+RUN ruby \
+spec/mspec/bin/mspec \
+--config spec/truffle.mspec \
+--excl-tag slow \
+--excl-tag fails \
+--excl-tag graalvm \
+-t ruby \
+-T -J-Dgraal.TruffleCompileOnly=nothing \
+:language

--- a/test/truffle/docker/ubuntu/Dockerfile
+++ b/test/truffle/docker/ubuntu/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:17.10
+
+MAINTAINER chris.seaton@oracle.com
+
+# We need a conventional locale for testing
+ENV LANG=en_US.UTF-8
+
+# Tools we will need to get and run our tests
+RUN apt-get update
+RUN apt-get install -y git=1:2.11.0-4
+
+# Create a user and working directory
+WORKDIR /test
+RUN useradd -ms /bin/bash test
+RUN chown test /test
+USER test
+
+# Extract the GraalVM binary tarball
+ENV GRAALVM_VERSION=0.24
+ADD graalvm-$GRAALVM_VERSION-linux-amd64-jdk8.tar.gz /test
+ENV PATH=/test/graalvm-$GRAALVM_VERSION/bin:$PATH
+
+# Straight away, just run the ruby executable as the most basic test
+RUN ruby --version
+
+# Clone the TruffleRuby source code to get tests
+RUN git clone --depth 1 https://github.com/graalvm/truffleruby.git
+
+# We just want specs and tests - we don't want to accidentally use anything else so we're actually going to delete the rest
+RUN cp -r truffleruby/spec .
+RUN cp -r truffleruby/test .
+RUN rm -rf truffleruby
+
+# Run language specs with compilation disabled as another basic test
+RUN ruby \
+spec/mspec/bin/mspec \
+--config spec/truffle.mspec \
+--excl-tag slow \
+--excl-tag fails \
+--excl-tag graalvm \
+-t ruby \
+-T -J-Dgraal.TruffleCompileOnly=nothing \
+:language

--- a/tool/docker/README.md
+++ b/tool/docker/README.md
@@ -1,0 +1,21 @@
+# Docker Development Images
+
+These are Dockerfiles to build an image for developing TruffleRuby, rather than
+for using it. It's useful to have a reproducible environment for build issues,
+and useful for building and testing on Linux if you normally develop on macOS.
+
+It also serves as a nice executable documentation of how to build TruffleRuby
+from scratch, on different distributions. We have images for OracleLinux, which
+should translate to other distributions based on the RedHat architecture, and
+Ubuntu, which should translate to other distributions based on the Debian
+architecture.
+
+We've tried to document versions of everything in here to keep it really stable,
+but our source repositories aren't versioned. If you are trying to make a
+reproducible build you should note down the versions of these. We've also tried
+to list the minimal set of packages needed.
+
+```
+$ docker build -t truffleruby-dev-oraclelinux .
+$ docker run -it truffleruby-dev-oraclelinux
+```

--- a/tool/docker/oraclelinux/Dockerfile
+++ b/tool/docker/oraclelinux/Dockerfile
@@ -1,0 +1,62 @@
+FROM oraclelinux:7.3
+
+MAINTAINER chris.seaton@oracle.com
+
+# We need a conventional locale for testing
+ENV LANG=en_US.UTF-8
+
+# To clone source repositories
+RUN yum install -y git-1.8.3.1 mercurial-2.6.2
+
+# To bootstrap our own JVMCI-comptaible JDK we need a JDK
+RUN yum install -y java-1.8.0-openjdk-devel-1.8.0.131
+
+# Other dependencies for building a JDK
+RUN yum install -y make-3.82 gcc-4.8.5 gcc-c++-4.8.5
+
+# We need also need libstdc++-static, which isn't available by default
+RUN yum-config-manager --add-repo http://public-yum.oracle.com/repo/OracleLinux/OL7/optional/latest/x86_64/
+RUN yum install -y libstdc++-static-4.8.5
+
+# To build Sulong and TruffleRuby's C extensions
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y clang-3.4.2
+
+# To build TruffleRuby
+RUN yum install -y ruby-2.0.0.648 openssl-devel-1.0.1e which-2.20
+ENV OPENSSL_LIB_HOME=/usr/lib64
+
+# Create a user and working directory
+WORKDIR /build
+RUN useradd -ms /bin/bash build
+RUN chown build /build
+USER build
+
+# Get the mx build tool
+RUN git clone https://github.com/graalvm/mx.git
+ENV PATH=$PATH:/build/mx
+
+# Build a JDK with JVMCI
+RUN hg clone http://hg.openjdk.java.net/graal/graal-jvmci-8
+RUN cd graal-jvmci-8 && mx build
+ENV JAVA_HOME=/build/graal-jvmci-8/jdk1.8.0_131/product
+
+# Build the Graal compiler
+RUN git clone https://github.com/graalvm/graal.git
+RUN cd graal/compiler && mx build
+ENV GRAAL_HOME=/build/graal/compiler
+
+# Build Sulong
+RUN git clone https://github.com/graalvm/sulong.git
+RUN cd sulong && mx build
+ENV SULONG_HOME=/build/sulong
+
+# Build TruffleRuby
+RUN git clone https://github.com/graalvm/truffleruby.git
+RUN cd truffleruby && mx build
+RUN cd truffleruby && ruby tool/jt.rb build cexts
+
+# Run a basic set of tests
+RUN cd truffleruby && ruby tool/jt.rb test fast :language
+RUN cd truffleruby && ruby tool/jt.rb test --sulong :openssl
+RUN cd truffleruby && ruby tool/jt.rb test compiler

--- a/tool/docker/ubuntu/Dockerfile
+++ b/tool/docker/ubuntu/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:17.10
+
+MAINTAINER chris.seaton@oracle.com
+
+# We need a conventional locale for testing
+ENV LANG=en_US.UTF-8
+
+RUN apt-get update
+
+# To clone source repositories
+RUN apt-get install -y git=1:2.11.0-4 mercurial=3.9.1-1
+
+# To bootstrap our own JVMCI-comptaible JDK we need a JDK
+RUN apt-get install -y openjdk-8-jdk=8u131-b11-2ubuntu1 openjdk-8-source=8u131-b11-2ubuntu1
+
+# Other dependencies for building a JDK
+RUN apt-get install -y make=4.1-9.1 gcc=4:6.3.0-2ubuntu1 g++=4:6.3.0-2ubuntu1
+
+# To build Sulong and TruffleRuby's C extensions
+RUN apt-get install -y clang=1:4.0-36ubuntu3 llvm-dev=1:4.0-36ubuntu3 libc++-dev=3.9.1-2 libc++abi-dev=3.9.1-2
+
+# To build TruffleRuby
+RUN apt-get install -y ruby=1:2.3.3 libssl-dev=1.0.2g-1ubuntu13
+ENV OPENSSL_LIB=/usr/lib/x86_64-linux-gnu/libssl.so
+
+# Create a user and working directory
+WORKDIR /build
+RUN useradd -ms /bin/bash build
+RUN chown build /build
+USER build
+
+# Get the mx build tool
+RUN git clone https://github.com/graalvm/mx.git
+ENV PATH=$PATH:/build/mx
+
+# Build a JDK with JVMCI
+RUN hg clone http://hg.openjdk.java.net/graal/graal-jvmci-8
+RUN cd graal-jvmci-8 && mx build
+ENV JAVA_HOME=/build/graal-jvmci-8/jdk1.8.0_131/product
+
+# Build the Graal compiler
+RUN git clone https://github.com/graalvm/graal.git
+RUN cd graal/compiler && mx build
+ENV GRAAL_HOME=/build/graal/compiler
+
+# Build Sulong
+RUN git clone https://github.com/graalvm/sulong.git
+RUN cd sulong && mx build
+ENV SULONG_HOME=/build/sulong
+
+# Build TruffleRuby
+RUN git clone https://github.com/graalvm/truffleruby.git
+RUN cd truffleruby && mx build
+RUN cd truffleruby && ruby tool/jt.rb build cexts
+
+# Run a basic set of tests
+RUN cd truffleruby && ruby tool/jt.rb test fast :language
+RUN cd truffleruby && ruby tool/jt.rb test --sulong :openssl
+RUN cd truffleruby && ruby tool/jt.rb test compiler


### PR DESCRIPTION
This is two pair of Dockerfiles.

The first pair takes a binary GraalVM tarball and runs tests on Ruby in it. It gets the tests from our repo, but deletes all other files so we don't accidentally depend on having a source repo to pass the tests. It also doesn't even have a system Ruby to get confused with. There is an Oracle Linux and Ubuntu version for people using GraalVM on those different distributions in case that makes a difference. This simulates someone who has never had GraalVM before downloading the tarball and trying to run it. This should be our final tier of testing.

The second pair sets up a complete development environment for TruffleRuby, including Sulong and Graal, from source, again on Oracle Linux and Ubuntu. This is useful for testing Linux from macOS, but it also serves as executable documentation of how to set up a development environment.

I might do openSUSE versions as well - I think that would cover the three major Linux distribution architectures, but I'm not really an expert on that.

Ideally if we had Docker in our CI we could run these there.