### PR TITLE
Fast path for eval adding variables to bindings.

### DIFF
--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -108,8 +108,8 @@ public abstract class BindingNodes {
         return newExtrasFrame(parent, descriptor);
     }
 
-    private static MaterializedFrame newExtrasFrame(MaterializedFrame parent, FrameDescriptor descriptor) {
-        final MaterializedFrame frame = Truffle.getRuntime().createMaterializedFrame(
+    public static MaterializedFrame newExtrasFrame(MaterializedFrame parent, FrameDescriptor descriptor) {
+        final MaterializedFrame frame = Truffle.getRuntime().createVirtualFrame(
                 RubyArguments.pack(
                         parent,
                         null,
@@ -119,7 +119,7 @@ public abstract class BindingNodes {
                         RubyArguments.getSelf(parent),
                         RubyArguments.getBlock(parent),
                         RubyArguments.getArguments(parent)),
-                descriptor);
+                descriptor).materialize();
         return frame;
     }
 

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -66,7 +66,7 @@ public abstract class BindingNodes {
     @TruffleBoundary
     public static FrameDescriptor newFrameDescriptor(RubyContext context, String name) {
         FrameDescriptor frameDescriptor = new FrameDescriptor(context.getCoreLibrary().getNil());
-        frameDescriptor.findOrAddFrameSlot(name);
+        frameDescriptor.addFrameSlot(name);
         return frameDescriptor;
     }
 

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -151,7 +151,7 @@ public abstract class BindingNodes {
         return null;
     }
 
-    public static FrameSlotAndDepth findFrameSlotOrNull(String identifier, FrameDescriptor frameDescriptor) {
+    public static FrameSlotAndDepth findFrameSlot(String identifier, FrameDescriptor frameDescriptor) {
         final FrameSlot frameSlot = frameDescriptor.findFrameSlot(identifier);
         assert frameSlot != null;
         return new FrameSlotAndDepth(frameSlot, 0);
@@ -305,7 +305,7 @@ public abstract class BindingNodes {
                 @Cached("getFrameDescriptor(binding)") FrameDescriptor cachedFrameDescriptor,
                 @Cached("findFrameSlotOrNull(name, getTopFrame(binding))") FrameSlotAndDepth cachedFrameSlot,
                 @Cached("newFrameDescriptor(getContext(), name)") FrameDescriptor newDescriptor,
-                @Cached("findFrameSlotOrNull(name, newDescriptor)") FrameSlotAndDepth newFrameSlot,
+                @Cached("findFrameSlot(name, newDescriptor)") FrameSlotAndDepth newFrameSlot,
                 @Cached("createWriteNode(newFrameSlot)") WriteFrameSlotNode writeLocalVariableNode) {
             final MaterializedFrame frame = newExtrasFrame(binding, newDescriptor);
             return writeLocalVariableNode.executeWrite(frame, value);

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -585,7 +585,7 @@ public abstract class KernelNodes {
             return eval(cachedRootNode, cachedCallTarget, callNode, parentFrame);
         }
 
-        private Object eval(final RootNodeWrapper rootNode, final CallTarget callTarget, final DirectCallNode callNode, final MaterializedFrame parentFrame) {
+        private Object eval(RootNodeWrapper rootNode, CallTarget callTarget, DirectCallNode callNode, MaterializedFrame parentFrame) {
             final Object bindingSelf = RubyArguments.getSelf(parentFrame);
 
             final InternalMethod method = new InternalMethod(
@@ -748,8 +748,8 @@ public abstract class KernelNodes {
         protected FrameDescriptor newBindingDescriptor(RubyContext context, RootNodeWrapper rootNode) {
             FrameDescriptor descriptor = rootNode.getRootNode().getFrameDescriptor();
             FrameDescriptor newDescriptor = new FrameDescriptor(context.getCoreLibrary().getNil());
-            for (FrameSlot s : descriptor.getSlots()) {
-                newDescriptor.findOrAddFrameSlot(s.getIdentifier());
+            for (FrameSlot frameSlot : descriptor.getSlots()) {
+                newDescriptor.findOrAddFrameSlot(frameSlot.getIdentifier());
             }
             return newDescriptor;
         }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -537,7 +537,7 @@ public abstract class KernelNodes {
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode,
                 @Cached("create()") RopeNodes.EqualNode equalNode) {
             final MaterializedFrame parentFrame = callerFrameNode.execute(frame).materialize();
-            return eval(cachedRootNode, cachedCallTarget, callNode, parentFrame);
+            return eval(RubyArguments.getSelf(frame), cachedRootNode, cachedCallTarget, callNode, parentFrame);
         }
 
         @Specialization(guards = {
@@ -582,12 +582,10 @@ public abstract class KernelNodes {
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode,
                 @Cached("create()") RopeNodes.EqualNode equalNode) {
             final MaterializedFrame parentFrame = BindingNodes.getTopFrame(binding);
-            return eval(cachedRootNode, cachedCallTarget, callNode, parentFrame);
+            return eval(RubyArguments.getSelf(parentFrame), cachedRootNode, cachedCallTarget, callNode, parentFrame);
         }
 
-        private Object eval(RootNodeWrapper rootNode, CallTarget callTarget, DirectCallNode callNode, MaterializedFrame parentFrame) {
-            final Object bindingSelf = RubyArguments.getSelf(parentFrame);
-
+        private Object eval(Object self, RootNodeWrapper rootNode, CallTarget callTarget, DirectCallNode callNode, MaterializedFrame parentFrame) {
             final InternalMethod method = new InternalMethod(
                     getContext(),
                     rootNode.getRootNode().getSharedMethodInfo(),
@@ -597,7 +595,7 @@ public abstract class KernelNodes {
                     Visibility.PUBLIC,
                     callTarget);
 
-            return callNode.call(RubyArguments.pack(parentFrame, null, method, RubyArguments.getDeclarationContext(parentFrame), null, bindingSelf, null, new Object[]{}));
+            return callNode.call(RubyArguments.pack(parentFrame, null, method, RubyArguments.getDeclarationContext(parentFrame), null, self, null, new Object[]{}));
         }
 
         @Specialization(guards = {
@@ -623,7 +621,7 @@ public abstract class KernelNodes {
                 @Cached("create()") RopeNodes.EqualNode equalNode) {
             final MaterializedFrame parentFrame = BindingNodes.newExtrasFrame(binding,
                     newBindingDescriptor);
-            return eval(rootNodeToEval, cachedCallTarget, callNode, parentFrame);
+            return eval(RubyArguments.getSelf(parentFrame), rootNodeToEval, cachedCallTarget, callNode, parentFrame);
         }
 
         @Specialization(guards = {

--- a/test/truffle/compiler/pe/core/binding_pe.rb
+++ b/test/truffle/compiler/pe/core/binding_pe.rb
@@ -15,7 +15,7 @@ example "x = 14; binding.local_variable_get(:x)", 14
 example "x = 14; p = Proc.new { }; p.binding.local_variable_get(:x)", 14
 
 # set + get
-tagged example "b = binding; b.local_variable_set(:x, 14); b.local_variable_get(:x)", 14
+example "b = binding; b.local_variable_set(:x, 14); b.local_variable_get(:x)", 14
 
 # get (2 levels)
 example "x = 14; y = nil; 1.times { y = binding.local_variable_get(:x) }; y", 14

--- a/test/truffle/compiler/pe/core/eval_pe.rb
+++ b/test/truffle/compiler/pe/core/eval_pe.rb
@@ -15,3 +15,7 @@ example "eval('[1, 2, 3]')[1]", 2
 example "eval([1, 2, 3].inspect)[1]", 2
 
 tagged counter example "eval(rand.to_s)"
+
+example "eval('14', binding)", 14
+
+example "b = binding; eval('temp = 14', b); b = eval('temp', b)", 14

--- a/test/truffle/compiler/pe/core/eval_pe.rb
+++ b/test/truffle/compiler/pe/core/eval_pe.rb
@@ -18,4 +18,4 @@ tagged counter example "eval(rand.to_s)"
 
 example "eval('14', binding)", 14
 
-example "b = binding; eval('temp = 14', b); b = eval('temp', b)", 14
+example "b = binding; eval('temp = 14', b); eval('temp', b)", 14


### PR DESCRIPTION
These changes allow `Kernel#eval(str, binding)` to be optimised for a constant eval string even when that evaluation adds variables to the binding. Thus the core of a mandelbrot implementation can be replaced with something like
```
eval "tr = zrzr - zizi + cr; ti = 2.0*zr*zi + ci; zr = tr; zi = ti; zrzr = zr*zr; zizi = zi*zi", binding
```
(where tr and ti are not present in the binding) without any drop in performance. The frame descriptor added to the binding is also stable allowing
```
b = binding
eval "tr = zrzr - zizi + cr; ti = 2.0*zr*zi + ci; zr = tr; zi = ti; zrzr = zr*zr; zizi = zi*zi", b
done = eval "zrzr+zizi > 4.0", b
b = nil
```
to also be optimised.

Performance will be affected if the binding itself escapes.