### PR TITLE
Remove old references to JRuby+Truffle

### DIFF
--- a/bench/benchmark-interface/README.md
+++ b/bench/benchmark-interface/README.md
@@ -249,7 +249,7 @@ Tested versions are in brackets.
 
 * MRI (1.8.7-p371, 1.9.3-p547, 2.0.0-p648, 2.1.10, 2.2.5, 2.3.1, head)
 * JRuby (1.7.25, 9.0.5.0, 9.1.0.0, head)
-* JRuby+Truffle
+* TruffleRuby
 * Rubinius (2.71828182, 3.29)
 * Topaz
 

--- a/bench/chunky_png/README.md
+++ b/bench/chunky_png/README.md
@@ -47,5 +47,3 @@ index e3d97ca..58c234a 100644
 ```
 
 OilyPNG is at revision `705202d54c891c709a2c9075e6d0cd4bba04f209`.
-
-Modified to use `rb_jt_scan_args_12` in `operations.c`.

--- a/bench/chunky_png/oily_png/ext/oily_png/operations.c
+++ b/bench/chunky_png/oily_png/ext/oily_png/operations.c
@@ -21,11 +21,7 @@ VALUE oily_png_compose_bang(int argc, VALUE *argv, VALUE self) {
   
   // Scan the passed in arguments, and populate the above-declared variables. Notice that '12'
   // specifies that oily_png_compose_bang takes in 1 required parameter, and 2 optional ones (the offsets)
-  #ifdef JRUBY_TRUFFLE
-  rb_jt_scan_args_12(argc, argv, "12", &other,&opt_offset_x,&opt_offset_y);
-  #else
   rb_scan_args(argc, argv, "12", &other,&opt_offset_x,&opt_offset_y);
-  #endif
   
   // Regardless of whether offsets were provided, we must specify a default value for them since they will
   // be used in calculating the position of the composed element.
@@ -81,11 +77,7 @@ VALUE oily_png_replace_bang(int argc, VALUE *argv, VALUE self) {
   
   // Scan the passed in arguments, and populate the above-declared variables. Notice that '12'
   // specifies that oily_png_compose_bang takes in 1 required parameter, and 2 optional ones (the offsets)
-  #ifdef JRUBY_TRUFFLE
-  rb_jt_scan_args_12(argc, argv, "12", &other,&opt_offset_x,&opt_offset_y);
-  #else
   rb_scan_args(argc, argv, "12", &other,&opt_offset_x,&opt_offset_y);
-  #endif
   
   // Regardless of whether offsets were provided, we must specify a default value for them since they will
   // be used in calculating the position of the composed element.

--- a/lib/cext/version.h
+++ b/lib/cext/version.h
@@ -9,7 +9,7 @@
  *
  * This file contains code that is based on the Ruby API headers,
  * copyright (C) Yukihiro Matsumoto, licensed under the 2-clause BSD licence
- * as described in the file BSDL included with JRuby+Truffle.
+ * as described in the file BSDL included with TruffleRuby.
  */
 
 #ifndef TRUFFLE_VERSION_H

--- a/lib/truffleruby-tool/lib/truffle_tool.rb
+++ b/lib/truffleruby-tool/lib/truffle_tool.rb
@@ -224,7 +224,7 @@ class TruffleTool
   attr_reader :options
 
   EXECUTABLE        = File.basename($PROGRAM_NAME)
-  BRANDING          = EXECUTABLE.include?('jruby') ? 'JRuby+Truffle' : 'RubyTruffle'
+  BRANDING          = 'TruffleRuby'
   LOCAL_CONFIG_FILE = '.truffleruby-tool.yaml'
   ROOT              = Pathname(__FILE__).dirname.parent.expand_path
   TRUFFLERUBY_PATH  = ROOT.join('../..').expand_path

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -9,7 +9,7 @@
  *
  * This file contains code that is based on the Ruby API headers and implementation,
  * copyright (C) Yukihiro Matsumoto, licensed under the 2-clause BSD licence
- * as described in the file BSDL included with JRuby+Truffle.
+ * as described in the file BSDL included with TruffleRuby.
  */
 
 // Needed for vasprintf

--- a/src/main/java/org/truffleruby/core/string/ConvertBytes.java
+++ b/src/main/java/org/truffleruby/core/string/ConvertBytes.java
@@ -7,7 +7,7 @@
  * GNU General Public License version 2
  * GNU Lesser General Public License version 2.1
  *
- * This is a port of org.jruby.util.ConvertBytes to work with the JRuby+Truffle backend.
+ * This is a port of org.jruby.util.ConvertBytes to work with the TruffleRuby backend.
  * The original class is licensed under the same EPL1.0/GPL 2.0/LGPL 2.1 used throughout.
  */
 

--- a/src/main/ruby/core/marshal.rb
+++ b/src/main/ruby/core/marshal.rb
@@ -230,7 +230,7 @@ end
 class Range
   # Custom marshal dumper for Range. Rubinius exposes the three main values in Range (begin, end, excl) as
   # instance variables. MRI does not, but the values are encoded as instance variables within the marshal output from
-  # MRI, so they both generate the same output, with the exception of the ordering of the variables. In JRuby+Truffle,
+  # MRI, so they both generate the same output, with the exception of the ordering of the variables. In TruffleRuby,
   # we do something more along the lines of MRI and as such, the default Rubinius handler for dumping Range doesn't
   # work for us because there are no instance variables to dump. This custom dumper explicitly encodes the three main
   # values so we generate the correct dump data.
@@ -1185,7 +1185,7 @@ module Marshal
     end
 
     # Rubinius stores three main values in Range (begin, end, excl) as instance variables and as such, can use the
-    # normal, generic object deserializer. In JRuby+Truffle, we do not expose these values as instance variables, in
+    # normal, generic object deserializer. In TruffleRuby, we do not expose these values as instance variables, in
     # keeping with MRI. Moreover, we have specialized versions of Ranges depending on these values, so changing them
     # after object construction would create optimization problems. Instead, we patch the Rubinius marshal loader here
     # to specifically handle Ranges by constructing a Range of the proper type using the deserialized main values and

--- a/test/truffle/ecosystem/blog/README.md
+++ b/test/truffle/ecosystem/blog/README.md
@@ -2,10 +2,10 @@
 
 -   Configure `config/database.yml` (Postgresql required)
 -   Start Postgres (eg `postgres -D /usr/local/var/postgres`)
--   Setup environment: `jruby-truffle-tool setup --offline`
--   Create database: `jruby-truffle-tool run bin/rake db:create`   
--   Migrate database: `jruby-truffle-tool run bin/rake db:migrate`   
--   Run Rails server: `jruby-truffle-tool run bin/rails server`
+-   Setup environment: `truffleruby-tool setup --offline`
+-   Create database: `truffleruby-tool run bin/rake db:create`   
+-   Migrate database: `truffleruby-tool run bin/rake db:migrate`   
+-   Run Rails server: `truffleruby-tool run bin/rails server`
 -   Go to <http://localhost:3000>
 -   Create a new post with:
 
@@ -34,7 +34,7 @@
 ## Alternatively using `bundler`
 
 -   _Omitting first 2 steps from above._     
--   Install stubs `jruby-truffle-tool setup --no-bundler` (used by bundle exec)
+-   Install stubs `truffleruby-tool setup --no-bundler` (used by bundle exec)
 -   Setup environment variables
     -   `export JRUBY_OTPS='-X+T'` (fish: `set -x JRUBY_OPTS '-X+T'`)
     -   `export RUBYOTP='-r ./workarounds'` (fish: `set -x RUBYOPT '-r ./workarounds'`)

--- a/test/truffle/integration/tcp-server/tcp-server.rb
+++ b/test/truffle/integration/tcp-server/tcp-server.rb
@@ -14,7 +14,7 @@ loop do
   socket = server.accept
 
   begin
-    request = "Hello, World from JRuby+Truffle! #{socket.gets}"
+    request = "Hello, World from TruffleRuby! #{socket.gets}"
 
     socket.print "HTTP/1.1 200 OK\r\n" +
                  "Content-Type: text/plain\r\n" +

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -9,7 +9,7 @@
 # GNU General Public License version 2
 # GNU Lesser General Public License version 2.1
 
-# A workflow tool for JRuby+Truffle development
+# A workflow tool for TruffleRuby development
 
 # Recommended: function jt { ruby tool/jt.rb "$@"; }
 
@@ -435,7 +435,7 @@ module Commands
       jt tag all spec/ruby/language                  tag all specs in this file, without running them
       jt untag spec/ruby/language                    untag passing specs in this directory
       jt untag spec/ruby/language/while_spec.rb      untag passing specs in this file
-      jt mspec ...                                   run MSpec with the JRuby+Truffle configuration and custom arguments
+      jt mspec ...                                   run MSpec with the TruffleRuby configuration and custom arguments
       jt metrics alloc [--json] ...                  how much memory is allocated running a program (use -Xclassic to test normal JRuby on this metric and others)
       jt metrics instructions ...                    how many CPU instructions are used to run a program
       jt metrics minheap ...                         what is the smallest heap you can use to run an application
@@ -456,7 +456,7 @@ module Commands
 
       recognised environment variables:
 
-        RUBY_BIN                                     The JRuby+Truffle executable to use (normally just bin/truffleruby)
+        RUBY_BIN                                     The TruffleRuby executable to use (normally just bin/truffleruby)
         GRAALVM_BIN                                  GraalVM executable (java command)
         GRAAL_HOME                                   Directory where there is a built checkout of the Graal compiler (make sure mx is on your path)
         JVMCI_BIN                                    JVMCI-enabled (so JDK 9 EA build) java command (aslo set JVMCI_GRAAL_HOME)
@@ -1661,6 +1661,6 @@ class JT
 end
 
 if $0 == __FILE__
-  abort "Do not run #{$0} with JRuby+Truffle itself, use MRI or some other Ruby." if RUBY_ENGINE == "truffleruby"
+  abort "Do not run #{$0} with TruffleRuby itself, use MRI or some other Ruby." if RUBY_ENGINE == "truffleruby"
   JT.new.main(ARGV)
 end

--- a/tool/strip_stdlib.rb
+++ b/tool/strip_stdlib.rb
@@ -1,4 +1,4 @@
-# Deletes files form stdlib-2.2.2 directory which are not used by JRuby+Truffle.
+# Deletes files form stdlib-2.2.2 directory which are not used by TruffleRuby.
 
 require 'pathname'
 require 'fileutils'

--- a/tool/update_copyright.rb
+++ b/tool/update_copyright.rb
@@ -61,7 +61,7 @@ excludes = %w[
 ]
 
 # Until those all have copyright headers
-excludes << "src/main/java/org/jruby/truffle/parser"
+excludes << "src/main/java/org/truffleruby/parser"
 
 truffle_paths.each do |path|
   puts "WARNING: incorrect path #{path}" unless File.exist? path


### PR DESCRIPTION
@pitr-ch There are a few references left in truffleruby-tool:
```bash
$ ack --ignore-dir truffleruby-gem-test-pack-1 -i 'jruby.truffle' 
lib/truffleruby-tool/README.md
65:  :jruby_truffle_path: '../../truffleruby/bin/truffleruby'

test/truffle/ecosystem/rails-app/.gitignore
2:.jruby+truffle_bundle

test/truffle/ecosystem/blog/.gitignore
2:.jruby+truffle_bundle

test/truffle/ecosystem/blog/.truffleruby-tool.yaml
169:                require_relative '../jruby+truffle/2.2.0/gems/systemu-2.6.5/lib/systemu'

test/truffle/ecosystem/blog/workarounds.rb
2:$LOAD_PATH.unshift '.jruby-truffle-tool_bundle/mocks/'
```

But I don't dare to touch that, probably it should migrate to standard Bundler and truffleruby-tool should disappear.