### PR TITLE
Make ProfileArgumentNode a DSL node

### DIFF
--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -34,6 +34,7 @@ import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadBlockNode;
 import org.truffleruby.language.arguments.ReadCallerFrameNode;
 import org.truffleruby.language.arguments.ReadPreArgumentNode;
@@ -221,7 +222,7 @@ public class CoreMethodNodeManager {
         final boolean needsSelf = needsSelf(method);
 
         if (needsSelf) {
-            RubyNode readSelfNode = new ProfileArgumentNode(new ReadSelfNode());
+            RubyNode readSelfNode = ProfileArgumentNodeGen.create(new ReadSelfNode());
             argumentsNodes.add(transformArgument(method, readSelfNode, 0));
         }
 
@@ -234,7 +235,7 @@ public class CoreMethodNodeManager {
         }
 
         for (int n = 0; n < nArgs; n++) {
-            RubyNode readArgumentNode = new ProfileArgumentNode(new ReadPreArgumentNode(n, MissingArgumentBehavior.UNDEFINED));
+            RubyNode readArgumentNode = ProfileArgumentNodeGen.create(new ReadPreArgumentNode(n, MissingArgumentBehavior.UNDEFINED));
             argumentsNodes.add(transformArgument(method, readArgumentNode, n + 1));
         }
 

--- a/src/main/java/org/truffleruby/builtins/PrimitiveNodeConstructor.java
+++ b/src/main/java/org/truffleruby/builtins/PrimitiveNodeConstructor.java
@@ -21,6 +21,7 @@ import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadPreArgumentNode;
 import org.truffleruby.language.arguments.ReadSelfNode;
 import org.truffleruby.parser.Translator;
@@ -47,12 +48,12 @@ public class PrimitiveNodeConstructor {
         final List<RubyNode> arguments = new ArrayList<>(argumentsCount);
 
         if (annotation.needsSelf()) {
-            arguments.add(transformArgument(new ProfileArgumentNode(new ReadSelfNode()), 0));
+            arguments.add(transformArgument(ProfileArgumentNodeGen.create(new ReadSelfNode()), 0));
             argumentsCount--;
         }
 
         for (int n = 0; n < argumentsCount; n++) {
-            RubyNode readArgumentNode = new ProfileArgumentNode(new ReadPreArgumentNode(n, MissingArgumentBehavior.UNDEFINED));
+            RubyNode readArgumentNode = ProfileArgumentNodeGen.create(new ReadPreArgumentNode(n, MissingArgumentBehavior.UNDEFINED));
             arguments.add(transformArgument(readArgumentNode, n + 1));
         }
 

--- a/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
@@ -487,7 +487,7 @@ public abstract class EncodingNodes {
 
     }
 
-    @Primitive(name = "encoding_get_encoding_by_index", needsSelf = false)
+    @Primitive(name = "encoding_get_encoding_by_index", needsSelf = false, lowerFixnum = 1)
     public static abstract class GetEncodingObjectByIndexNode extends PrimitiveArrayArgumentsNode {
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -66,6 +66,7 @@ import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadPreArgumentNode;
 import org.truffleruby.language.arguments.ReadSelfNode;
 import org.truffleruby.language.arguments.RubyArguments;
@@ -381,12 +382,12 @@ public abstract class ModuleNodes {
                     null,
                     false);
 
-            final RubyNode self = new ProfileArgumentNode(new ReadSelfNode());
+            final RubyNode self = ProfileArgumentNodeGen.create(new ReadSelfNode());
             final RubyNode accessInstanceVariable;
             if (isGetter) {
                 accessInstanceVariable = new ReadInstanceVariableNode(ivar, self);
             } else {
-                RubyNode readArgument = new ProfileArgumentNode(new ReadPreArgumentNode(0, MissingArgumentBehavior.RUNTIME_ERROR));
+                RubyNode readArgument = ProfileArgumentNodeGen.create(new ReadPreArgumentNode(0, MissingArgumentBehavior.RUNTIME_ERROR));
                 accessInstanceVariable = new WriteInstanceVariableNode(ivar, self, readArgument);
             }
             final RubyNode sequence = Translator.sequence(sourceIndexLength, Arrays.asList(checkArity, accessInstanceVariable));
@@ -1721,7 +1722,7 @@ public abstract class ModuleNodes {
     public abstract static class UndefMethodNode extends CoreMethodArrayArgumentsNode {
 
         @Child private NameToJavaStringNode nameToJavaStringNode = NameToJavaStringNode.create();
-        @Child private RaiseIfFrozenNode raiseIfFrozenNode = new RaiseIfFrozenNode(new ProfileArgumentNode(new ReadSelfNode()));
+        @Child private RaiseIfFrozenNode raiseIfFrozenNode = new RaiseIfFrozenNode(ProfileArgumentNodeGen.create(new ReadSelfNode()));
         @Child private CallDispatchHeadNode methodUndefinedNode = CallDispatchHeadNode.createOnSelf();
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3336,7 +3336,7 @@ public abstract class StringNodes {
         }
     }
 
-    @Primitive(name = "string_byte_character_index", needsSelf = false)
+    @Primitive(name = "string_byte_character_index", needsSelf = false, lowerFixnum = { 2, 3 })
     @ImportStatic(StringGuards.class)
     public static abstract class StringByteCharacterIndexNode extends PrimitiveArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/language/arguments/ProfileArgumentNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ProfileArgumentNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+ * Copyright (c) 2016, 2017 Oracle and/or its affiliates. All rights reserved. This
  * code is released under a tri EPL/GPL/LGPL license. You can use it,
  * redistribute it and/or modify it under the terms of the:
  *
@@ -9,37 +9,68 @@
  */
 package org.truffleruby.language.arguments;
 
-import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import com.oracle.truffle.api.profiles.ConditionProfile;
-import com.oracle.truffle.api.profiles.PrimitiveValueProfile;
-import com.oracle.truffle.api.profiles.ValueProfile;
 import org.truffleruby.language.RubyNode;
 
 @NodeInfo(cost = NodeCost.NONE)
-public class ProfileArgumentNode extends RubyNode {
+@NodeChild(value = "child", type = RubyNode.class)
+public abstract class ProfileArgumentNode extends RubyNode {
 
-    @Child private RubyNode readArgumentNode;
-
-    private final ConditionProfile objectProfile = ConditionProfile.createBinaryProfile();
-    private final ValueProfile primitiveProfile = PrimitiveValueProfile.createEqualityProfile();
-    private final ValueProfile classProfile = ValueProfile.createClassProfile();
-
-    public ProfileArgumentNode(RubyNode readArgumentNode) {
-        this.readArgumentNode = readArgumentNode;
+    @Specialization(guards = "value == cachedValue", limit = "1")
+    protected boolean cacheBoolean(boolean value,
+            @Cached("value") boolean cachedValue) {
+        return cachedValue;
     }
 
-    @Override
-    public Object execute(VirtualFrame frame) {
-        final Object value = readArgumentNode.execute(frame);
+    @Specialization(guards = "value == cachedValue", limit = "1")
+    protected int cacheInt(int value,
+            @Cached("value") int cachedValue) {
+        return cachedValue;
+    }
 
-        if (objectProfile.profile(value instanceof TruffleObject)) {
-            return classProfile.profile(value);
+    // We need this to avoid going to long once different int values are passed,
+    // due to the implicit cast int -> long.
+    @Specialization(replaces = "cacheInt")
+    protected int uncachedInt(int value) {
+        return value;
+    }
+
+    @Specialization(guards = "value == cachedValue", limit = "1")
+    protected long cacheLong(long value,
+            @Cached("value") long cachedValue) {
+        return cachedValue;
+    }
+
+    @Specialization(guards = "exactCompare(value, cachedValue)", limit = "1")
+    protected double cacheDouble(double value,
+            @Cached("value") double cachedValue) {
+        return cachedValue;
+    }
+
+    @Specialization(guards = "object.getClass() == cachedClass", limit = "1")
+    protected Object cacheClass(Object object,
+            @Cached("object.getClass()") Class<?> cachedClass) {
+        // The cast is only useful for the compiler.
+        if (CompilerDirectives.inInterpreter()) {
+            return object;
         } else {
-            return primitiveProfile.profile(value);
+            return cachedClass.cast(object);
         }
+    }
+
+    @Specialization(replaces = { "cacheBoolean", "cacheInt", "uncachedInt", "cacheLong", "cacheDouble", "cacheClass" })
+    protected Object unprofiled(Object object) {
+        return object;
+    }
+
+    protected static boolean exactCompare(double a, double b) {
+        // -0.0 == 0.0, but you can tell the difference through other means, so we need to differentiate.
+        return Double.doubleToRawLongBits(a) == Double.doubleToRawLongBits(b);
     }
 
 }

--- a/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
@@ -25,6 +25,7 @@ import org.truffleruby.language.arguments.ArrayIsAtLeastAsLargeAsNode;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.MissingKeywordArgumentNode;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadBlockNode;
 import org.truffleruby.language.arguments.ReadKeywordArgumentNode;
 import org.truffleruby.language.arguments.ReadKeywordRestArgumentNode;
@@ -317,7 +318,7 @@ public class LoadArgumentsTranslator extends Translator {
             return PrimitiveArrayNodeFactory.read(loadArray(sourceSection), index);
         } else {
             if (state == State.PRE) {
-                return new ProfileArgumentNode(new ReadPreArgumentNode(index, isProc ? MissingArgumentBehavior.NIL : MissingArgumentBehavior.RUNTIME_ERROR));
+                return ProfileArgumentNodeGen.create(new ReadPreArgumentNode(index, isProc ? MissingArgumentBehavior.NIL : MissingArgumentBehavior.RUNTIME_ERROR));
             } else if (state == State.POST) {
                 return new ReadPostArgumentNode(-index);
             } else {

--- a/src/main/java/org/truffleruby/parser/MethodTranslator.java
+++ b/src/main/java/org/truffleruby/parser/MethodTranslator.java
@@ -27,6 +27,7 @@ import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadBlockNode;
 import org.truffleruby.language.arguments.ReadPreArgumentNode;
 import org.truffleruby.language.arguments.ShouldDestructureNode;
@@ -111,7 +112,7 @@ public class MethodTranslator extends BodyTranslator {
 
         final RubyNode preludeProc;
         if (shouldConsiderDestructuringArrayArg(arity)) {
-            final RubyNode readArrayNode = new ProfileArgumentNode(new ReadPreArgumentNode(0, MissingArgumentBehavior.RUNTIME_ERROR));
+            final RubyNode readArrayNode = ProfileArgumentNodeGen.create(new ReadPreArgumentNode(0, MissingArgumentBehavior.RUNTIME_ERROR));
             final RubyNode castArrayNode = ArrayCastNodeGen.create(readArrayNode);
 
             final FrameSlot arraySlot = environment.declareVar(environment.allocateLocalTemp("destructure"));

--- a/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
@@ -20,6 +20,7 @@ import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadPreArgumentNode;
 import org.truffleruby.language.control.SequenceNode;
 import org.truffleruby.language.literal.ObjectLiteralNode;
@@ -141,7 +142,7 @@ public class ReloadArgumentsTranslator extends Translator {
 
     @Override
     public RubyNode visitMultipleAsgnNode(MultipleAsgnParseNode node) {
-        return new ProfileArgumentNode(new ReadPreArgumentNode(index, MissingArgumentBehavior.NIL));
+        return ProfileArgumentNodeGen.create(new ReadPreArgumentNode(index, MissingArgumentBehavior.NIL));
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/Translator.java
+++ b/src/main/java/org/truffleruby/parser/Translator.java
@@ -19,6 +19,7 @@ import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.arguments.CheckArityNode;
 import org.truffleruby.language.arguments.CheckKeywordArityNode;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadSelfNode;
 import org.truffleruby.language.control.SequenceNode;
 import org.truffleruby.language.literal.NilLiteralNode;
@@ -166,7 +167,7 @@ public abstract class Translator extends AbstractNodeVisitor<RubyNode> {
 
     public static RubyNode loadSelf(RubyContext context, TranslatorEnvironment environment) {
         final FrameSlot slot = environment.getFrameDescriptor().findOrAddFrameSlot(SelfNode.SELF_IDENTIFIER);
-        return new WriteLocalVariableNode(slot, new ProfileArgumentNode(new ReadSelfNode()));
+        return new WriteLocalVariableNode(slot, ProfileArgumentNodeGen.create(new ReadSelfNode()));
     }
 
     public static <T extends RubyNode> T withSourceSection(SourceIndexLength sourceSection, T node) {

--- a/src/main/java/org/truffleruby/parser/TranslatorDriver.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorDriver.java
@@ -56,6 +56,7 @@ import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.ProfileArgumentNode;
+import org.truffleruby.language.arguments.ProfileArgumentNodeGen;
 import org.truffleruby.language.arguments.ReadPreArgumentNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
@@ -219,7 +220,7 @@ public class TranslatorDriver {
 
             for (int n = 0; n < argumentNames.length; n++) {
                 final String name = argumentNames[n];
-                final RubyNode readNode = new ProfileArgumentNode(new ReadPreArgumentNode(n, MissingArgumentBehavior.NIL));
+                final RubyNode readNode = ProfileArgumentNodeGen.create(new ReadPreArgumentNode(n, MissingArgumentBehavior.NIL));
                 final FrameSlot slot = environment.getFrameDescriptor().findFrameSlot(name);
                 sequence.add(new WriteLocalVariableNode(slot, readNode));
             }


### PR DESCRIPTION
* Less expensive to compile.
* More control over what is profiled.
* No need for an expensive instanceof TruffleObject check.