### PR TITLE
Use the system libssl more conventionally

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -146,7 +146,6 @@ sulong: ${labsjdk8} {
     GRAAL_HOME: "$PWD/../sulong",
     SULONG_HOME: "$PWD/../sulong",
     LIBXML_LIB: "/usr/lib64/libxml2.so.2",
-    OPENSSL_LIB: "/usr/lib64/libssl.so.10",
     HOST_VM: server,
     HOST_VM_CONFIG: graal-core
   }

--- a/doc/contributor/cexts.md
+++ b/doc/contributor/cexts.md
@@ -5,20 +5,28 @@
 TruffleRuby runs C extension using Sulong. You should build Sulong from source.
 Clone from https://github.com/graalvm/sulong
 
-You need LLVM installed - version 3.8 or above.
+You need LLVM installed - version 3.8 or above we think but we haven't tested
+many versions.
 
 We need the `opt` command, so you can't just use what is installed by Xcode if
 you are on macOS. We would recommend that you install LLVM via Homebrew (`brew
 install llvm`) and then manually set your path in shells where you are building
 Sulong or TruffleRuby (`export PATH="/usr/local/opt/llvm/bin:$PATH"`).
 
-You can now build the C extension support. Building the OpenSSL C extension is
-incomplete, so most people probably want to disable that with `--no-openssl`.
+You also need OpenSSL - version 1.0.1 or above we think but we haven't tested
+many versions. The system version of OpenSSL on macOS is too old, so you should
+install a new version, again via Homebrew (`brew install openssl`). If you are
+on macOS, or otherwise even if you just want to use a different version of
+OpenSSL you then need to set `OPENSSL_PREFIX` to tell us where to find it (for
+example `export OPENSSL_PREFIX=/usr/local/opt/openssl`
+if you installed from Homebrew).
+
+You can now build the C extension support.
 
 ```bash
 export SULONG_HOME=/absolute/path/to/sulong
 export PATH="/usr/local/opt/llvm/bin:$PATH"
-jt build cexts --no-openssl
+jt build cexts
 ```
 
 ## Testing
@@ -32,17 +40,28 @@ jt gem-test-pack
 You can then test C extension support.
 
 ```bash
-GEM_HOME=$(jt gem-test-pack)/gems jt test cexts --no-libxml --no-openssl
+export GEM_HOME=$(jt gem-test-pack)/gems
+jt test cexts --no-libxml
 ```
 
 If you want to test `libxml`, remove that flag and set either `LIBXML_HOME` or
-`LIBXML_INCLUDE` and `LIBXML_LIB`. Try the same with `OPENSSL_` if you are
-adventurous.
+`LIBXML_INCLUDE` and `LIBXML_LIB`.
 
 You can also runs specs:
 
 ```bash
 jt test --sulong :capi
+```
+
+### OpenSSL
+
+The `openssl` specs and tests are currently segregated and are run separately.
+We have patches to workaround `openssl` so you need to disable these to
+actually test it, with `-T-Xpatching=false`.
+
+```bash
+jt test -T-Xpatching=false --sulong :openssl
+jt test mri --openssl --sulong
 ```
 
 ## Benchmarking
@@ -64,38 +83,6 @@ C extension is actually being used by looking for these log lines.
 
 ```
 [ruby] INFO loading cext module ...
-```
-
-## OpenSSL
-
-To build the `openssl` gem you need to install the OpenSSL system library and configure the
-location to the OpenSSL header and library files. On macOS we use Homebrew and 1.0.2g.
-On Linux, it's probably safe to use your package manager's version of the OpenSSL dev package
-(just note that we currently test with 1.0.2g).
-For Homebrew you can simply set the `OPENSSL_HOME` variable to the Cellar location.
-For Linux users installing system packages, you may need
-to set one or more of `OPENSSL_LIB_HOME`, `OPENSSL_INCLUDE`, or `OPENSSL_LIB`.
-On Ubuntu, setting `OPENSSL_LIB_HOME` is sufficient.
-Once your environment variables are set, you can build the C extensions, including support for `openssl`.
-Note that if you do change any of the aforementioned environment variables you will need to recompile the extension.
-
-```bash
-# macOS
-OPENSSL_HOME=/usr/local/Cellar/openssl/1.0.2g jt build cexts
-
-# Linux, Ubuntu
-OPENSSL_LIB_HOME=/usr/lib/x86_64-linux-gnu jt build cexts
-# Linux, Fedora
-OPENSSL_LIB_HOME=/usr/lib64 jt build cexts
-```
-
-The `openssl` specs and tests are currently segregated and are run separately.
-We have patches to workaround `openssl` so you need to disable these to
-actually test it, with `-T-Xpatching=false`.
-
-```bash
-jt test -T-Xpatching=false --sulong :openssl
-jt test mri --openssl --sulong
 ```
 
 ## Tools

