### PR TITLE
Eval node rewrite

### DIFF
--- a/src/main/java/org/truffleruby/builtins/LowerFixnumChecker.java
+++ b/src/main/java/org/truffleruby/builtins/LowerFixnumChecker.java
@@ -48,6 +48,10 @@ public class LowerFixnumChecker {
                     }
                 }
                 if (lowerArgs == null) {
+                    if (end < skip) {
+                        reportError(nodeFactory, "should have needsSelf = false");
+                        return;
+                    }
                     lowerArgs = new byte[end - skip];
                 } else {
                     assert lowerArgs.length == end - skip;
@@ -67,9 +71,13 @@ public class LowerFixnumChecker {
         for (int i = 0; i < lowerArgs.length; i++) {
             boolean shouldLower = lowerArgs[i] == 0b01; // int without long
             if (shouldLower && !ArrayUtils.contains(lowerFixnum, i + 1)) {
-                SUCCESS = false;
-                Log.LOGGER.warning("node " + nodeFactory.getNodeClass().getCanonicalName() + " should use lowerFixnum for argument " + (i + 1));
+                reportError(nodeFactory, "should use lowerFixnum for argument " + (i + 1));
             }
         }
+    }
+
+    private static void reportError(NodeFactory<? extends RubyNode> nodeFactory, String message) {
+        SUCCESS = false;
+        Log.LOGGER.warning("node " + nodeFactory.getNodeClass().getCanonicalName() + " " + message);
     }
 }

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -1627,6 +1627,7 @@ public class CoreLibrary {
             "/core/truffle/ffi/ffi_file.rb",
             "/core/truffle/ffi/ffi_struct.rb",
             "/core/truffle/support.rb",
+            "/core/kernel.rb", // Needed before boot.rb since binding is now in Ruby.
             "/core/truffle/boot.rb",
             "/core/truffle/debug.rb",
             "/core/truffle/string_operations.rb",
@@ -1643,7 +1644,6 @@ public class CoreLibrary {
             "/core/argf.rb",
             "/core/exception.rb",
             "/core/hash.rb",
-            "/core/kernel.rb",
             "/core/comparable.rb",
             "/core/numeric_mirror.rb",
             "/core/numeric.rb",

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -410,8 +410,6 @@ public abstract class BindingNodes {
 
         @Specialization
         public DynamicObject binding(VirtualFrame frame) {
-            // Materialize the caller's frame - false means don't use a slow path to get it - we
-            // want to optimize it
             final MaterializedFrame callerFrame = callerFrameNode.execute(frame).materialize();
 
             return BindingNodes.createBinding(getContext(), callerFrame);

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -401,7 +401,7 @@ public abstract class BindingNodes {
 
     }
 
-    @Primitive(name = "caller_binding")
+    @Primitive(name = "caller_binding", needsSelf = false)
     public abstract static class CallerBindingNode extends PrimitiveArrayArgumentsNode {
 
         @Child ReadCallerFrameNode callerFrameNode = new ReadCallerFrameNode(CallerFrameAccess.MATERIALIZE);

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -14,16 +14,20 @@ import java.util.Set;
 
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
+import org.truffleruby.builtins.CallerFrameAccess;
 import org.truffleruby.builtins.CoreClass;
 import org.truffleruby.builtins.CoreMethod;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.CoreMethodNode;
+import org.truffleruby.builtins.Primitive;
+import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.array.ArrayHelpers;
 import org.truffleruby.core.cast.NameToJavaStringNodeGen;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.Visibility;
+import org.truffleruby.language.arguments.ReadCallerFrameNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.locals.ReadFrameSlotNode;
@@ -45,6 +49,8 @@ import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node.Child;
 import com.oracle.truffle.api.object.DynamicObject;
 
 @CoreClass("Binding")
@@ -395,4 +401,20 @@ public abstract class BindingNodes {
 
     }
 
+    @Primitive(name = "caller_binding")
+    public abstract static class CallerBindingNode extends PrimitiveArrayArgumentsNode {
+
+        @Child ReadCallerFrameNode callerFrameNode = new ReadCallerFrameNode(CallerFrameAccess.MATERIALIZE);
+
+        public abstract DynamicObject executeBinding(VirtualFrame frame);
+
+        @Specialization
+        public DynamicObject binding(VirtualFrame frame) {
+            // Materialize the caller's frame - false means don't use a slow path to get it - we
+            // want to optimize it
+            final MaterializedFrame callerFrame = callerFrameNode.execute(frame).materialize();
+
+            return BindingNodes.createBinding(getContext(), callerFrame);
+        }
+    }
 }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -9,6 +9,8 @@
  */
 package org.truffleruby.core.kernel;
 
+import static org.truffleruby.core.string.StringOperations.rope;
+
 import java.io.File;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -29,6 +31,7 @@ import org.truffleruby.builtins.CoreMethodNode;
 import org.truffleruby.builtins.NonStandard;
 import org.truffleruby.builtins.Primitive;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
+import org.truffleruby.builtins.PrimitiveNode;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.Hashing;
 import org.truffleruby.core.array.ArrayUtils;
@@ -458,33 +461,12 @@ public abstract class KernelNodes {
 
     }
 
-    @CoreMethod(names = "eval", isModuleFunction = true, required = 1, optional = 3, lowerFixnum = 4)
-    @NodeChildren({
-            @NodeChild(value = "source", type = RubyNode.class),
-            @NodeChild(value = "binding", type = RubyNode.class),
-            @NodeChild(value = "file", type = RubyNode.class),
-            @NodeChild(value = "line", type = RubyNode.class)
-    })
+    @Primitive(name = "kernel_eval", needsSelf = false)
     @ImportStatic({ StringCachingGuards.class, StringOperations.class })
-    public abstract static class EvalNode extends CoreMethodNode {
+    public abstract static class EvalNode extends PrimitiveArrayArgumentsNode {
 
-        @Child private CallDispatchHeadNode toStr;
         @Child private BindingNodes.CallerBindingNode bindingNode;
         @Child ReadCallerFrameNode callerFrameNode = new ReadCallerFrameNode(CallerFrameAccess.MATERIALIZE);
-
-        @CreateCast("source")
-        public RubyNode coerceSourceToString(RubyNode source) {
-            return ToStrNodeGen.create(source);
-        }
-
-        protected DynamicObject getCallerBinding(VirtualFrame frame) {
-            if (bindingNode == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                bindingNode = insert(BindingNodesFactory.CallerBindingNodeFactory.create(null));
-            }
-
-            return bindingNode.executeBinding(frame);
-        }
 
         protected static class RootNodeWrapper {
             private final RubyRootNode rootNode;
@@ -498,76 +480,67 @@ public abstract class KernelNodes {
             }
         }
 
-        // We always cache against the caller's frame descriptor to avoid breaking assumptions about
-        // the shapes of declaration frames made in other areas. Specifically other code in the
-        // runtime assumes that a frame with a particular shape will always have a chain of
-        // declaration frame also of stable shapes. This assumption could be broken by code such
-        // as eval("binding") which does not depend on a declaration context from the parses point
-        // of view but could produce frames that broke the assumption.
+        public abstract Object execute(VirtualFrame frame, Object self, DynamicObject str, DynamicObject binding, DynamicObject file, int line);
+
         @Specialization(guards = {
-                "isRubyString(source)",
                 "equalNode.execute(rope(source), cachedSource)",
-                "callerDescriptor == callerFrameNode.execute(frame).getFrameDescriptor()",
-        }, limit = "getCacheLimit()")
-        public Object evalNoBindingCached(
-                VirtualFrame frame,
-                DynamicObject source,
-                NotProvided binding,
-                NotProvided file,
-                NotProvided line,
-                @Cached("privatizeRope(source)") Rope cachedSource,
-                @Cached("callerFrameNode.execute(frame).getFrameDescriptor()") FrameDescriptor callerDescriptor,
-                @Cached("compileSource(source, callerFrameNode.execute(frame).materialize())") RootNodeWrapper cachedRootNode,
-                @Cached("createCallTarget(cachedRootNode)") CallTarget cachedCallTarget,
-                @Cached("create(cachedCallTarget)") DirectCallNode callNode,
-                @Cached("create()") RopeNodes.EqualNode equalNode) {
-            final MaterializedFrame parentFrame = callerFrameNode.execute(frame).materialize();
-            return eval(RubyArguments.getSelf(frame), cachedRootNode, cachedCallTarget, callNode, parentFrame);
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)"
-        }, replaces = "evalNoBindingCached")
-        public Object evalNoBindingUncached(VirtualFrame frame, DynamicObject source, NotProvided noBinding, NotProvided file, NotProvided line,
-                @Cached("create()") IndirectCallNode callNode) {
-            final DynamicObject binding = getCallerBinding(frame);
-            final MaterializedFrame topFrame = Layouts.BINDING.getFrame(binding);
-            RubyArguments.setSelf(topFrame, RubyArguments.getSelf(frame));
-            final CodeLoader.DeferredCall deferredCall = doEvalX(source, binding, "(eval)", 1, true);
-            return deferredCall.call(callNode);
-
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "isNil(noBinding)",
-                "isRubyString(file)"
-        })
-        public Object evalNilBinding(VirtualFrame frame, DynamicObject source, DynamicObject noBinding, DynamicObject file, Object unusedLine,
-                @Cached("create()") IndirectCallNode callNode) {
-            return evalNoBindingUncached(frame, source, NotProvided.INSTANCE, NotProvided.INSTANCE, NotProvided.INSTANCE, callNode);
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "equalNode.execute(rope(source), cachedSource)",
-                "isRubyBinding(binding)",
+                "equalNode.execute(rope(file), cachedFile)",
+                "line == cachedLine",
                 "assignsNoNewVariables(cachedRootNode)",
                 "bindingDescriptor == getBindingDescriptor(binding)"
         }, limit = "getCacheLimit()")
-        public Object evalBindingCached(
+        public Object evalBindingNoAddsVarsCached(
+                Object self,
                 DynamicObject source,
                 DynamicObject binding,
-                NotProvided file,
-                NotProvided line,
+                DynamicObject file,
+                int line,
                 @Cached("privatizeRope(source)") Rope cachedSource,
+                @Cached("privatizeRope(file)") Rope cachedFile,
+                @Cached("line") int cachedLine,
                 @Cached("getBindingDescriptor(binding)") FrameDescriptor bindingDescriptor,
-                @Cached("compileSource(source, getBindingFrame(binding))") RootNodeWrapper cachedRootNode,
+                @Cached("compileSource(cachedSource, getBindingFrame(binding), cachedFile, cachedLine)") RootNodeWrapper cachedRootNode,
                 @Cached("createCallTarget(cachedRootNode)") CallTarget cachedCallTarget,
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode,
                 @Cached("create()") RopeNodes.EqualNode equalNode) {
             final MaterializedFrame parentFrame = BindingNodes.getTopFrame(binding);
-            return eval(RubyArguments.getSelf(parentFrame), cachedRootNode, cachedCallTarget, callNode, parentFrame);
+            return eval(self, cachedRootNode, cachedCallTarget, callNode, parentFrame);
+        }
+
+        @Specialization(guards = {
+                "equalNode.execute(rope(source), cachedSource)",
+                "equalNode.execute(rope(file), cachedFile)",
+                "line == cachedLine",
+                "!assignsNoNewVariables(cachedRootNode)",
+                "assignsNoNewVariables(rootNodeToEval)",
+                "bindingDescriptor == getBindingDescriptor(binding)"
+        }, limit = "getCacheLimit()")
+        public Object evalBindingAddsVarsCached(
+                Object self,
+                DynamicObject source,
+                DynamicObject binding,
+                DynamicObject file,
+                int line,
+                @Cached("privatizeRope(source)") Rope cachedSource,
+                @Cached("privatizeRope(file)") Rope cachedFile,
+                @Cached("line") int cachedLine,
+                @Cached("getBindingDescriptor(binding)") FrameDescriptor bindingDescriptor,
+                @Cached("compileSource(cachedSource, getBindingFrame(binding), cachedFile, cachedLine)") RootNodeWrapper cachedRootNode,
+                @Cached("newBindingDescriptor(getContext(), cachedRootNode)") FrameDescriptor newBindingDescriptor,
+                @Cached("compileSource(cachedSource, getBindingFrame(binding), newBindingDescriptor, cachedFile, cachedLine)") RootNodeWrapper rootNodeToEval,
+                @Cached("createCallTarget(rootNodeToEval)") CallTarget cachedCallTarget,
+                @Cached("create(cachedCallTarget)") DirectCallNode callNode,
+                @Cached("create()") RopeNodes.EqualNode equalNode) {
+            final MaterializedFrame parentFrame = BindingNodes.newExtrasFrame(binding,
+                    newBindingDescriptor);
+            return eval(self, rootNodeToEval, cachedCallTarget, callNode, parentFrame);
+        }
+
+        @Specialization
+        public Object evalBindingUncached(Object self, DynamicObject source, DynamicObject binding, DynamicObject file, int line,
+                @Cached("create()") IndirectCallNode callNode) {
+            final CodeLoader.DeferredCall deferredCall = doEvalX(self, rope(source), binding, rope(file), line, false);
+            return deferredCall.call(callNode);
         }
 
         private Object eval(Object self, RootNodeWrapper rootNode, CallTarget callTarget, DirectCallNode callNode, MaterializedFrame parentFrame) {
@@ -583,141 +556,42 @@ public abstract class KernelNodes {
             return callNode.call(RubyArguments.pack(parentFrame, null, method, RubyArguments.getDeclarationContext(parentFrame), null, self, null, new Object[]{}));
         }
 
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "equalNode.execute(rope(source), cachedSource)",
-                "isRubyBinding(binding)",
-                "!assignsNoNewVariables(cachedRootNode)",
-                "assignsNoNewVariables(rootNodeToEval)",
-                "bindingDescriptor == getBindingDescriptor(binding)"
-        }, limit = "getCacheLimit()")
-        public Object evalBindingAddsVarsCached(
-                DynamicObject source,
-                DynamicObject binding,
-                NotProvided file,
-                NotProvided line,
-                @Cached("privatizeRope(source)") Rope cachedSource,
-                @Cached("getBindingDescriptor(binding)") FrameDescriptor bindingDescriptor,
-                @Cached("compileSource(source, getBindingFrame(binding))") RootNodeWrapper cachedRootNode,
-                @Cached("newBindingDescriptor(getContext(), cachedRootNode)") FrameDescriptor newBindingDescriptor,
-                @Cached("compileSource(source, getBindingFrame(binding), newBindingDescriptor)") RootNodeWrapper rootNodeToEval,
-                @Cached("createCallTarget(rootNodeToEval)") CallTarget cachedCallTarget,
-                @Cached("create(cachedCallTarget)") DirectCallNode callNode,
-                @Cached("create()") RopeNodes.EqualNode equalNode) {
-            final MaterializedFrame parentFrame = BindingNodes.newExtrasFrame(binding,
-                    newBindingDescriptor);
-            return eval(RubyArguments.getSelf(parentFrame), rootNodeToEval, cachedCallTarget, callNode, parentFrame);
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "isRubyBinding(binding)"
-        })
-        public Object evalBinding(VirtualFrame frame, DynamicObject source, DynamicObject binding, NotProvided file, NotProvided line,
-                @Cached("create()") IndirectCallNode callNode) {
-            final CodeLoader.DeferredCall deferredCall = doEvalX(source, binding, "(eval)", 1, false);
-            return deferredCall.call(callNode);
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "isRubyBinding(binding)",
-                "isNil(noFile)",
-                "isNil(noLine)"
-        })
-        public Object evalBinding(VirtualFrame frame, DynamicObject source, DynamicObject binding, DynamicObject noFile, DynamicObject noLine,
-                @Cached("create()") IndirectCallNode callNode) {
-            return evalBinding(frame, source, binding, NotProvided.INSTANCE, NotProvided.INSTANCE, callNode);
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "isRubyBinding(binding)",
-                "isRubyString(file)" })
-        public Object evalBindingFilename(VirtualFrame frame, DynamicObject source, DynamicObject binding, DynamicObject file, NotProvided line,
-                @Cached("create()") IndirectCallNode callNode) {
-            return evalBindingFilenameLine(frame, source, binding, file, 0, callNode);
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "isRubyBinding(binding)",
-                "isRubyString(file)",
-                "isNil(noLine)"
-        })
-        public Object evalBindingFilename(VirtualFrame frame, DynamicObject source, DynamicObject binding, DynamicObject file, DynamicObject noLine,
-                @Cached("create()") IndirectCallNode callNode) {
-            return evalBindingFilename(frame, source, binding, file, NotProvided.INSTANCE, callNode);
-        }
-
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "isRubyBinding(binding)",
-                "isRubyString(file)" })
-        public Object evalBindingFilenameLine(VirtualFrame frame, DynamicObject source, DynamicObject binding, DynamicObject file, int line,
-                @Cached("create()") IndirectCallNode callNode) {
-            final CodeLoader.DeferredCall deferredCall = doEvalX(source, binding, file.toString(), line, false);
-            return deferredCall.call(callNode);
-        }
-
         @TruffleBoundary
