### PR TITLE
Move .su library code to TruffleRuby

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -145,6 +145,7 @@ sulong: ${labsjdk8} {
     LD_LIBRARY_PATH: "$LIBGMP/lib:$LLVM/lib:$LD_LIBRARY_PATH",
     PATH: "$LLVM/bin:$PATH",
     GRAAL_HOME: "$PWD/../sulong",
+    SULONG_HOME: "$PWD/../sulong",
     LIBXML_LIB: "/usr/lib64/libxml2.so.2",
     HOST_VM: server,
     HOST_VM_CONFIG: graal-core
@@ -155,9 +156,7 @@ sulong: ${labsjdk8} {
     [cd, ../sulong],
     [mx, sversions],
     [mx, build],
-    [export, "SULONG_HOME=$PWD/../sulong"],
     [cd, ../main],
-    [mx, build], # compile cexts as SULONG_HOME was not set on first mx build
   ]
 }
 

--- a/ci.hocon
+++ b/ci.hocon
@@ -44,6 +44,11 @@ common: ${common-base} {
     git:        ">=1.8.3"
     mercurial:  ">=3.2.4"
     ruby:       ">=2.1.0"
+    llvm:       "==3.8"
+  }
+
+  environment: {
+    PATH: "$LLVM/bin:$PATH",
   }
 }
 
@@ -52,6 +57,12 @@ common-darwin: ${common-base} {
     # Homebrew doesn't support versions.
     mercurial: ""
     ruby: ""
+    llvm: ""
+  }
+
+  environment: {
+    # Homebrew does not put llvm on the PATH by default
+    PATH: "$LLVM/bin:$PATH",
   }
 }
 
