### PR TITLE
Consistent C exts tests

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -155,10 +155,7 @@ sulong: ${labsjdk8} {
   environment: {
     CPPFLAGS: "-I$LIBGMP/include",
     LD_LIBRARY_PATH: "$LIBGMP/lib:$LLVM/lib:$LD_LIBRARY_PATH",
-    GRAAL_HOME: "$PWD/../sulong",
     LIBXML_LIB: "/usr/lib64/libxml2.so.2",
-    HOST_VM: server,
-    HOST_VM_CONFIG: graal-core
   }
 
   setup: ${common.setup} [
@@ -573,5 +570,5 @@ builds: [
   //{name: ruby-benchmarks-server-graal-vm-snapshot} ${common} ${graal-vm-snapshot} ${bench-caps} ${truffleruby} ${server-benchmarks},
   {name: ruby-benchmarks-server-svm} ${common} ${svm-bench} ${bench-caps} ${truffleruby} ${server-benchmarks},
 
-  {name: ruby-benchmarks-cext} ${common} ${daily-bench-caps} ${truffleruby-cexts} ${cext-benchmarks},
+  {name: ruby-benchmarks-cext} ${common} ${graal-core} ${daily-bench-caps} ${truffleruby-cexts} ${cext-benchmarks},
 ]

--- a/ci.hocon
+++ b/ci.hocon
@@ -448,11 +448,7 @@ test-cexts: ${sulong} ${gem-test-pack} {
   setup: ${sulong.setup} ${gem-test-pack.setup}
 
   run: [
-    ${jt} [test, bundle, --openssl],
-    ${jt} [test, cexts],
-    ${jt} [test, specs, --sulong, ":capi"],
-    ${jt} [test, specs, --sulong, "-T-Xpatching=false", ":openssl"],
-    ${jt} [test, mri, --openssl, --sulong]
+    [mx, "--dynamicimports", "sulong", ruby_testdownstream_sulong]
   ]
 }
 

--- a/ci.hocon
+++ b/ci.hocon
@@ -156,7 +156,6 @@ sulong: ${labsjdk8} {
     CPPFLAGS: "-I$LIBGMP/include",
     LD_LIBRARY_PATH: "$LIBGMP/lib:$LLVM/lib:$LD_LIBRARY_PATH",
     GRAAL_HOME: "$PWD/../sulong",
-    SULONG_HOME: "$PWD/../sulong",
     LIBXML_LIB: "/usr/lib64/libxml2.so.2",
     HOST_VM: server,
     HOST_VM_CONFIG: graal-core

--- a/doc/contributor/cexts.md
+++ b/doc/contributor/cexts.md
@@ -3,7 +3,14 @@
 ## Setup
 
 TruffleRuby runs C extension using Sulong. You should build Sulong from source.
-Clone from https://github.com/graalvm/sulong.
+Clone Sulong as a sibling directory and build it:
+
+```bash
+# In the truffleruby repo
+git clone https://github.com/graalvm/sulong.git ../sulong
+cd ../sulong
+mx build
+```
 
 You need LLVM installed - version 3.8 or above we think but we haven't tested
 many versions.
@@ -21,7 +28,6 @@ If you want to use a different version of OpenSSL you then need to set
 You can now build the C extension support.
 
 ```bash
-export SULONG_HOME=/absolute/path/to/sulong
 export PATH="/usr/local/opt/llvm/bin:$PATH"
 jt build
 ```

--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -139,11 +139,11 @@ def ruby_testdownstream_sulong(args):
     sulong = mx.suite('sulong')
     os.environ['SULONG_HOME'] = sulong.dir
 
-    jt('test', 'bundle', '--openssl')
     jt('test', 'cexts')
     jt('test', 'specs', '--sulong', ':capi')
     jt('test', 'specs', '--sulong', '-T-Xpatching=false', ':openssl')
     jt('test', 'mri', '--openssl', '--sulong')
+    jt('test', 'bundle', '--openssl')
 
 mx.update_commands(_suite, {
     'rubytck': [ruby_tck, ''],

--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -136,8 +136,8 @@ def ruby_testdownstream_aot(args):
 
 def ruby_testdownstream_sulong(args):
     build_truffleruby()
-    sulong = mx.suite('sulong')
-    os.environ['SULONG_HOME'] = sulong.dir
+    # Ensure Sulong is available
+    mx.suite('sulong')
 
     jt('test', 'cexts')
     jt('test', 'specs', '--sulong', ':capi')

--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -78,6 +78,10 @@ class TruffleRubyLauncherBuildTask(mx.ArchivableBuildTask):
 
 # Commands
 
+def jt(*args):
+    mx.log("\n$ " + ' '.join(['jt'] + list(args)) + "\n")
+    mx.run(['ruby', join(root, 'tool/jt.rb')] + list(args))
+
 def build_truffleruby():
     mx.command_function('sversions')([])
     mx.command_function('build')([])
@@ -134,7 +138,12 @@ def ruby_testdownstream_sulong(args):
     build_truffleruby()
     sulong = mx.suite('sulong')
     os.environ['SULONG_HOME'] = sulong.dir
-    mx.run(['ruby', 'tool/jt.rb', 'test', '--sulong', ':capi'])
+
+    jt('test', 'bundle', '--openssl')
+    jt('test', 'cexts')
+    jt('test', 'specs', '--sulong', ':capi')
+    jt('test', 'specs', '--sulong', '-T-Xpatching=false', ':openssl')
+    jt('test', 'mri', '--openssl', '--sulong')
 
 mx.update_commands(_suite, {
     'rubytck': [ruby_tck, ''],

--- a/tool/docker/oraclelinux/Dockerfile
+++ b/tool/docker/oraclelinux/Dockerfile
@@ -48,7 +48,6 @@ ENV GRAAL_HOME=/build/graal/compiler
 # Build Sulong
 RUN git clone https://github.com/graalvm/sulong.git
 RUN cd sulong && mx build
-ENV SULONG_HOME=/build/sulong
 
 # Build TruffleRuby
 RUN git clone https://github.com/graalvm/truffleruby.git

--- a/tool/docker/ubuntu/Dockerfile
+++ b/tool/docker/ubuntu/Dockerfile
@@ -45,7 +45,6 @@ ENV GRAAL_HOME=/build/graal/compiler
 # Build Sulong
 RUN git clone https://github.com/graalvm/sulong.git
 RUN cd sulong && mx build
-ENV SULONG_HOME=/build/sulong
 
 # Build TruffleRuby
 RUN git clone https://github.com/graalvm/truffleruby.git

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -43,6 +43,9 @@ SO = MAC ? 'dylib' : 'so'
 ENV['GEM_HOME'] = File.expand_path(ENV['GEM_HOME']) if ENV['GEM_HOME']
 
 SULONG_HOME = ENV['SULONG_HOME'] = ENV['SULONG_HOME'] && File.expand_path(ENV['SULONG_HOME'])
+if SULONG_HOME and File.dirname(TRUFFLERUBY_DIR) != File.dirname(SULONG_HOME)
+  abort 'SULONG_HOME must be a sibling of TRUFFLERUBY_DIR to allow for --dynamicimports'
+end
 
 LIBXML_HOME = ENV['LIBXML_HOME'] = ENV['LIBXML_HOME'] || '/usr'
 LIBXML_LIB_HOME = ENV['LIBXML_LIB_HOME'] = ENV['LIBXML_LIB_HOME'] || "#{LIBXML_HOME}/lib"
@@ -348,15 +351,12 @@ module ShellUtils
     end
   end
 
-  def mx(dir, *args)
-    command = ['mx', '-p', dir]
-    command.push *args
-    sh *command
+  def mx(*args)
+    sh 'mx', *args
   end
 
   def mx_sulong(*args)
-    abort "You need to set SULONG_HOME" unless SULONG_HOME
-    mx SULONG_HOME, *args
+    mx '--dynamicimports', 'sulong', *args
   end
 
   def mspec(command, *args)
@@ -1566,9 +1566,9 @@ module Commands
   alias :'native-launcher' :native_launcher
 
   def check_dsl_usage
-    mx(TRUFFLERUBY_DIR, 'clean')
+    mx('clean')
     # We need to build with -parameters to get parameter names
-    mx(TRUFFLERUBY_DIR, 'build', '-A-parameters')
+    mx('build', '-A-parameters')
     run({ "TRUFFLE_CHECK_DSL_USAGE" => "true" }, '-e', 'exit')
   end
 


### PR DESCRIPTION
* Test the same way as it's run in Sulong's gate.
* Run all cexts tests.
* Use `--dynamicimports sulong` and removes `SULONG_HOME`.