-        @Specialization(guards = {
-                "isRubyString(source)",
-                "!isRubyBinding(badBinding)" })
-        public Object evalBadBinding(DynamicObject source, DynamicObject badBinding, NotProvided file, NotProvided line) {
-            throw new RaiseException(coreExceptions().typeErrorWrongArgumentType(badBinding, "binding", this));
-        }
-
-        @TruffleBoundary
-        private CodeLoader.DeferredCall doEvalX(DynamicObject rubySource,
+        private CodeLoader.DeferredCall doEvalX(Object self, Rope source,
                 DynamicObject binding,
-                String file,
+                Rope file,
                 int line,
                 boolean ownScopeForAssignments) {
-            final Rope code = StringOperations.rope(rubySource);
-
-            // TODO (pitr 15-Oct-2015): fix this ugly hack, required for AS, copy-paste
-            final String s = new String(new char[Math.max(line - 1, 0)]);
-            final String space = StringUtils.replace(s, "\0", "\n");
-            // TODO CS 14-Apr-15 concat space + code as a rope, otherwise the string will be copied
-            // after the rope is converted
-            final Source source = Source.newBuilder(space + RopeOperations.decodeRope(code)).name(file).mimeType(RubyLanguage.MIME_TYPE).build();
-
             final MaterializedFrame frame = BindingNodes.getExtrasFrame(getContext(), binding);
             final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(frame);
-            final RubyRootNode rootNode = getContext().getCodeLoader().parse(
-                    source, code.getEncoding(), ParserContext.EVAL, frame, ownScopeForAssignments, this);
+            RubyRootNode rootNode = buildRootNode(source, frame, file, line, false);
             return getContext().getCodeLoader().prepareExecute(
-                    ParserContext.EVAL, declarationContext, rootNode, frame, RubyArguments.getSelf(frame));
+                    ParserContext.EVAL, declarationContext, rootNode, frame, self);
         }
 
