### PR TITLE
Add a lot of missing boundaries around method definition

### DIFF
--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -19,6 +19,7 @@ import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameInstance.FrameAccess;
+import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
@@ -707,7 +708,7 @@ public class CExtNodes {
         @TruffleBoundary
         @Specialization(guards = "isRubySymbol(visibility)")
         public boolean toRubyString(DynamicObject visibility) {
-            final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameAccess.MATERIALIZE);
+            final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameAccess.READ_ONLY);
             final Visibility callerVisibility = DeclarationContext.findVisibility(callerFrame);
 
             switch (visibility.toString()) {

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1775,7 +1775,7 @@ public abstract class ModuleNodes {
         }
 
         private void setCurrentVisibility(Visibility visibility) {
-            final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameInstance.FrameAccess.READ_WRITE);
+            final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameAccess.READ_WRITE);
             DeclarationContext.changeVisibility(callerFrame, visibility);
         }
 

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1764,7 +1764,7 @@ public abstract class ModuleNodes {
         @Specialization
         public DynamicObject setVisibility(VirtualFrame frame, DynamicObject module, Object[] names) {
             if (names.length == 0) {
-                setCurrentVisibility(visibility);
+                DeclarationContext.setCurrentVisibility(getContext(), visibility);
             } else {
                 for (Object name : names) {
                     setMethodVisibilityNode.executeSetMethodVisibility(frame, module, name);
@@ -1772,11 +1772,6 @@ public abstract class ModuleNodes {
             }
 
             return module;
-        }
-
-        private void setCurrentVisibility(Visibility visibility) {
-            final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameAccess.READ_WRITE);
-            DeclarationContext.changeVisibility(callerFrame, visibility);
         }
 
     }

--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -11,6 +11,7 @@ package org.truffleruby.language;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.TypeSystemReference;
 import com.oracle.truffle.api.instrumentation.StandardTags;
@@ -209,6 +210,7 @@ public abstract class RubyBaseNode extends Node {
         return null;
     }
 
+    @TruffleBoundary
     @Override
     public SourceSection getSourceSection() {
         if (sourceCharIndex == -1) {

--- a/src/main/java/org/truffleruby/language/SourceIndexLength.java
+++ b/src/main/java/org/truffleruby/language/SourceIndexLength.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.language;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -22,6 +23,7 @@ public class SourceIndexLength {
         this.length = length;
     }
 
+    @TruffleBoundary
     public SourceSection toSourceSection(Source source) {
         return source.createSection(charIndex, length);
     }

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -10,6 +10,7 @@
 package org.truffleruby.language.methods;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.RubyContext;
@@ -41,6 +42,7 @@ public class DeclarationContext {
         this.defaultDefinee = defaultDefinee;
     }
 
+    @TruffleBoundary
     private static Frame lookupVisibility(Frame frame) {
         while (frame != null) {
             final Visibility visibility = RubyArguments.getDeclarationContext(frame).visibility;
@@ -49,14 +51,17 @@ public class DeclarationContext {
             }
             frame = RubyArguments.getDeclarationFrame(frame);
         }
+        CompilerDirectives.transferToInterpreterAndInvalidate();
         throw new UnsupportedOperationException("No declaration frame with visibility found");
     }
 
+    @TruffleBoundary
     public static Visibility findVisibility(Frame frame) {
         final Frame visibilityFrame = lookupVisibility(frame);
         return RubyArguments.getDeclarationContext(visibilityFrame).visibility;
     }
 
+    @TruffleBoundary
     public static void changeVisibility(Frame frame, Visibility newVisibility) {
         final Frame visibilityFrame = lookupVisibility(frame);
         final DeclarationContext oldDeclarationContext = RubyArguments.getDeclarationContext(visibilityFrame);
@@ -70,6 +75,7 @@ public class DeclarationContext {
         return new DeclarationContext(visibility, defaultDefinee);
     }
 
+    @TruffleBoundary
     public DynamicObject getModuleToDefineMethods(Object self, InternalMethod method, RubyContext context, SingletonClassNode singletonClassNode) {
         switch (defaultDefinee) {
         case LEXICAL_SCOPE:
@@ -79,7 +85,6 @@ public class DeclarationContext {
         case SELF:
             return (DynamicObject) self;
         default:
-            CompilerDirectives.transferToInterpreterAndInvalidate();
             throw new UnsupportedOperationException();
         }
     }

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -12,6 +12,7 @@ package org.truffleruby.language.methods;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.FrameInstance.FrameAccess;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.RubyContext;
 import org.truffleruby.language.Visibility;
@@ -62,12 +63,18 @@ public class DeclarationContext {
     }
 
     @TruffleBoundary
-    public static void changeVisibility(Frame frame, Visibility newVisibility) {
+    private static void changeVisibility(Frame frame, Visibility newVisibility) {
         final Frame visibilityFrame = lookupVisibility(frame);
         final DeclarationContext oldDeclarationContext = RubyArguments.getDeclarationContext(visibilityFrame);
         if (newVisibility != oldDeclarationContext.visibility) {
             RubyArguments.setDeclarationContext(visibilityFrame, oldDeclarationContext.withVisibility(newVisibility));
         }
+    }
+
+    @TruffleBoundary
+    public static void setCurrentVisibility(RubyContext context, Visibility visibility) {
+        final Frame callerFrame = context.getCallStack().getCallerFrameIgnoringSend().getFrame(FrameAccess.READ_WRITE);
+        changeVisibility(callerFrame, visibility);
     }
 
     private DeclarationContext withVisibility(Visibility visibility) {

--- a/src/main/java/org/truffleruby/language/methods/GetCurrentVisibilityNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetCurrentVisibilityNode.java
@@ -15,12 +15,18 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.Visibility;
+import org.truffleruby.language.arguments.RubyArguments;
 
 public class GetCurrentVisibilityNode extends RubyNode {
 
     @Override
     public Visibility execute(VirtualFrame frame) {
-        return DeclarationContext.findVisibility(frame);
+        final Visibility visibility = RubyArguments.getDeclarationContext(frame).visibility;
+        if (visibility != null) {
+            return visibility;
+        } else {
+            return DeclarationContext.findVisibility(RubyArguments.getDeclarationFrame(frame));
+        }
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/language/methods/GetDefaultDefineeNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetDefaultDefineeNode.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.language.methods;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.language.RubyNode;
@@ -22,15 +23,17 @@ public class GetDefaultDefineeNode extends RubyNode {
 
     @Override
     public DynamicObject execute(VirtualFrame frame) {
-        final InternalMethod method = RubyArguments.getMethod(frame);
+        return getDefaultDefinee(RubyArguments.getMethod(frame), RubyArguments.getSelf(frame), RubyArguments.getDeclarationContext(frame));
+    }
+
+    @TruffleBoundary
+    public DynamicObject getDefaultDefinee(InternalMethod method, Object self, DeclarationContext declarationContext) {
         final DynamicObject capturedDefaultDefinee = method.getCapturedDefaultDefinee();
 
         if (capturedDefaultDefinee != null) {
             return capturedDefaultDefinee;
         }
 
-        final Object self = RubyArguments.getSelf(frame);
-        final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(frame);
         return declarationContext.getModuleToDefineMethods(self, method, getContext(), singletonClassNode);
     }
 }


### PR DESCRIPTION
* Passing a VirtualFrame to a method taking a Frame is usually bad
  unless the method folds away.