### PR TITLE
Add a specialization for incrementing an int to improve tight loops.

### DIFF
--- a/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
@@ -82,7 +82,12 @@ public abstract class FixnumNodes {
 
         public abstract Object executeAdd(Object a, Object b);
 
-        @Specialization(rewriteOn = ArithmeticException.class)
+        @Specialization(guards = "b == 1", rewriteOn = ArithmeticException.class)
+        public int incInt(int a, int b) {
+            return Math.incrementExact(a);
+        }
+
+        @Specialization(rewriteOn = ArithmeticException.class, replaces = "incInt")
         public int add(int a, int b) {
             return Math.addExact(a, b);
         }


### PR DESCRIPTION
Although tight loops of the form
```
i = 0
while i < n
  #Some small action
  i += 1
end
```
can be unrolled this tends to produce either long sequences of add and jump on overflow instructions, or tight loops of them, that Graal cannot optimise further. Introducing a specialisation for adding one to an integer allows Graal to either remove overflow checks entirely or group them together into comparisons with a single add operations for the profiled loop count.

This change gives 20-times increase in peak performance of many of the MJIT benchmarks, and shows no degradation in other cases.