### PR TITLE
Invalidate at most once when a global variable is changed

### DIFF
--- a/src/main/java/org/truffleruby/language/globals/GlobalVariableStorage.java
+++ b/src/main/java/org/truffleruby/language/globals/GlobalVariableStorage.java
@@ -76,6 +76,7 @@ public class GlobalVariableStorage {
                 return;
             }
 
+            // <= because the initial assignment is counted as an invalidation
             if (changes <= context.getOptions().GLOBAL_VARIABLE_MAX_INVALIDATIONS) {
                 changes++;
                 unchangedAssumption.invalidate();

--- a/src/main/java/org/truffleruby/options/OptionsCatalog.java
+++ b/src/main/java/org/truffleruby/options/OptionsCatalog.java
@@ -53,7 +53,7 @@ public class OptionsCatalog {
     public static final BooleanOptionDescription ROPE_LAZY_SUBSTRINGS = new BooleanOptionDescription("ruby.rope.lazy_substrings", "Indicates whether a substring operation on a rope should be performed lazily", true);
     public static final BooleanOptionDescription ROPE_PRINT_INTERN_STATS = new BooleanOptionDescription("ruby.rope.print_intern_stats", "Print interned rope stats at application exit", false);
     public static final IntegerOptionDescription ROPE_DEPTH_THRESHOLD = new IntegerOptionDescription("ruby.rope.depth_threshold", "Threshold value at which ropes will be rebalanced (indirectly controls flattening as well)", 128);
-    public static final IntegerOptionDescription GLOBAL_VARIABLE_MAX_INVALIDATIONS = new IntegerOptionDescription("ruby.global_variable.max_invalidations", "Maximum number of times a global variable can be changed to be considered constant", 10);
+    public static final IntegerOptionDescription GLOBAL_VARIABLE_MAX_INVALIDATIONS = new IntegerOptionDescription("ruby.global_variable.max_invalidations", "Maximum number of times a global variable can be changed to be considered constant", 1);
     public static final IntegerOptionDescription DEFAULT_CACHE = new IntegerOptionDescription("ruby.default_cache", "Default size for caches", 8);
     public static final IntegerOptionDescription METHOD_LOOKUP_CACHE = new IntegerOptionDescription("ruby.method_lookup.cache", "Method lookup cache size", DEFAULT_CACHE.getDefaultValue());
     public static final IntegerOptionDescription DISPATCH_CACHE = new IntegerOptionDescription("ruby.dispatch.cache", "Dispatch (various forms of method call) cache size", DEFAULT_CACHE.getDefaultValue());

--- a/test/truffle/compiler/pe/language/global_pe.rb
+++ b/test/truffle/compiler/pe/language/global_pe.rb
@@ -16,6 +16,12 @@ $almost_stable_global = 2
 example "$almost_stable_global", 2
 
 100.times { |i|
+  $same_value_global = 21
+}
+
+example "$same_value_global", 21
+
+100.times { |i|
   $unstable_global = i
 }
 

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -46,7 +46,7 @@ ROPE_LAZY_SUBSTRINGS: [rope.lazy_substrings, boolean, true, Indicates whether a 
 ROPE_PRINT_INTERN_STATS: [rope.print_intern_stats, boolean, false, Print interned rope stats at application exit]
 ROPE_DEPTH_THRESHOLD: [rope.depth_threshold, integer, 128, Threshold value at which ropes will be rebalanced (indirectly controls flattening as well)]
 
-GLOBAL_VARIABLE_MAX_INVALIDATIONS: [global_variable.max_invalidations, integer, 10, Maximum number of times a global variable can be changed to be considered constant]
+GLOBAL_VARIABLE_MAX_INVALIDATIONS: [global_variable.max_invalidations, integer, 1, Maximum number of times a global variable can be changed to be considered constant]
 
 DEFAULT_CACHE: [default_cache, integer, 8, Default size for caches]
 


### PR DESCRIPTION
Otherwise we could have up to 10 deopts per global variable which is too much.

In practice, if a global variable is defined and then changed to another value, it's likely it will change again, so we optimize it as a constant after 1 change, but after give up and read the value from memory.