### PR TITLE
Fix file check used by have_header, add RUBY_VM and rubyio.h

### DIFF
--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -218,6 +218,7 @@ void rb_check_safe_obj(VALUE object);
 bool SYMBOL_P(VALUE value);
 
 // Constants
+#define RUBY_VM 1
 
 // START from tool/generate-cext-constants.rb
 

--- a/lib/cext/ruby/rubyio.h
+++ b/lib/cext/ruby/rubyio.h
@@ -1,0 +1,1 @@
+#include "../ruby.h"

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -55,6 +55,7 @@ module RbConfig
       'configure_args'    => ' ',
       'ARCH_FLAG'         => '',
       'CPPFLAGS'          => cppflags,
+      'CPPOUTFILE'        => '-o conftest.i',
       'LDFLAGS'           => '',
       'DLDFLAGS'          => '',
       'DLEXT'             => 'su',


### PR DESCRIPTION
Correcting this `file?`check fixes the `have_header` checks allowing `extconf.rb` to create makefiles for more native gems (for example pg, sqlite3, etc).