--- a/src/main/c/openssl/extconf.rb
+++ b/src/main/c/openssl/extconf.rb
@@ -26,8 +26,15 @@ have_flags = %w[
   OPENSSL_OCSP_H
 ]
 
-$CFLAGS += " -I #{ENV['OPENSSL_INCLUDE']} #{have_flags.map { |h| "-DHAVE_#{h}" }.join(' ')}"
-$LIBS += " -l #{ENV['OPENSSL_LIB']}"
+$CFLAGS += " #{have_flags.map { |h| "-DHAVE_#{h}" }.join(' ')}"
+
+if ENV['OPENSSL_PREFIX']
+  $CFLAGS += " -I #{ENV['OPENSSL_PREFIX']}/include"
+  $LIBS += " -l #{ENV['OPENSSL_PREFIX']}/lib/libssl.#{RbConfig::CONFIG['NATIVE_DLEXT']}"
+else
+  $LIBS += " -l libssl.#{RbConfig::CONFIG['NATIVE_DLEXT']}"
+end
+
 create_makefile('openssl')
 
 _not_applied_have_flags = %w[

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -58,6 +58,7 @@ module RbConfig
       'LDFLAGS'           => '',
       'DLDFLAGS'          => '',
       'DLEXT'             => 'su',
+      'NATIVE_DLEXT'      => RUBY_PLATFORM.include?('darwin') ? 'dylib' : 'so',
       'host_os'           => host_os,
       'host_cpu'          => host_cpu,
       'LIBEXT'            => 'c',

--- a/test/truffle/cexts/xopenssl/ext/xopenssl/extconf.rb
+++ b/test/truffle/cexts/xopenssl/ext/xopenssl/extconf.rb
@@ -1,4 +1,10 @@
 require 'mkmf'
-$CFLAGS += " -I #{ENV['OPENSSL_INCLUDE']}"
-$LIBS += " -l #{ENV['OPENSSL_LIB']}"
+
+if ENV['OPENSSL_PREFIX']
+  $CFLAGS += " -I #{ENV['OPENSSL_PREFIX']}/include"
+  $LIBS += " -l #{ENV['OPENSSL_PREFIX']}/lib/libssl.#{RbConfig::CONFIG['NATIVE_DLEXT']}"
+else
+  $LIBS += " -l libssl.#{RbConfig::CONFIG['NATIVE_DLEXT']}"
+end
+
 create_makefile('xopenssl')

--- a/tool/docker/oraclelinux/Dockerfile
+++ b/tool/docker/oraclelinux/Dockerfile
@@ -24,7 +24,6 @@ RUN yum install -y clang-3.4.2
 
 # To build TruffleRuby
 RUN yum install -y ruby-2.0.0.648 openssl-devel-1.0.1e which-2.20
-ENV OPENSSL_LIB_HOME=/usr/lib64
 
 # Create a user and working directory
 WORKDIR /build
@@ -53,6 +52,7 @@ ENV SULONG_HOME=/build/sulong
 
 # Build TruffleRuby
 RUN git clone https://github.com/graalvm/truffleruby.git
+RUN cd truffleruby && git checkout system-libssl
 RUN cd truffleruby && mx build
 RUN cd truffleruby && ruby tool/jt.rb build cexts
 

--- a/tool/docker/ubuntu/Dockerfile
+++ b/tool/docker/ubuntu/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get install -y clang=1:4.0-36ubuntu3 llvm-dev=1:4.0-36ubuntu3 libc++-dev
 
 # To build TruffleRuby
 RUN apt-get install -y ruby=1:2.3.3 libssl-dev=1.0.2g-1ubuntu13
-ENV OPENSSL_LIB=/usr/lib/x86_64-linux-gnu/libssl.so
 
 # Create a user and working directory
 WORKDIR /build


### PR DESCRIPTION
Rely on standard locations for system versions of libssl, without configuration, and don't hard code system paths of Linux shared objects because they won't be in the same place on different distributions.

`OPENSSL_PREFIX` is now the one way to override where OpenSSL is taken from and expected to be on deployment.