### PR TITLE
Fix a few blocking calls and flushing standard streams on exit

### DIFF
--- a/src/main/java/org/truffleruby/core/rubinius/IOBufferNodes.java
+++ b/src/main/java/org/truffleruby/core/rubinius/IOBufferNodes.java
@@ -168,11 +168,11 @@ public abstract class IOBufferNodes {
                         // Treat as seeing eof
                         bytesRead = 0;
                         break;
-                    } else if (errno == Errno.EAGAIN.intValue() || errno == Errno.EINTR.intValue()) {
+                    } else if (errno == Errno.EAGAIN.intValue()) {
                         //if (!state -> check_async(calling_environment))
                         //    return NULL;
                         //io -> ensure_open(state);
-                        getContext().getSafepointManager().poll(this);
+                        getContext().getSafepointManager().pollFromBlockingCall(this);
                         continue;
                     } else {
                         throw new RaiseException(ExceptionOperations.createSystemCallError(coreLibrary().getErrnoClass(Errno.valueOf(errno)), nil(), null, errno));

--- a/src/main/ruby/core/file.rb
+++ b/src/main/ruby/core/file.rb
@@ -1354,16 +1354,18 @@ end
 
 if STDOUT.tty? || Truffle::Boot.get_option('sync.stdio')
   STDOUT.sync = true
-else
-  Truffle::KernelOperations.at_exit true do
-    STDOUT.flush
-  end
 end
 
 if STDERR.tty? || Truffle::Boot.get_option('sync.stdio')
   STDERR.sync = true
-else
-  Truffle::KernelOperations.at_exit true do
-    STDERR.flush
-  end
+end
+
+# Always flush standard streams on exit
+
+Truffle::KernelOperations.at_exit true do
+  STDOUT.flush
+end
+
+Truffle::KernelOperations.at_exit true do
+  STDERR.flush
 end


### PR DESCRIPTION
This was a problem with `minitest/pride` as the SummaryReporter sets STDOUT.sync = false and due to a Minitest bug does not restore it (to true), which meant for us not printing test errors at all!
It actually worked on MRI because there standard streams are flushed natively.
cc @pitr-ch @nirvdrum 