### PR TITLE
Rope dispatch fixes

### DIFF
--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -245,6 +245,7 @@ public abstract class BasicObjectNodes {
 
         @Child private YieldNode yield = new YieldNode(DeclarationContext.INSTANCE_EVAL);
 
+        @TruffleBoundary
         @Specialization(guards = { "isRubyString(string)", "isRubyString(fileName)" })
         public Object instanceEval(Object receiver, DynamicObject string, DynamicObject fileName, int line, NotProvided block,
                 @Cached("create()") IndirectCallNode callNode) {
@@ -277,18 +278,15 @@ public abstract class BasicObjectNodes {
             return yield.dispatchWithModifiedSelf(block, receiver, receiver);
         }
 
-        @TruffleBoundary
         private String getSpace(int line) {
             final String s = new String(new char[Math.max(line - 1, 0)]);
             return StringUtils.replace(s, "\0", "\n");
         }
 
-        @TruffleBoundary
         private String ropeToString(Rope rope) {
             return rope.toString();
         }
 
-        @TruffleBoundary
         private Source loadFragment(String fragment, String name) {
             return Source.newBuilder(fragment).name(name).mimeType(RubyLanguage.MIME_TYPE).build();
         }

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -37,6 +37,7 @@ import org.truffleruby.core.cast.BooleanCastNodeGen;
 import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.core.rope.Rope;
+import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.language.NotProvided;
@@ -253,7 +254,7 @@ public abstract class BasicObjectNodes {
 
             // TODO (pitr 15-Oct-2015): fix this ugly hack, required for AS, copy-paste
             final String space = getSpace(line);
-            final Source source = loadFragment(space + ropeToString(code), ropeToString(StringOperations.rope(fileName)));
+            final Source source = loadFragment(space + RopeOperations.decodeRope(code), RopeOperations.decodeRope(StringOperations.rope(fileName)));
 
             final RubyRootNode rootNode = getContext().getCodeLoader().parse(source, code.getEncoding(), ParserContext.EVAL, null, true, this);
             final CodeLoader.DeferredCall deferredCall = getContext().getCodeLoader().prepareExecute(ParserContext.EVAL, DeclarationContext.INSTANCE_EVAL, rootNode, null, receiver);
@@ -281,10 +282,6 @@ public abstract class BasicObjectNodes {
         private String getSpace(int line) {
             final String s = new String(new char[Math.max(line - 1, 0)]);
             return StringUtils.replace(s, "\0", "\n");
-        }
-
-        private String ropeToString(Rope rope) {
-            return rope.toString();
         }
 
         private Source loadFragment(String fragment, String name) {

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -252,7 +252,7 @@ public abstract class BasicObjectNodes {
 
             // TODO (pitr 15-Oct-2015): fix this ugly hack, required for AS, copy-paste
             final String space = getSpace(line);
-            final Source source = loadFragment(space + code.toString(), StringOperations.rope(fileName).toString());
+            final Source source = loadFragment(space + ropeToString(code), ropeToString(StringOperations.rope(fileName)));
 
             final RubyRootNode rootNode = getContext().getCodeLoader().parse(source, code.getEncoding(), ParserContext.EVAL, null, true, this);
             final CodeLoader.DeferredCall deferredCall = getContext().getCodeLoader().prepareExecute(ParserContext.EVAL, DeclarationContext.INSTANCE_EVAL, rootNode, null, receiver);
@@ -281,6 +281,11 @@ public abstract class BasicObjectNodes {
         private String getSpace(int line) {
             final String s = new String(new char[Math.max(line - 1, 0)]);
             return StringUtils.replace(s, "\0", "\n");
+        }
+
+        @TruffleBoundary
+        private String ropeToString(Rope rope) {
+            return rope.toString();
         }
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
@@ -389,12 +389,13 @@ public abstract class EncodingConverterNodes {
 
         @Specialization
         public DynamicObject setReplacement(DynamicObject encodingConverter, DynamicObject replacement,
-                                            @Cached("create()") BranchProfile errorProfile) {
+                @Cached("create()") BranchProfile errorProfile,
+                @Cached("create()") RopeNodes.BytesNode bytesNode) {
             final EConv ec = Layouts.ENCODING_CONVERTER.getEconv(encodingConverter);
             final Rope rope = StringOperations.rope(replacement);
             final Encoding encoding = rope.getEncoding();
 
-            final int ret = TranscodingManager.setReplacement(ec, rope.getBytes(), 0, rope.byteLength(), encoding.getName());
+            final int ret = TranscodingManager.setReplacement(ec, bytesNode.execute(rope), 0, rope.byteLength(), encoding.getName());
 
             if (ret == -1) {
                 errorProfile.enter();

--- a/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
@@ -107,7 +107,8 @@ public abstract class ToStringNode extends FormatNode {
     }
 
     @Specialization(guards = "isRubyArray(array)")
-    public byte[] toString(VirtualFrame frame, DynamicObject array) {
+    public byte[] toString(VirtualFrame frame, DynamicObject array,
+            @Cached("create()") RopeNodes.BytesNode bytesNode) {
         if (toSNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             toSNode = insert(new CallDispatchHeadNode(true, MissingBehavior.RETURN_MISSING));
@@ -120,7 +121,7 @@ public abstract class ToStringNode extends FormatNode {
                 setTainted(frame);
             }
 
-            return Layouts.STRING.getRope((DynamicObject) value).getBytes();
+            return bytesNode.execute(Layouts.STRING.getRope((DynamicObject) value));
         } else {
             throw new NoImplicitConversionException(array, "String");
         }

--- a/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
@@ -128,7 +128,8 @@ public abstract class ToStringNode extends FormatNode {
     }
 
     @Specialization(guards = {"!isRubyString(object)", "!isRubyArray(object)", "!isForeignObject(object)"})
-    public byte[] toString(VirtualFrame frame, Object object) {
+    public byte[] toString(VirtualFrame frame, Object object,
+            @Cached("create()") RopeNodes.BytesNode bytesNode) {
         final Object value = getToStrNode().call(frame, object, conversionMethod);
 
         if (RubyGuards.isRubyString(value)) {

--- a/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
@@ -136,7 +136,7 @@ public abstract class ToStringNode extends FormatNode {
                 setTainted(frame);
             }
 
-            return Layouts.STRING.getRope((DynamicObject) value).getBytes();
+            return bytesNode.execute(Layouts.STRING.getRope((DynamicObject) value));
         }
 
         if (inspectOnConversionFailure) {
@@ -145,7 +145,7 @@ public abstract class ToStringNode extends FormatNode {
                 inspectNode = insert(KernelNodesFactory.ToSNodeFactory.create(null));
             }
 
-            return Layouts.STRING.getRope(inspectNode.toS(object)).getBytes();
+            return bytesNode.execute(Layouts.STRING.getRope(inspectNode.toS(object)));
         } else {
             throw new NoImplicitConversionException(object, "String");
         }

--- a/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/convert/ToStringNode.java
@@ -98,7 +98,7 @@ public abstract class ToStringNode extends FormatNode {
                     setTainted(frame);
                 }
 
-                return Layouts.STRING.getRope((DynamicObject) value).getBytes();
+                return bytesNode.execute(Layouts.STRING.getRope((DynamicObject) value));
             } else {
                 throw new NoImplicitConversionException(string, "String");
             }

--- a/src/main/java/org/truffleruby/core/rope/ConcatRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ConcatRope.java
@@ -12,7 +12,7 @@ package org.truffleruby.core.rope;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import org.jcodings.Encoding;
 
-public class ConcatRope extends Rope {
+public class ConcatRope extends OnHeapRope {
 
     private final Rope left;
     private final Rope right;

--- a/src/main/java/org/truffleruby/core/rope/ConcatRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ConcatRope.java
@@ -12,7 +12,7 @@ package org.truffleruby.core.rope;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import org.jcodings.Encoding;
 
-public class ConcatRope extends OnHeapRope {
+public class ConcatRope extends ManagedRope {
 
     private final Rope left;
     private final Rope right;

--- a/src/main/java/org/truffleruby/core/rope/LazyRope.java
+++ b/src/main/java/org/truffleruby/core/rope/LazyRope.java
@@ -11,7 +11,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public abstract class LazyRope extends OnHeapRope {
+public abstract class LazyRope extends ManagedRope {
 
     protected LazyRope(Encoding encoding, int byteLength, int characterLength) {
         super(encoding, CodeRange.CR_7BIT, true, byteLength, characterLength, 1, null);

--- a/src/main/java/org/truffleruby/core/rope/LazyRope.java
+++ b/src/main/java/org/truffleruby/core/rope/LazyRope.java
@@ -11,7 +11,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public abstract class LazyRope extends Rope {
+public abstract class LazyRope extends OnHeapRope {
 
     protected LazyRope(Encoding encoding, int byteLength, int characterLength) {
         super(encoding, CodeRange.CR_7BIT, true, byteLength, characterLength, 1, null);

--- a/src/main/java/org/truffleruby/core/rope/LeafRope.java
+++ b/src/main/java/org/truffleruby/core/rope/LeafRope.java
@@ -11,7 +11,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public abstract class LeafRope extends OnHeapRope {
+public abstract class LeafRope extends ManagedRope {
 
     public LeafRope(byte[] bytes, Encoding encoding, CodeRange codeRange, boolean singleByteOptimizable, int characterLength) {
         super(encoding, codeRange, singleByteOptimizable, bytes.length, characterLength, 1, bytes);

--- a/src/main/java/org/truffleruby/core/rope/LeafRope.java
+++ b/src/main/java/org/truffleruby/core/rope/LeafRope.java
@@ -11,7 +11,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public abstract class LeafRope extends Rope {
+public abstract class LeafRope extends OnHeapRope {
 
     public LeafRope(byte[] bytes, Encoding encoding, CodeRange codeRange, boolean singleByteOptimizable, int characterLength) {
         super(encoding, codeRange, singleByteOptimizable, bytes.length, characterLength, 1, bytes);

--- a/src/main/java/org/truffleruby/core/rope/ManagedRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ManagedRope.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
 package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;

--- a/src/main/java/org/truffleruby/core/rope/ManagedRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ManagedRope.java
@@ -2,9 +2,9 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public abstract class OnHeapRope extends Rope {
+public abstract class ManagedRope extends Rope {
 
-    protected OnHeapRope(Encoding encoding, CodeRange codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth, byte[] bytes) {
+    protected ManagedRope(Encoding encoding, CodeRange codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth, byte[] bytes) {
         super(encoding, codeRange, singleByteOptimizable, byteLength, characterLength, ropeDepth, bytes);
     }
 

--- a/src/main/java/org/truffleruby/core/rope/OnHeapRope.java
+++ b/src/main/java/org/truffleruby/core/rope/OnHeapRope.java
@@ -1,0 +1,28 @@
+package org.truffleruby.core.rope;
+
+import org.jcodings.Encoding;
+
+public abstract class OnHeapRope extends Rope {
+
+    protected OnHeapRope(Encoding encoding, CodeRange codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth, byte[] bytes) {
+        super(encoding, codeRange, singleByteOptimizable, byteLength, characterLength, ropeDepth, bytes);
+    }
+
+    public final boolean bytesSet() {
+        return bytes != null;
+    }
+
+    public final byte[] getBytesFast() {
+        return bytes;
+    }
+
+    @Override
+    public final byte[] getBytes() {
+        if (bytes == null) {
+            bytes = getBytesSlow();
+        }
+
+        return bytes;
+    }
+
+}

--- a/src/main/java/org/truffleruby/core/rope/OnHeapRope.java
+++ b/src/main/java/org/truffleruby/core/rope/OnHeapRope.java
@@ -8,14 +8,6 @@ public abstract class OnHeapRope extends Rope {
         super(encoding, codeRange, singleByteOptimizable, byteLength, characterLength, ropeDepth, bytes);
     }
 
-    public final boolean bytesSet() {
-        return bytes != null;
-    }
-
-    public final byte[] getBytesFast() {
-        return bytes;
-    }
-
     @Override
     public final byte[] getBytes() {
         if (bytes == null) {

--- a/src/main/java/org/truffleruby/core/rope/RepeatingRope.java
+++ b/src/main/java/org/truffleruby/core/rope/RepeatingRope.java
@@ -12,7 +12,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public class RepeatingRope extends OnHeapRope {
+public class RepeatingRope extends ManagedRope {
 
     private final Rope child;
     private final int times;

--- a/src/main/java/org/truffleruby/core/rope/RepeatingRope.java
+++ b/src/main/java/org/truffleruby/core/rope/RepeatingRope.java
@@ -12,7 +12,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public class RepeatingRope extends Rope {
+public class RepeatingRope extends OnHeapRope {
 
     private final Rope child;
     private final int times;

--- a/src/main/java/org/truffleruby/core/rope/Rope.java
+++ b/src/main/java/org/truffleruby/core/rope/Rope.java
@@ -11,6 +11,9 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 import org.truffleruby.core.Hashing;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
 import java.util.Arrays;
 
 public abstract class Rope {
@@ -95,6 +98,7 @@ public abstract class Rope {
     protected static final int MURMUR_SEED = System.identityHashCode(Rope.class);
 
     @Override
+    @TruffleBoundary
     public int hashCode() {
         if (!isHashCodeCalculated()) {
             long hash = Hashing.hash(MURMUR_SEED, RopeOperations.hashForRange(this, 1, 0, byteLength));
@@ -106,6 +110,14 @@ public abstract class Rope {
 
     public final boolean isHashCodeCalculated() {
         return hashCode != 0;
+    }
+
+    public final int calculatedHashCode() {
+        return hashCode;
+    }
+
+    public final boolean hashesMatch(Rope other) {
+        return (isHashCodeCalculated() && hashCode == other.hashCode) || (hashCode() == other.hashCode());
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/rope/Rope.java
+++ b/src/main/java/org/truffleruby/core/rope/Rope.java
@@ -59,13 +59,7 @@ public abstract class Rope {
         return bytes;
     }
 
-    public byte[] getBytes() {
-        if (bytes == null) {
-            bytes = getBytesSlow();
-        }
-
-        return bytes;
-    }
+    public abstract byte[] getBytes();
 
     protected byte[] getBytesSlow() {
         return RopeOperations.flattenBytes(this);

--- a/src/main/java/org/truffleruby/core/rope/Rope.java
+++ b/src/main/java/org/truffleruby/core/rope/Rope.java
@@ -111,7 +111,7 @@ public abstract class Rope {
     }
 
     public final boolean hashesMatch(Rope other) {
-        return (isHashCodeCalculated() && hashCode == other.hashCode) || (hashCode() == other.hashCode());
+        return !isHashCodeCalculated() || !other.isHashCodeCalculated() || (hashCode == other.hashCode);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -1204,6 +1204,7 @@ public abstract class RopeNodes {
             return rope.getRawBytes();
         }
 
+        @Specialization
         public byte[] getBytesNative(NativeRope rope) {
             return rope.getBytes();
         }

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -1276,7 +1276,7 @@ public abstract class RopeNodes {
             return ropeProfile.profile(rope).getBytesCopy();
         }
 
-        @Specialization(guards = "!rope.bytesSet()")
+        @Specialization(guards = "!rope.bytesSet()", replaces = "getBytesCopyFromRope")
         @TruffleBoundary
         public byte[] getBytesFromRope(OnHeapRope rope) {
             return rope.getBytesCopy();

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -932,8 +932,9 @@ public abstract class RopeNodes {
                 "!isAsciiCompatibleChange(rope, encoding)"
         })
         public Rope withEncoding(Rope rope, Encoding encoding, CodeRange codeRange,
-                                 @Cached("create()") MakeLeafRopeNode makeLeafRopeNode) {
-            return makeLeafRopeNode.executeMake(rope.getBytes(), encoding, codeRange, NotProvided.INSTANCE);
+                @Cached("create()") MakeLeafRopeNode makeLeafRopeNode,
+                @Cached("create()") RopeNodes.BytesNode bytesNode) {
+            return makeLeafRopeNode.executeMake(bytesNode.execute(rope), encoding, codeRange, NotProvided.INSTANCE);
         }
 
         protected static boolean isAsciiCompatibleChange(Rope rope, Encoding encoding) {

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -1210,15 +1210,14 @@ public abstract class RopeNodes {
     })
     public abstract static class ByteSlowNode extends RubyNode {
 
-    public static ByteSlowNode create() {
+        public static ByteSlowNode create() {
             return RopeNodesFactory.ByteSlowNodeGen.create(null, null);
         }
 
         public abstract byte execute(Rope rope, int index);
 
         @Specialization
-        public byte getByteFromSubString(SubstringRope rope,
-                int index,
+        public byte getByteFromSubString(SubstringRope rope, int index,
                 @Cached("create()") ByteSlowNode childNode) {
             return childNode.execute(rope.getChild(), rope.getOffset() + index);
         }
@@ -1233,8 +1232,8 @@ public abstract class RopeNodes {
             return rope.getByteSlow(index);
         }
 
-        @Specialization(guards = "rope.getRawBytes() == null")
         @TruffleBoundary
+        @Specialization(guards = "rope.getRawBytes() == null")
         public byte getByteFromRope(ManagedRope rope, int index) {
             return rope.getByteSlow(index);
         }
@@ -1265,8 +1264,8 @@ public abstract class RopeNodes {
             return rope.getRawBytes().clone();
         }
 
-        @Specialization(guards = "rope.getRawBytes() == null")
         @TruffleBoundary
+        @Specialization(guards = "rope.getRawBytes() == null")
         public byte[] getBytesFromRope(ManagedRope rope) {
             return rope.getBytesCopy();
         }

--- a/src/main/java/org/truffleruby/core/rope/SubstringRope.java
+++ b/src/main/java/org/truffleruby/core/rope/SubstringRope.java
@@ -12,7 +12,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public class SubstringRope extends OnHeapRope {
+public class SubstringRope extends ManagedRope {
 
     private final Rope child;
     private final int offset;

--- a/src/main/java/org/truffleruby/core/rope/SubstringRope.java
+++ b/src/main/java/org/truffleruby/core/rope/SubstringRope.java
@@ -12,7 +12,7 @@ package org.truffleruby.core.rope;
 
 import org.jcodings.Encoding;
 
-public class SubstringRope extends Rope {
+public class SubstringRope extends OnHeapRope {
 
     private final Rope child;
     private final int offset;

--- a/src/main/java/org/truffleruby/core/rubinius/ByteArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/rubinius/ByteArrayNodes.java
@@ -23,6 +23,7 @@ import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeBuilder;
+import org.truffleruby.core.rope.RopeNodes;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.control.RaiseException;
@@ -62,13 +63,14 @@ public abstract class ByteArrayNodes {
     public abstract static class PrependNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = "isRubyString(string)")
-        public DynamicObject prepend(DynamicObject bytes, DynamicObject string) {
+        public DynamicObject prepend(DynamicObject bytes, DynamicObject string,
+                @Cached("create()") RopeNodes.BytesNode bytesNode) {
             final Rope rope = StringOperations.rope(string);
             final int prependLength = rope.byteLength();
             final int originalLength = Layouts.BYTE_ARRAY.getBytes(bytes).getUnsafeBytes().length;
             final int newLength = prependLength + originalLength;
             final byte[] prependedBytes = new byte[newLength];
-            System.arraycopy(rope.getBytes(), 0, prependedBytes, 0, prependLength);
+            System.arraycopy(bytesNode.execute(rope), 0, prependedBytes, 0, prependLength);
             System.arraycopy(Layouts.BYTE_ARRAY.getBytes(bytes).getUnsafeBytes(), 0, prependedBytes, prependLength, originalLength);
             return ByteArrayNodes.createByteArray(coreLibrary().getByteArrayFactory(), RopeBuilder.createRopeBuilder(prependedBytes));
         }

--- a/src/main/java/org/truffleruby/core/rubinius/IOBufferNodes.java
+++ b/src/main/java/org/truffleruby/core/rubinius/IOBufferNodes.java
@@ -55,6 +55,7 @@ import org.truffleruby.core.exception.ExceptionOperations;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeBuffer;
 import org.truffleruby.core.rope.RopeBuilder;
+import org.truffleruby.core.rope.RopeNodes;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.control.RaiseException;
@@ -86,7 +87,8 @@ public abstract class IOBufferNodes {
 
         @Specialization(guards = "isRubyString(string)")
         public int unshift(DynamicObject ioBuffer, DynamicObject string, int startPosition, int used,
-                           @Cached("createBinaryProfile()") ConditionProfile ropeBufferProfile) {
+                @Cached("createBinaryProfile()") ConditionProfile ropeBufferProfile,
+                @Cached("create()") RopeNodes.BytesNode bytesNode) {
             final Rope rope = StringOperations.rope(string);
             final int available = IOBUFFER_SIZE - used;
 
@@ -99,7 +101,7 @@ public abstract class IOBufferNodes {
                 bytes = byteList.getUnsafeBytes();
                 written = byteList.getLength() - startPosition;
             } else {
-                bytes = rope.getBytes();
+                bytes = bytesNode.execute(rope);
                 written = rope.byteLength() - startPosition;
             }
 

--- a/src/main/java/org/truffleruby/core/string/StringCachingGuards.java
+++ b/src/main/java/org/truffleruby/core/string/StringCachingGuards.java
@@ -25,21 +25,6 @@ public abstract class StringCachingGuards {
         }
     }
 
-    public static boolean ropesEqual(DynamicObject string, Rope rope) {
-        if (RubyGuards.isRubyString(string)) {
-            final Rope stringRope = StringOperations.rope(string);
-
-            // equal below does not check encoding
-            if (stringRope.getEncoding() != rope.getEncoding()) {
-                return false;
-            }
-
-            return stringRope.equals(rope);
-        } else {
-            return false;
-        }
-    }
-
     public static int ropeLength(Rope rope) {
         return rope.byteLength();
     }

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -2375,7 +2375,8 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = "!isSingleByteOptimizable(string)")
-        public DynamicObject upcase(DynamicObject string) {
+        public DynamicObject upcase(DynamicObject string,
+                @Cached("create()") RopeNodes.BytesNode bytesNode) {
             final Rope rope = rope(string);
             final Encoding encoding = rope.getEncoding();
 
@@ -2387,7 +2388,7 @@ public abstract class StringNodes {
                 return nil();
             }
 
-            final RopeBuilder bytes = RopeOperations.toByteListCopy(rope);
+            final RopeBuilder bytes = RopeBuilder.createRopeBuilder(bytesNode.execute(rope), rope.getEncoding());
             final boolean modified = multiByteUpcase(encoding, bytes.getUnsafeBytes(), 0, bytes.getLength());
             if (modified) {
                 StringOperations.setRope(string, RopeOperations.ropeFromByteList(bytes, rope.getCodeRange()));

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -2848,9 +2848,8 @@ public abstract class StringNodes {
         public boolean fullEqual(DynamicObject string, DynamicObject other,
                                  @Cached("createBinaryProfile()") ConditionProfile hashCodesCalculatedProfile,
                                  @Cached("createBinaryProfile()") ConditionProfile differentHashCodesProfile,
-                                 @Cached("createBinaryProfile()") ConditionProfile aHasRawBytesProfile,
-                @Cached("createBinaryProfile()") ConditionProfile bHasRawBytesProfile,
-                @Cached("create()") RopeNodes.BytesNode bytesNode,
+                @Cached("create()") RopeNodes.BytesNode aBytesNode,
+                @Cached("create()") RopeNodes.BytesNode bBytesNode,
                 @Cached("create()") RopeNodes.HashNode hashNode) {
             final Rope a = rope(string);
             final Rope b = rope(other);
@@ -2861,19 +2860,8 @@ public abstract class StringNodes {
                 }
             }
 
-            final byte[] aBytes;
-            if (aHasRawBytesProfile.profile(a.getRawBytes() != null)) {
-                aBytes = a.getRawBytes();
-            } else {
-                aBytes = bytesNode.execute(a);
-            }
-
-            final byte[] bBytes;
-            if (bHasRawBytesProfile.profile(b.getRawBytes() != null)) {
-                bBytes = b.getRawBytes();
-            } else {
-                bBytes = b.getBytes();
-            }
+            final byte[] aBytes = aBytesNode.execute(a);
+            final byte[] bBytes = bBytesNode.execute(b);
 
             return arraysEquals(aBytes, bBytes);
         }

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -51,11 +51,13 @@ public final class StringSupport {
     public static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     // rb_enc_fast_mbclen
+    @TruffleBoundary
     public static int encFastMBCLen(byte[] bytes, int p, int e, Encoding enc) {
         return enc.length(bytes, p, e);
     }
 
     // rb_enc_mbclen
+    @TruffleBoundary
     public static int length(Encoding enc, byte[]bytes, int p, int end) {
         int n = enc.length(bytes, p, end);
         if (MBCLEN_CHARFOUND_P(n) && MBCLEN_CHARFOUND_LEN(n) <= end - p) return MBCLEN_CHARFOUND_LEN(n);

--- a/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -11,6 +11,7 @@ package org.truffleruby.language.dispatch;
 
 import org.truffleruby.RubyContext;
 import org.truffleruby.builtins.CallerFrameAccess;
+import org.truffleruby.core.rope.RopeNodes;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyRootNode;
@@ -46,6 +47,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
     private final boolean cachedNameIsRubyString;
 
     @Child protected DispatchNode next;
+    @Child private RopeNodes.EqualNode equalsNode = RopeNodes.EqualNode.create();
 
     private final BranchProfile moreThanReferenceCompare = BranchProfile.create();
 

--- a/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -47,7 +47,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
     private final boolean cachedNameIsRubyString;
 
     @Child protected DispatchNode next;
-    @Child private RopeNodes.EqualNode equalsNode = RopeNodes.EqualNode.create();
+    @Child private RopeNodes.BytesEqualNode equalsNode = RopeNodes.BytesEqualNode.create();
 
     private final BranchProfile moreThanReferenceCompare = BranchProfile.create();
 
@@ -144,7 +144,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
         if (cachedName instanceof String) {
             return cachedName.equals(methodName);
         } else if (cachedNameIsRubyString) {
-            return RubyGuards.isRubyString(methodName) && StringOperations.rope((DynamicObject) cachedName).equals(StringOperations.rope((DynamicObject) methodName));
+            return RubyGuards.isRubyString(methodName) && equalsNode.execute(StringOperations.rope((DynamicObject) cachedName), StringOperations.rope((DynamicObject) methodName));
         } else { // cachedName is a Symbol
             // cachedName == methodName was checked above and was not true,
             // and since Symbols are compared by identity we know they don't match.


### PR DESCRIPTION
Running tests and benchmarks with performance warnings set to be fatal revealed a large set of issues with our Rope implementation for strings. The root of the problem was that several methods on Rope either required virtual dispatch as they were non-final, or called other methods that had this issue.

Testing showed that adding boundaries round all these cases caused a significant performance drop in string heavy work loads such as webrick, while naively replacing these methods with nodes which split on the rope type and used profiles to ensure the dispatch could be removed also caused performance degradation.

To resolve this the Rope hierarchy has been refactored to help avoid virtual dispatch on common operations, and nodes introduced for common rope operations that can avoid truffle boundaries in most cases.