### PR TITLE
Allow to set TRUFFLERUBY_CEXT_ENABLED=false to not build cexts with mx build

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -49,6 +49,13 @@ common: ${common-base} {
   }
 }
 
+common-solaris: ${common-base} {
+  environment: {
+    # LLVM is currently not available on Solaris
+    TRUFFLERUBY_CEXT_ENABLED: "false"
+  }
+}
+
 common-darwin: ${common-base} {
   packages: {
     # Homebrew doesn't support versions.
@@ -493,7 +500,7 @@ deploy-and-test-fast-darwin: {
 builds: [
   {name: ruby-deploy-and-test-fast-linux} ${common} ${gate-caps} ${deploy-and-test-fast},
   {name: ruby-deploy-and-test-fast-darwin} ${common-darwin} ${gate-caps-darwin} ${deploy-and-test-fast-darwin},
-  {name: ruby-deploy-and-test-fast-solaris} ${common} ${gate-caps-solaris} ${deploy-and-test-fast},
+  {name: ruby-deploy-and-test-fast-solaris} ${common-solaris} ${gate-caps-solaris} ${deploy-and-test-fast},
 
   {name: ruby-test-tck} ${common} ${gate-caps} {run: [[mx, rubytck]]},
   {name: ruby-test-specs-command-line} ${common} ${gate-caps} {run: [${jt} [test, specs, ":command_line"]]},
@@ -526,9 +533,9 @@ builds: [
   //{name: ruby-benchmarks-classic-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${classic-benchmarks},
   //{name: ruby-benchmarks-classic-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${truffleruby} ${classic-benchmarks},
   {name: ruby-benchmarks-classic-graal-core} ${common} ${graal-core} ${bench-caps} ${truffleruby} ${classic-benchmarks},
-  {name: ruby-benchmarks-classic-graal-core-solaris} ${common} ${graal-core} ${daily-bench-caps-solaris} ${truffleruby} ${classic-benchmarks-solaris},
+  {name: ruby-benchmarks-classic-graal-core-solaris} ${common-solaris} ${graal-core} ${daily-bench-caps-solaris} ${truffleruby} ${classic-benchmarks-solaris},
   {name: ruby-benchmarks-classic-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${truffleruby} ${classic-benchmarks},
-  {name: ruby-benchmarks-classic-graal-enterprise-solaris} ${common} ${graal-enterprise} ${daily-bench-caps-solaris} ${truffleruby} ${classic-benchmarks-solaris},
+  {name: ruby-benchmarks-classic-graal-enterprise-solaris} ${common-solaris} ${graal-enterprise} ${daily-bench-caps-solaris} ${truffleruby} ${classic-benchmarks-solaris},
   {name: ruby-benchmarks-classic-graal-enterprise-no-om} ${common} ${graal-enterprise-no-om} ${daily-bench-caps} ${truffleruby} ${classic-benchmarks},
   //{name: ruby-benchmarks-classic-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${truffleruby} ${classic-benchmarks},
   {name: ruby-benchmarks-classic-svm} ${common} ${svm-bench} ${bench-caps} ${truffleruby} ${classic-benchmarks} {timelimit: "01:10:00"},

--- a/lib/patches/stdlib/rubygems/basic_specification.rb
+++ b/lib/patches/stdlib/rubygems/basic_specification.rb
@@ -1,6 +1,6 @@
 Truffle::Patching.require_original __FILE__
 
-unless ENV['TRUFFLERUBY_CEXT_ENABLED']
+if !ENV['TRUFFLERUBY_CEXT_ENABLED'] || ENV['TRUFFLERUBY_CEXT_ENABLED'] == "false"
   module Truffle::Patching::NoWarnIfBuildingCextDisabled
     def contains_requirable_file? file
       if @ignored then

--- a/lib/patches/stdlib/rubygems/ext.rb
+++ b/lib/patches/stdlib/rubygems/ext.rb
@@ -6,7 +6,7 @@ module Truffle::Patching::ConditionallyBuildNativeExtensions
   def build_extensions
     return if @spec.extensions.empty?
 
-    if ENV['TRUFFLERUBY_CEXT_ENABLED']
+    if ENV['TRUFFLERUBY_CEXT_ENABLED'] && ENV['TRUFFLERUBY_CEXT_ENABLED'] != "false"
       super
     else
       puts "WORKAROUND: Not building native extensions for #{@spec.name}.\n" +

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -2,14 +2,14 @@ ROOT := $(realpath ../../..)
 RUBY := $(ROOT)/bin/truffleruby
 OS := $(shell uname)
 
-ifeq ($(OS),SunOS)
-goal: no_clang
+ifeq ($(TRUFFLERUBY_CEXT_ENABLED),false)
+goal: no_cexts
 else
 goal: all
 endif
 
-no_clang:
-	@echo "WARNING: clang is not avaiable on this platform - not building cexts" 1>&2
+no_cexts: clean
+	@echo "WARNING: TRUFFLERUBY_CEXT_ENABLED is set to false - not building cexts" 1>&2
 
 all: $(ROOT)/lib/cext/ruby.su $(ROOT)/lib/mri/openssl.su $(ROOT)/lib/mri/zlib.su
 
@@ -50,4 +50,3 @@ zlib/zlib.su: zlib/Makefile zlib/zlib.c
 
 $(ROOT)/lib/mri/zlib.su: zlib/zlib.su
 	cp $< $@
-


### PR DESCRIPTION
* Consider TRUFFLERUBY_CEXT_ENABLED=false as disabled in patches as well.