@@ -128,10 +139,6 @@ graal-enterprise-no-om: {
 }
 
 sulong: ${labsjdk8} {
-  packages: {
-    llvm: "==3.8"
-  }
-
   downloads: {
     LIBGMP: {
       name: libgmp,
@@ -143,7 +150,6 @@ sulong: ${labsjdk8} {
   environment: {
     CPPFLAGS: "-I$LIBGMP/include",
     LD_LIBRARY_PATH: "$LIBGMP/lib:$LLVM/lib:$LD_LIBRARY_PATH",
-    PATH: "$LLVM/bin:$PATH",
     GRAAL_HOME: "$PWD/../sulong",
     SULONG_HOME: "$PWD/../sulong",
     LIBXML_LIB: "/usr/lib64/libxml2.so.2",

--- a/lib/cext/truffle.h
+++ b/lib/cext/truffle.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TRUFFLE_H
+#define TRUFFLE_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+/*
+ READ ME:
+
+ All interop functions that are commented-out are not implemented
+ or not tested in Sulong.
+*/
+
+void *truffle_import(const char *name);
+/* This import function caches the result (i.e. the imported object) for a given name,
+i.e., a subsequent import with the same name does not do a lookup but returns the cached value.
+*/
+void *truffle_import_cached(const char *name);
+// void truffle_export(const char *name, void *value);
+
+void *truffle_address_to_function(void *address);
+
+void *truffle_get_arg(int i);
+
+// Predicates:
+bool truffle_is_executable(const void *object);
+bool truffle_is_null(const void *object);
+bool truffle_has_size(const void *object);
+bool truffle_is_boxed(const void *object);
+bool truffle_is_truffle_object(const void *object);
+
+// Execute:
+void *truffle_execute(void *object, ...);
+int truffle_execute_i(void *object, ...);
+long truffle_execute_l(void *object, ...);
+char truffle_execute_c(void *object, ...);
+float truffle_execute_f(void *object, ...);
+double truffle_execute_d(void *object, ...);
+bool truffle_execute_b(void *object, ...);
+
+// Invoke:
+void *truffle_invoke(void *object, const char *name, ...);
+int truffle_invoke_i(void *object, const char *name, ...);
+long truffle_invoke_l(void *object, const char *name, ...);
+char truffle_invoke_c(void *object, const char *name, ...);
+float truffle_invoke_f(void *object, const char *name, ...);
+double truffle_invoke_d(void *object, const char *name, ...);
+bool truffle_invoke_b(void *object, const char *name, ...);
+
+// GetSize
+int truffle_get_size(void *object);
+
+// Unbox
+int truffle_unbox_i(void *object);
+long truffle_unbox_l(void *object);
+char truffle_unbox_c(void *object);
+float truffle_unbox_f(void *object);
+double truffle_unbox_d(void *object);
+bool truffle_unbox_b(void *object);
+
+// Read
+void *truffle_read(void *object, const char *name);
+int truffle_read_i(void *object, const char *name);
+long truffle_read_l(void *object, const char *name);
+char truffle_read_c(void *object, const char *name);
+float truffle_read_f(void *object, const char *name);
+double truffle_read_d(void *object, const char *name);
+bool truffle_read_b(void *object, const char *name);
+
+void *truffle_read_idx(void *object, int idx);
+int truffle_read_idx_i(void *object, int idx);
+long truffle_read_idx_l(void *object, int idx);
+char truffle_read_idx_c(void *object, int idx);
+float truffle_read_idx_f(void *object, int idx);
+double truffle_read_idx_d(void *object, int idx);
+bool truffle_read_idx_b(void *object, int idx);
+
+// Write
+void truffle_write(void *object, const char *name, void *value);
+void truffle_write_i(void *object, const char *name, int value);
+void truffle_write_l(void *object, const char *name, long value);
+void truffle_write_c(void *object, const char *name, char value);
+void truffle_write_f(void *object, const char *name, float value);
+void truffle_write_d(void *object, const char *name, double value);
+void truffle_write_b(void *object, const char *name, bool value);
+
+void truffle_write_idx(void *object, int idx, void *value);
+void truffle_write_idx_i(void *object, int idx, int value);
+void truffle_write_idx_l(void *object, int idx, long value);
+void truffle_write_idx_c(void *object, int idx, char value);
+void truffle_write_idx_f(void *object, int idx, float value);
+void truffle_write_idx_d(void *object, int idx, double value);
+void truffle_write_idx_b(void *object, int idx, bool value);
+
+// Strings
+void *truffle_read_string(const char *string);
+void *truffle_read_n_string(const char *string, int n);
+void *truffle_read_bytes(const char *bytes);
+void *truffle_read_n_bytes(const char *bytes, int n);
+
+// Managed operations
+void *truffle_managed_malloc(long size);
+void *truffle_managed_memcpy(void *destination, const void *source, size_t count);
+
+// Managed objects <===> native handles
+void *truffle_handle_for_managed(void *managedObject);
+void *truffle_release_handle(void *nativeHandle);
+void *truffle_managed_from_handle(void *nativeHandle);
+
+void *truffle_sulong_function_to_native_pointer(void *sulongFunctionPointer, const void *signature);
+
+void truffle_load_library(const char *string);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/lib/mri/mkmf.rb
+++ b/lib/mri/mkmf.rb
@@ -10,11 +10,6 @@ require 'shellwords'
 # For TruffleRuby
 require 'pathname'
 
-# For TruffleRuby
-unless ENV['SULONG_HOME']
-  raise 'You need to set $SULONG_HOME to a built checkout of the Sulong repository to use mkmf'
-end
-
 # :stopdoc:
 class String
   # Wraps a string in escaped quotes if it contains whitespace.

--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -21,10 +21,6 @@ if 'RUBY_BENCHMARKS' in os.environ:
 _suite = mx.suite('truffleruby')
 root = _suite.dir
 
-# Automatically set SULONG_HOME if it is a sibling suite
-if exists('../sulong/mx.sulong/mx_sulong.py'):
-    os.environ['SULONG_HOME'] = os.path.abspath('../sulong')
-
 # Project classes
 
 class ArchiveProject(mx.ArchivableProject):

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -1,15 +1,6 @@
 ROOT := $(realpath ../../..)
 RUBY := $(ROOT)/bin/truffleruby
 
-ifdef SULONG_HOME
-goal: all
-else
-goal: no_sulong
-endif
-
-no_sulong: clean
-	@echo "WARNING: SULONG_HOME not set - not building cexts" 1>&2
-
 all: $(ROOT)/lib/cext/ruby.su $(ROOT)/lib/mri/openssl.su
 
 clean:

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -1,5 +1,15 @@
 ROOT := $(realpath ../../..)
 RUBY := $(ROOT)/bin/truffleruby
+OS := $(shell uname)
+
+ifeq ($(OS),SunOS)
+goal: no_clang
+else
+goal: all
+endif
+
+no_clang:
+	@echo "WARNING: clang is not avaiable on this platform - not building cexts" 1>&2
 
 all: $(ROOT)/lib/cext/ruby.su $(ROOT)/lib/mri/openssl.su
 

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -2566,6 +2566,11 @@ void rb_tr_release_handle(void *handle) {
   truffle_release_handle(handle);
 }
 
+void rb_tr_load_library(const char *library) {
+  const char *real_c_string = ruby_strdup(library);
+  truffle_load_library(real_c_string);
+}
+
 // util
 char *
 ruby_strdup(const char *str)

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -65,7 +65,9 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
     public static final String MIME_TYPE = "application/x-ruby";
     public static final String EXTENSION = ".rb";
 
-    public static final String CEXT_MIME_TYPE = "application/x-sulong-library";
+    public static final String SULONG_BITCODE_BASE64_MIME_TYPE = "application/x-llvm-ir-bitcode-base64";
+
+    public static final String CEXT_MIME_TYPE = "application/x-ruby-cext-library";
     public static final String CEXT_EXTENSION = ".su";
 
     public RubyLanguage() {

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -1142,6 +1142,7 @@ public class CExtNodes {
     @CoreMethod(names = "linker", onSingleton = true, required = 3)
     public abstract static class LinkerNode extends CoreMethodArrayArgumentsNode {
 
+        @TruffleBoundary
         @Specialization(guards = { "isRubyString(outputFileName)", "isRubyArray(libraries)", "isRubyArray(bitcodeFiles)" })
         public Object linker(DynamicObject outputFileName, DynamicObject libraries, DynamicObject bitcodeFiles) {
             try {

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -92,7 +92,6 @@ import org.truffleruby.platform.FDSet;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -1150,7 +1149,7 @@ public class CExtNodes {
                         StringOperations.getString(outputFileName),
                         array2StringList(libraries),
                         array2StringList(bitcodeFiles));
-            } catch (NoSuchAlgorithmException | IOException e) {
+            } catch (IOException e) {
                 throw new JavaException(e);
             }
             return outputFileName;

--- a/src/main/java/org/truffleruby/cext/Linker.java
+++ b/src/main/java/org/truffleruby/cext/Linker.java
@@ -28,6 +28,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import org.truffleruby.RubyLanguage;
+
 import com.oracle.truffle.api.source.Source;
 
 public class Linker {
@@ -35,7 +37,6 @@ public class Linker {
     private static final int BUFFER_SIZE = 4096;
 
     private static final String LLVM_BITCODE_EXTENSION = "bc";
-    private static final String LLVM_BITCODE_BASE64_MIME_TYPE = "application/x-llvm-ir-bitcode-base64";
 
     public static void link(String outputFileName, Collection<String> libraryNames, Collection<String> bitcodeFileNames) throws IOException, NoSuchAlgorithmException {
         final byte[] buffer = new byte[BUFFER_SIZE];
@@ -125,7 +126,7 @@ public class Linker {
                     }
                 } else if (zipEntry.getName().endsWith("." + LLVM_BITCODE_EXTENSION)) {
                     final String sourceCode = Base64.getEncoder().encodeToString(bytes);
-                    final Source source = Source.newBuilder(sourceCode).name(file.getPath() + "@" + zipEntry.getName()).mimeType(LLVM_BITCODE_BASE64_MIME_TYPE).build();
+                    final Source source = Source.newBuilder(sourceCode).name(file.getPath() + "@" + zipEntry.getName()).mimeType(RubyLanguage.SULONG_BITCODE_BASE64_MIME_TYPE).build();
                     handleSource.accept(source);
                 }
 

--- a/src/main/java/org/truffleruby/cext/Linker.java
+++ b/src/main/java/org/truffleruby/cext/Linker.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby.cext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.RandomAccessFile;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Scanner;
+import java.util.function.Consumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import com.oracle.truffle.api.source.Source;
+
+public class Linker {
+
+    private static final int BUFFER_SIZE = 4096;
+
+    private static final String LLVM_BITCODE_EXTENSION = "bc";
+    private static final String LLVM_BITCODE_BASE64_MIME_TYPE = "application/x-llvm-ir-bitcode-base64";
+
+    public static void link(String outputFileName, Collection<String> libraryNames, Collection<String> bitcodeFileNames) throws IOException, NoSuchAlgorithmException {
+        final byte[] buffer = new byte[BUFFER_SIZE];
+
+        try (ZipOutputStream outputStream = new ZipOutputStream(new FileOutputStream(outputFileName))) {
+            outputStream.putNextEntry(new ZipEntry("libs"));
+
+            PrintStream libsStream = new PrintStream(outputStream);
+
+            for (String libraryName : libraryNames) {
+                libsStream.println(libraryName);
+            }
+
+            libsStream.flush();
+
+            outputStream.closeEntry();
+
+            for (String bitcodeFileName : bitcodeFileNames) {
+                final File bitcodeFile = new File(bitcodeFileName);
+
+                final MessageDigest digest = MessageDigest.getInstance("SHA-1");
+
+                try (RandomAccessFile inputFile = new RandomAccessFile(bitcodeFile, "r")) {
+                    while (true) {
+                        int count = inputFile.read(buffer);
+
+                        if (count == -1) {
+                            break;
+                        }
+
+                        digest.update(buffer, 0, count);
+                    }
+
+                    final String digestString = new BigInteger(1, digest.digest()).toString(16);
+                    final String entryName = String.format("%s_%s", digestString, bitcodeFile.getName());
+
+                    outputStream.putNextEntry(new ZipEntry(entryName));
+
+                    inputFile.seek(0);
+
+                    while (true) {
+                        int count = inputFile.read(buffer);
+
+                        if (count == -1) {
+                            break;
+                        }
+
+                        outputStream.write(buffer, 0, count);
+                    }
+
+                    outputStream.closeEntry();
+                }
+            }
+        }
+    }
+
+    public static void loadLibrary(File file, Consumer<String> handleLibrary, Consumer<Source> handleSource) throws IOException {
+        final byte[] buffer = new byte[BUFFER_SIZE];
+
+        try (ZipInputStream zipStream = new ZipInputStream(new FileInputStream(file))) {
+            ZipEntry zipEntry = zipStream.getNextEntry();
+
+            while (zipEntry != null) {
+                if (zipEntry.isDirectory()) {
+                    zipEntry = zipStream.getNextEntry();
+                    continue;
+                }
+
+                final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+
+                while (true) {
+                    final int read = zipStream.read(buffer);
+                    if (read == -1) {
+                        break;
+                    }
+                    byteStream.write(buffer, 0, read);
+                }
+
+                final byte[] bytes = byteStream.toByteArray();
+
+                if (zipEntry.getName().equals("libs")) {
+                    final String libs = byteStream.toString(StandardCharsets.UTF_8.name());
+                    try (Scanner scanner = new Scanner(libs)) {
+                        while (scanner.hasNextLine()) {
+                            handleLibrary.accept(scanner.nextLine());
+                        }
+                    }
+                } else if (zipEntry.getName().endsWith("." + LLVM_BITCODE_EXTENSION)) {
+                    final String sourceCode = Base64.getEncoder().encodeToString(bytes);
+                    final Source source = Source.newBuilder(sourceCode).name(file.getPath() + "@" + zipEntry.getName()).mimeType(LLVM_BITCODE_BASE64_MIME_TYPE).build();
+                    handleSource.accept(source);
+                }
+
+                zipEntry = zipStream.getNextEntry();
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/truffleruby/cext/Linker.java
+++ b/src/main/java/org/truffleruby/cext/Linker.java
@@ -38,7 +38,7 @@ public class Linker {
 
     private static final String LLVM_BITCODE_EXTENSION = "bc";
 
-    public static void link(String outputFileName, Collection<String> libraryNames, Collection<String> bitcodeFileNames) throws IOException, NoSuchAlgorithmException {
+    public static void link(String outputFileName, Collection<String> libraryNames, Collection<String> bitcodeFileNames) throws IOException {
         final byte[] buffer = new byte[BUFFER_SIZE];
 
         try (ZipOutputStream outputStream = new ZipOutputStream(new FileOutputStream(outputFileName))) {
@@ -57,7 +57,12 @@ public class Linker {
             for (String bitcodeFileName : bitcodeFileNames) {
                 final File bitcodeFile = new File(bitcodeFileName);
 
-                final MessageDigest digest = MessageDigest.getInstance("SHA-1");
+                final MessageDigest digest;
+                try {
+                    digest = MessageDigest.getInstance("SHA-1");
+                } catch (NoSuchAlgorithmException e) {
+                    throw new RuntimeException(e);
+                }
 
                 try (RandomAccessFile inputFile = new RandomAccessFile(bitcodeFile, "r")) {
                     while (true) {

--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -15,6 +15,36 @@ end
 module Truffle::CExt
   extend self
 
+  class Linker
+    def self.main(argv = ARGV)
+      argv = argv.dup
+      output = 'out.su'
+      libraries = []
+      files = []
+      while arg = argv.shift
+        case arg
+        when '-h', '-help', '--help', '/?', '/help'
+          puts "#{$0} -e Truffle::CExt::Linker.main [-o out.su] [-l one.so -l two.so ...] one.bc two.bc ..."
+          puts '  Links zero or more LLVM binary bitcode files into a single file which can be loaded by Sulong.'
+        when '-o'
+          raise '-o needs to be followed by a file name' if argv.empty?
+          output = argv.shift
+        when '-l'
+          raise '-l needs to be followed by a file name' if argv.empty?
+          libraries << argv.shift
+        else
+          if arg.start_with?('-')
+            raise "Unknown argument: #{arg}"
+          else
+            files << arg
+          end
+        end
+      end
+
+      Truffle::CExt.linker(output, libraries, files)
+    end
+  end
+
   class DataHolder
     attr_accessor :data
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -465,7 +465,7 @@ module Commands
         GRAAL_HOME                                   Directory where there is a built checkout of the Graal compiler (make sure mx is on your path)
         JVMCI_BIN                                    JVMCI-enabled (so JDK 9 EA build) java command (aslo set JVMCI_GRAAL_HOME)
         JVMCI_GRAAL_HOME                             Like GRAAL_HOME, but only used for the JARs to run with JVMCI_BIN
-        SULONG_HOME                                  The Sulong source repository, if you want to build and run cexts
+        SULONG_HOME                                  The Sulong source repository, if you want to run cexts
         GRAAL_JS_JAR                                 The location of trufflejs.jar
         SL_JAR                                       The location of truffle-sl.jar
         LIBXML_HOME, LIBXML_INCLUDE, LIBXML_LIB      The location of libxml2 (the directory containing include etc), and the direct include directory and library file
@@ -645,8 +645,6 @@ module Commands
   end
 
   def compile_cext(name, ext_dir, target, *clang_opts)
-    abort "You need to set SULONG_HOME" unless SULONG_HOME
-
     extconf = "#{ext_dir}/extconf.rb"
     raise "#{extconf} does not exist" unless File.exist?(extconf)
 


### PR DESCRIPTION
`SULONG_HOME` is only needed to get the options now:
```ruby
[
      "-J-Dpolyglot.llvm.libraryPath=#{SULONG_HOME}/mxbuild/sulong-libs",
      '-J-cp', "#{SULONG_HOME}/build/sulong.jar",
]
```
Both of these are automatically set in GraalVM, so we should now be able to compile and run C-extensions in GraalVM!