### PR TITLE
exec() when running specs

### DIFF
--- a/spec/ruby/optional/capi/ext/io_spec.c
+++ b/spec/ruby/optional/capi/ext/io_spec.c
@@ -151,9 +151,9 @@ VALUE io_spec_rb_io_wait_readable(VALUE self, VALUE io, VALUE read_p) {
     }
     saved_errno = errno;
     rb_ivar_set(self, rb_intern("@write_data"), Qtrue);
+    errno = saved_errno;
   }
 
-  errno = saved_errno;
   ret = rb_io_wait_readable(fd);
 
   if(RTEST(read_p)) {
@@ -162,7 +162,6 @@ VALUE io_spec_rb_io_wait_readable(VALUE self, VALUE io, VALUE read_p) {
       perror("read");
       return INT2FIX(r);
     }
-    buf[r] = '\0';
     rb_ivar_set(self, rb_intern("@read_data"),
         rb_str_new(buf, RB_IO_WAIT_READABLE_BUF));
   }

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -699,14 +699,10 @@ module Commands
 
     case path
     when nil
-      test_tck
-      test_specs('run')
-      test_mri
-      test_integration
-      test_gems
-      test_ecosystem 'HAS_REDIS' => 'true'
-      test_compiler
-      test_cexts
+      ENV['HAS_REDIS'] = 'true'
+      %w[tck specs mri integration gems ecosystem compiler cexts].each do |kind|
+        jt('test', kind)
+      end
     when 'bundle' then test_bundle(*rest)
     when 'compiler' then test_compiler(*rest)
     when 'cexts' then test_cexts(*rest)
@@ -726,6 +722,11 @@ module Commands
       end
     end
   end
+
+  def jt(*args)
+    sh RbConfig.ruby, 'tool/jt.rb', *args
+  end
+  private :jt
 
   def test_mri(*args)
     if args.delete('--openssl')

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -700,7 +700,7 @@ module Commands
     case path
     when nil
       ENV['HAS_REDIS'] = 'true'
-      %w[tck specs mri integration gems ecosystem compiler cexts].each do |kind|
+      %w[bundle compiler cexts integration gems ecosystem specs tck mri].each do |kind|
         jt('test', kind)
       end
     when 'bundle' then test_bundle(*rest)

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -707,9 +707,9 @@ module Commands
     when 'compiler' then test_compiler(*rest)
     when 'cexts' then test_cexts(*rest)
     when 'report' then test_report(*rest)
-    when 'integration' then test_integration({}, *rest)
-    when 'gems' then test_gems({}, *rest)
-    when 'ecosystem' then test_ecosystem({}, *rest)
+    when 'integration' then test_integration(*rest)
+    when 'gems' then test_gems(*rest)
+    when 'ecosystem' then test_ecosystem(*rest)
     when 'specs' then test_specs('run', *rest)
     when 'tck' then
       test_tck
@@ -898,9 +898,7 @@ module Commands
     end
   end
 
-  def test_integration(env={}, *args)
-    env = env.dup
-
+  def test_integration(*args)
     classpath = []
 
     if ENV['GRAAL_JS_JAR']
@@ -911,6 +909,7 @@ module Commands
       classpath << Utilities.find_sl
     end
 
+    env = {}
     unless classpath.empty?
       env['JAVA_OPTS'] = "-cp #{classpath.join(':')}"
     end
@@ -926,11 +925,10 @@ module Commands
   end
   private :test_integration
 
-  def test_gems(env={}, *args)
+  def test_gems(*args)
     gem_test_pack
 
-    env = env.dup
-
+    env = {}
     if ENV['GRAAL_JS_JAR']
       env['JAVA_OPTS'] = "-cp #{Utilities.find_graal_js}"
     end
@@ -946,7 +944,7 @@ module Commands
   end
   private :test_gems
 
-  def test_ecosystem(env={}, *args)
+  def test_ecosystem(*args)
     gem_test_pack
 
     tests_path             = "#{TRUFFLERUBY_DIR}/test/truffle/ecosystem"
@@ -954,9 +952,9 @@ module Commands
     test_names             = single_test ? '{' + args.join(',') + '}' : '*'
 
     success = Dir["#{tests_path}/#{test_names}.sh"].sort.all? do |test_script|
-      sh env, test_script, continue_on_failure: true
+      sh test_script, continue_on_failure: true
     end
-    exit success ? 0 : 1
+    exit success
   end
   private :test_ecosystem
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -365,9 +365,9 @@ module ShellUtils
     if i = args.index('-t')
       launcher = args[i+1]
       flags = args.select { |arg| arg.start_with?('-T') }.map { |arg| arg[2..-1] }
-      sh env_vars, launcher, *flags, *mspec_args
+      sh env_vars, launcher, *flags, *mspec_args, { use_exec: true }
     else
-      run env_vars, *mspec_args
+      ruby env_vars, *mspec_args
     end
   end
 


### PR DESCRIPTION
In case the parent process tries to kill the `jt.rb` process, then it will rightly kill the spec process and not just jt.rb.