### PR TITLE
Dispatch chain performance fixes

### DIFF
--- a/src/main/java/org/truffleruby/language/arguments/ProfileArgumentNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ProfileArgumentNode.java
@@ -52,7 +52,7 @@ public abstract class ProfileArgumentNode extends RubyNode {
         return cachedValue;
     }
 
-    @Specialization(guards = "object.getClass() == cachedClass", limit = "1")
+    @Specialization(guards = { "object != null", "object.getClass() == cachedClass" }, limit = "1")
     protected Object cacheClass(Object object,
             @Cached("object.getClass()") Class<?> cachedClass) {
         // The cast is only useful for the compiler.

--- a/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -43,6 +43,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
 
     private final Object cachedName;
     private final DynamicObject cachedNameAsSymbol;
+    private final boolean cachedNameIsRubyString;
 
     @Child protected DispatchNode next;
 
@@ -63,10 +64,13 @@ public abstract class CachedDispatchNode extends DispatchNode {
 
         if (RubyGuards.isRubySymbol(cachedName)) {
             cachedNameAsSymbol = (DynamicObject) cachedName;
+            cachedNameIsRubyString = false;
         } else if (RubyGuards.isRubyString(cachedName)) {
             cachedNameAsSymbol = context.getSymbolTable().getSymbol(StringOperations.rope((DynamicObject) cachedName));
+            cachedNameIsRubyString = true;
         } else if (cachedName instanceof String) {
             cachedNameAsSymbol = context.getSymbolTable().getSymbol((String) cachedName);
+            cachedNameIsRubyString = false;
         } else {
             throw new UnsupportedOperationException();
         }
@@ -138,7 +142,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
         } else if (RubyGuards.isRubySymbol(cachedName)) {
             // TODO(CS, 11-Jan-15) this just repeats the above guard...
             return cachedName == methodName;
-        } else if (RubyGuards.isRubyString(cachedName)) {
+        } else if (cachedNameIsRubyString) {
             return (RubyGuards.isRubyString(methodName)) && StringOperations.rope((DynamicObject) cachedName).equals(StringOperations.rope((DynamicObject) methodName));
         } else {
             CompilerDirectives.transferToInterpreterAndInvalidate();

--- a/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -140,8 +140,8 @@ public abstract class CachedDispatchNode extends DispatchNode {
         if (cachedName instanceof String) {
             return cachedName.equals(methodName);
         } else if (RubyGuards.isRubySymbol(cachedName)) {
-            // TODO(CS, 11-Jan-15) this just repeats the above guard...
-            return cachedName == methodName;
+            // The above guard already proved they are different
+            return false;
         } else if (cachedNameIsRubyString) {
             return RubyGuards.isRubyString(methodName) && StringOperations.rope((DynamicObject) cachedName).equals(StringOperations.rope((DynamicObject) methodName));
         } else {

--- a/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -141,6 +141,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
         } else if (RubyGuards.isRubyString(cachedName)) {
             return (RubyGuards.isRubyString(methodName)) && StringOperations.rope((DynamicObject) cachedName).equals(StringOperations.rope((DynamicObject) methodName));
         } else {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
             throw new UnsupportedOperationException();
         }
     }

--- a/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -143,7 +143,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
             // TODO(CS, 11-Jan-15) this just repeats the above guard...
             return cachedName == methodName;
         } else if (cachedNameIsRubyString) {
-            return (RubyGuards.isRubyString(methodName)) && StringOperations.rope((DynamicObject) cachedName).equals(StringOperations.rope((DynamicObject) methodName));
+            return RubyGuards.isRubyString(methodName) && StringOperations.rope((DynamicObject) cachedName).equals(StringOperations.rope((DynamicObject) methodName));
         } else {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             throw new UnsupportedOperationException();

--- a/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedDispatchNode.java
@@ -139,7 +139,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
 
         if (cachedName instanceof String) {
             return cachedName.equals(methodName);
-        } else if (RubyGuards.isRubySymbol(cachedName)) {
+        } else if (cachedName == cachedNameAsSymbol) { // If cachedName is a Symbol
             // The above guard already proved they are different
             return false;
         } else if (cachedNameIsRubyString) {


### PR DESCRIPTION
When a call site is polymorphic, we want an efficient check for the method name, whether it matches or not.