### PR TITLE
Basics of object allocation reporting - just user objects for now

### DIFF
--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -14,8 +14,10 @@ import com.oracle.truffle.api.CompilerOptions;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.TruffleOptions;
+import com.oracle.truffle.api.instrumentation.AllocationReporter;
 import com.oracle.truffle.api.instrumentation.Instrumenter;
 import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.object.DynamicObjectFactory;
 import org.truffleruby.builtins.PrimitiveManager;
 import org.truffleruby.core.CoreLibrary;
 import org.truffleruby.core.encoding.EncodingManager;
@@ -60,6 +62,8 @@ public class RubyContext {
     private final RubyLanguage language;
     private final TruffleLanguage.Env env;
 
+    private final AllocationReporter allocationReporter;
+
     private final Options options;
 
     private final String rubyHome;
@@ -100,6 +104,8 @@ public class RubyContext {
     public RubyContext(RubyLanguage language, TruffleLanguage.Env env) {
         this.language = language;
         this.env = env;
+
+        allocationReporter = env.lookup(AllocationReporter.class);
 
         final OptionsBuilder optionsBuilder = new OptionsBuilder();
         optionsBuilder.set(env.getOptions());           // Options from the SDK first as they always overwrite everything
@@ -226,6 +232,10 @@ public class RubyContext {
 
     public TruffleLanguage.Env getEnv() {
         return env;
+    }
+
+    public AllocationReporter getAllocationReporter() {
+        return allocationReporter;
     }
 
     public NativePlatform getNativePlatform() {


### PR DESCRIPTION
We want to report all allocations - but we're using the layout DSL which hides it from us!

We could:

* Manually report allocations around every use of the layout DSL allocate method
* Write a facade that reports the allocations then calls the layout DSL
* Modify the layout DSL to report allocations

We probably need to work out what is wanted from the users of this API more, and to think more about size estimation, before we do any work.