### PR TITLE
Better top-level error handling

### DIFF
--- a/spec/tags/truffle/launcher_tags.txt
+++ b/spec/tags/truffle/launcher_tags.txt
@@ -15,6 +15,7 @@ slow:The launcher allows -cp in JAVA_OPTS
 slow:The launcher allows -classpath in JAVA_OPTS
 slow:The launcher prints available options for -Xoptions
 slow:The launcher logs options if -Xoptions.log=true is set
+slow:The launcher prints an error for an unknown option
 aot:The launcher prints the full java command with -J-cmd
 aot:The launcher prints the full java command with -cmd in JAVA_OPTS
 aot:The launcher adds options from $JAVA_OPTS to the command

--- a/spec/truffle/launcher_spec.rb
+++ b/spec/truffle/launcher_spec.rb
@@ -140,4 +140,10 @@ describe "The launcher" do
     out.should include("CONFIG option home=")
   end
 
+  it "prints an error for an unknown option" do
+    out = `#{RbConfig.ruby} -Xunknown 2>&1`
+    $?.success?.should == false
+    out.should include("unknown option")
+  end
+
 end

--- a/src/main/java/org/truffleruby/language/control/RaiseException.java
+++ b/src/main/java/org/truffleruby/language/control/RaiseException.java
@@ -38,7 +38,7 @@ public class RaiseException extends ControlFlowException implements TruffleExcep
     public String getMessage() {
         Object message = Layouts.EXCEPTION.getMessage(exception);
         if (message != null) {
-            return message.toString();
+            return String.format("%s (%s)", message.toString(), Layouts.MODULE.getFields(Layouts.BASIC_OBJECT.getLogicalClass(exception)).getName());
         } else {
             return null;
         }

--- a/src/main/java/org/truffleruby/language/loader/SourceLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/SourceLoader.java
@@ -202,9 +202,13 @@ public class SourceLoader {
         }
     }
 
-    private static void ensureReadable(String path, File file) throws IOException {
+    private void ensureReadable(String path, File file) throws IOException {
+        if (!file.exists()) {
+            throw new RaiseException(context.getCoreExceptions().loadError("No such file or directory -- " + path, path, null));
+        }
+
         if (!file.canRead()) {
-            throw new IOException("Can't read file " + path);
+            throw new RaiseException(context.getCoreExceptions().loadError("Permission denied -- " + path, path, null));
         }
     }
 

--- a/src/main/java/org/truffleruby/options/CommandLineParser.java
+++ b/src/main/java/org/truffleruby/options/CommandLineParser.java
@@ -369,7 +369,13 @@ public class CommandLineParser {
                             extendedOption = extendedOption.substring(0, equals);
                         }
 
-                        config.getOptions().put(Main.LANGUAGE_ID + "." + extendedOption, value);
+                        final String fullName = Main.LANGUAGE_ID + "." + extendedOption;
+
+                        if (OptionsCatalog.fromName(fullName) == null) {
+                            throw new CommandLineException("unknown option " + extendedOption);
+                        }
+
+                        config.getOptions().put(fullName, value);
                     }
                     break FOR;
                 case '-':


### PR DESCRIPTION
MRI:

```
$ ruby missing.rb
ruby: No such file or directory -- missing.rb (LoadError)
```

```
$ ruby unreadable.rb 
ruby: Permission denied -- unreadable.rb (LoadError)
```

TruffleRuby before:

```
$ bin/truffleruby missing.rb
Exception in thread "main" org.graalvm.polyglot.PolyglotException: org.truffleruby.language.control.RaiseException: Can't read file missing.rb
	IOException org.truffleruby.language.loader.SourceLoader.ensureReadable(SourceLoader.java:207)
```

```
$ bin/truffleruby unreadable.rb
Exception in thread "main" org.graalvm.polyglot.PolyglotException: org.truffleruby.language.control.RaiseException: Can't read file missing.rb
	IOException org.truffleruby.language.loader.SourceLoader.ensureReadable(SourceLoader.java:207)
```

```
$ bin/truffleruby exception.rb
exception.rb:10:in `throw_java_exception': message (RubyTruffleError)
	RuntimeException org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwJavaException(TruffleDebugNodes.java:314)
	from exception.rb:10:in `baz'
	from exception.rb:6:in `bar'
	from exception.rb:2:in `foo'
	from exception.rb:13:in `<main>'
```

TruffleRuby after:

```
$ bin/truffleruby missing.rb
truffleruby: No such file or directory -- missing.rb (LoadError)
```

```
$ bin/truffleruby unreadable.rb
truffleruby: Permission denied -- unreadable.rb (LoadError)
```

```
$ bin/truffleruby exception.rb
exception.rb:10:in `throw_java_exception': message (RubyTruffleError)
	RuntimeException org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwJavaException(TruffleDebugNodes.java:314)
	from exception.rb:10:in `baz'
	from exception.rb:6:in `bar'
	from exception.rb:2:in `foo'
	from exception.rb:13:in `<main>'
```