### PR TITLE
Fix C extensions to define weakly inlined functions in ruby.h

### DIFF
--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -41,7 +41,7 @@ extern "C" {
 // Support
 
 #define RUBY_CEXT (void *)truffle_import_cached("ruby_cext")
-#define MUST_INLINE __attribute__((always_inline))
+#define MUST_INLINE __attribute__((always_inline)) inline
 
 // Configuration
 


### PR DESCRIPTION
cc @rschatz