-        protected RootNodeWrapper compileSource(VirtualFrame frame, DynamicObject sourceText) {
-            assert RubyGuards.isRubyString(sourceText);
+        protected RubyRootNode buildRootNode(Rope sourceText, MaterializedFrame parentFrame, Rope file, int line, boolean ownScopeForAssignments) {
 
-            final DynamicObject callerBinding = getCallerBinding(frame);
-            final MaterializedFrame parentFrame = Layouts.BINDING.getFrame(callerBinding);
-
-            final Encoding encoding = Layouts.STRING.getRope(sourceText).getEncoding();
-            final Source source = Source.newBuilder(sourceText.toString()).name("(eval)").mimeType(RubyLanguage.MIME_TYPE).build();
+            String sourceString;
+            if (line > 0) {
+                String s = StringUtils.replace(new String(new char[Math.max(line - 1, 0)]), '\0', '\n');
+                sourceString = s + sourceText.toString();
+            } else {
+                sourceString = sourceText.toString();
+            }
+            final Encoding encoding = sourceText.getEncoding();
+            final Source source = Source.newBuilder(sourceString).name(file.toString()).mimeType(RubyLanguage.MIME_TYPE).build();
 
             final TranslatorDriver translator = new TranslatorDriver(getContext());
 
-            return new RootNodeWrapper(translator.parse(source, encoding, ParserContext.EVAL, null, null, parentFrame, true, this));
+            return translator.parse(source, encoding, ParserContext.EVAL, null, null, parentFrame, ownScopeForAssignments, this);
         }
 
-        protected RootNodeWrapper compileSource(DynamicObject sourceText, MaterializedFrame parentFrame) {
-            assert RubyGuards.isRubyString(sourceText);
-
-            final Encoding encoding = Layouts.STRING.getRope(sourceText).getEncoding();
-            final Source source = Source.newBuilder(sourceText.toString()).name("(eval)").mimeType(RubyLanguage.MIME_TYPE).build();
-
-            final TranslatorDriver translator = new TranslatorDriver(getContext());
-
-            return new RootNodeWrapper(translator.parse(source, encoding, ParserContext.EVAL, null, null, parentFrame, true, this));
+        protected RootNodeWrapper compileSource(Rope sourceText, MaterializedFrame parentFrame, Rope file, int line) {
+            return new RootNodeWrapper(buildRootNode(sourceText, parentFrame, file, line, true));
         }
 
-        protected RootNodeWrapper compileSource(DynamicObject sourceText, MaterializedFrame parentFrame, FrameDescriptor additionalVariables) {
-            return compileSource(sourceText, BindingNodes.newExtrasFrame(parentFrame, additionalVariables));
+        protected RootNodeWrapper compileSource(Rope sourceText, MaterializedFrame parentFrame, FrameDescriptor additionalVariables, Rope file, int line) {
+            return compileSource(sourceText, BindingNodes.newExtrasFrame(parentFrame, additionalVariables), file, line);
         }
 
         protected CallTarget createCallTarget(RootNodeWrapper rootNode) {

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -461,7 +461,7 @@ public abstract class KernelNodes {
 
     }
 
-    @Primitive(name = "kernel_eval", needsSelf = false)
+    @Primitive(name = "kernel_eval", needsSelf = false, lowerFixnum = 5)
     @ImportStatic({ StringCachingGuards.class, StringOperations.class })
     public abstract static class EvalNode extends PrimitiveArrayArgumentsNode {
 

--- a/src/main/ruby/core/enumerator.rb
+++ b/src/main/ruby/core/enumerator.rb
@@ -541,11 +541,3 @@ class Enumerator
     end
   end
 end
-
-module Kernel
-  def to_enum(method=:each, *args)
-    Enumerator.new(self, method, *args)
-  end
-
-  alias_method :enum_for, :to_enum
-end

--- a/src/main/ruby/core/kernel.rb
+++ b/src/main/ruby/core/kernel.rb
@@ -226,6 +226,30 @@ module Kernel
     port.write self
   end
 
+  def eval(str, a_binding=nil, file=nil, line=nil)
+    file = '(eval)' unless file
+    line = 0 unless line
+    str = str.to_str unless str.class == String
+    file = file.to_str unless file.class == String
+    line = line.to_i unless line.class == Fixnum
+    unless a_binding
+      receiver = self
+      a_binding = Truffle.invoke_primitive(:caller_binding)
+    else
+      unless a_binding.class == Binding
+        raise TypeError, "Wrong argument type #{a_binding.class} (expected binding)"
+      end
+      receiver = a_binding.receiver
+    end
+
+    Truffle.invoke_primitive(:kernel_eval, receiver, str, a_binding, file, line)
+  end
+  module_function :eval
+
+  # It is important that eval is always cloned so that the primitive
+  # inside can be specialised efficiently.
+  Truffle::Graal.always_split(method(:eval))
+
   def exec(*args)
     Process.exec(*args)
   end

--- a/src/main/ruby/core/kernel.rb
+++ b/src/main/ruby/core/kernel.rb
@@ -211,6 +211,11 @@ module Kernel
   end
   private :autoload?
 
+  def binding
+    Truffle.invoke_primitive(:caller_binding)
+  end
+  module_function :binding
+
   alias_method :iterator?, :block_given?
 
   def define_singleton_method(*args, &block)


### PR DESCRIPTION
This PR converts the EvalNode from a method to a primitive and replaces the other specialisations with a small amount of logic in Ruby. Since this also required getting the caller's binding in an efficient manner a primitive has been introduced to do so, and `Kernel#binding` has been rewritten in Ruby to use this new mechanism.