### PR TITLE
Remove extra's frame creation from `Binding#dup`.

### DIFF
--- a/src/main/java/org/truffleruby/core/binding/BindingLayout.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingLayout.java
@@ -18,9 +18,10 @@ import com.oracle.truffle.api.object.dsl.Nullable;
 import org.truffleruby.core.basicobject.BasicObjectLayout;
 
 /**
- * Bindings capture the frame from where they are called, which is stored in {@code frames}, but
- * also have their own frame(s) in {@code extras} to store variables added in the Binding, which
- * must not be added in the captured frame (MRI semantics). New frame(s) are added as required to
+ * Bindings capture the frame from where they are called, which is initially stored in
+ * {@code frame}, but may have their own frame(s) to store variables added in the Binding, which
+ * must not be added in the captured frame (MRI semantics). Each new frame is chained to the current
+ * frame and then replaces it in the {#code frame} property. New frame(s) are added as required to
  * prevent evaluation using the binding from leaking new variables into the captured frame, and when
  * cloning a binding to stop variables from the clone leaking to the original or vice versa.
  */

--- a/src/main/java/org/truffleruby/core/binding/BindingLayout.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingLayout.java
@@ -31,14 +31,11 @@ public interface BindingLayout extends BasicObjectLayout {
                                             DynamicObject metaClass);
 
     DynamicObject createBinding(DynamicObjectFactory factory,
-            MaterializedFrame frame,
-            @Nullable MaterializedFrame extras);
+            MaterializedFrame frame);
 
     boolean isBinding(DynamicObject object);
 
     MaterializedFrame getFrame(DynamicObject object);
 
-    MaterializedFrame getExtras(DynamicObject object);
-
-    void setExtras(DynamicObject object, MaterializedFrame value);
+    void setFrame(DynamicObject object, MaterializedFrame value);
 }

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -175,10 +175,9 @@ public abstract class BindingNodes {
         @Specialization
         public DynamicObject dup(DynamicObject binding) {
             MaterializedFrame frame = getTopFrame(binding);
-            Layouts.BINDING.setExtras(binding, newExtrasFrame(getContext(), frame));
             DynamicObject copy = allocateObjectNode.allocate(
                     Layouts.BASIC_OBJECT.getLogicalClass(binding),
-                    newExtrasFrame(getContext(), frame),
+                    frame,
                     null);
             return copy;
         }

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -57,11 +57,11 @@ import com.oracle.truffle.api.object.DynamicObject;
 public abstract class BindingNodes {
 
     public static DynamicObject createBinding(RubyContext context, MaterializedFrame frame) {
-        return Layouts.BINDING.createBinding(context.getCoreLibrary().getBindingFactory(), frame, null);
+        return Layouts.BINDING.createBinding(context.getCoreLibrary().getBindingFactory(), frame);
     }
 
     public static DynamicObject createBinding(RubyContext context, MaterializedFrame frame, FrameDescriptor extrasDescriptor) {
-        return Layouts.BINDING.createBinding(context.getCoreLibrary().getBindingFactory(), frame, newExtrasFrame(frame, extrasDescriptor));
+        return Layouts.BINDING.createBinding(context.getCoreLibrary().getBindingFactory(), newFrame(frame, extrasDescriptor));
     }
 
     @TruffleBoundary
@@ -78,43 +78,28 @@ public abstract class BindingNodes {
 
     public static FrameDescriptor getFrameDescriptor(DynamicObject binding) {
         assert RubyGuards.isRubyBinding(binding);
-        return getTopFrame(binding).getFrameDescriptor();
+        return getFrame(binding).getFrameDescriptor();
     }
 
-    public static MaterializedFrame getTopFrame(DynamicObject binding) {
+    public static MaterializedFrame getFrame(DynamicObject binding) {
         assert RubyGuards.isRubyBinding(binding);
-        MaterializedFrame frame = Layouts.BINDING.getExtras(binding);
-        if (frame != null) {
-            return frame;
-        } else {
-            return Layouts.BINDING.getFrame(binding);
-        }
+        return Layouts.BINDING.getFrame(binding);
     }
 
-    public static MaterializedFrame getExtrasFrame(RubyContext context, DynamicObject binding) {
+    public static MaterializedFrame newFrame(DynamicObject binding, FrameDescriptor frameDescriptor) {
         assert RubyGuards.isRubyBinding(binding);
-        MaterializedFrame frame = Layouts.BINDING.getExtras(binding);
-        if (frame == null) {
-            frame = newExtrasFrame(context, Layouts.BINDING.getFrame(binding));
-            Layouts.BINDING.setExtras(binding, frame);
-        }
+        MaterializedFrame frame = getFrame(binding);
+        frame = newFrame(frame, frameDescriptor);
+        Layouts.BINDING.setFrame(binding, frame);
         return frame;
     }
 
-    public static MaterializedFrame newExtrasFrame(DynamicObject binding, FrameDescriptor frameDescriptor) {
-        assert RubyGuards.isRubyBinding(binding);
-        MaterializedFrame frame = getTopFrame(binding);
-        frame = newExtrasFrame(frame, frameDescriptor);
-        Layouts.BINDING.setExtras(binding, frame);
-        return frame;
-    }
-
-    public static MaterializedFrame newExtrasFrame(RubyContext context, MaterializedFrame parent) {
+    public static MaterializedFrame newFrame(RubyContext context, MaterializedFrame parent) {
         FrameDescriptor descriptor = newFrameDescriptor(context);
-        return newExtrasFrame(parent, descriptor);
+        return newFrame(parent, descriptor);
     }
 
-    public static MaterializedFrame newExtrasFrame(MaterializedFrame parent, FrameDescriptor descriptor) {
+    public static MaterializedFrame newFrame(MaterializedFrame parent, FrameDescriptor descriptor) {
         final MaterializedFrame frame = Truffle.getRuntime().createVirtualFrame(
                 RubyArguments.pack(
                         parent,
@@ -174,11 +159,9 @@ public abstract class BindingNodes {
 
         @Specialization
         public DynamicObject dup(DynamicObject binding) {
-            MaterializedFrame frame = getTopFrame(binding);
             DynamicObject copy = allocateObjectNode.allocate(
                     Layouts.BASIC_OBJECT.getLogicalClass(binding),
-                    frame,
-                    null);
+                    Layouts.BINDING.getFrame(binding));
             return copy;
         }
     }
@@ -199,7 +182,7 @@ public abstract class BindingNodes {
         @TruffleBoundary
         @Specialization(guards = "!hiddenVariable(name)")
         public boolean localVariableDefinedUncached(DynamicObject binding, String name) {
-            return findFrameSlotOrNull(name, getTopFrame(binding)) != null;
+            return findFrameSlotOrNull(name, getFrame(binding)) != null;
         }
 
         @TruffleBoundary
@@ -232,16 +215,16 @@ public abstract class BindingNodes {
         public Object localVariableGetCached(DynamicObject binding, String name,
                 @Cached("name") String cachedName,
                 @Cached("getFrameDescriptor(binding)") FrameDescriptor descriptor,
-                @Cached("findFrameSlotOrNull(name, getTopFrame(binding))") FrameSlotAndDepth cachedFrameSlot,
+                @Cached("findFrameSlotOrNull(name, getFrame(binding))") FrameSlotAndDepth cachedFrameSlot,
                 @Cached("createReadNode(cachedFrameSlot)") ReadFrameSlotNode readLocalVariableNode) {
-            final MaterializedFrame frame = RubyArguments.getDeclarationFrame(getTopFrame(binding), cachedFrameSlot.depth);
+            final MaterializedFrame frame = RubyArguments.getDeclarationFrame(getFrame(binding), cachedFrameSlot.depth);
             return readLocalVariableNode.executeRead(frame);
         }
 
         @TruffleBoundary
         @Specialization(guards = "!hiddenVariable(name)")
         public Object localVariableGetUncached(DynamicObject binding, String name) {
-            MaterializedFrame frame = getTopFrame(binding);
+            MaterializedFrame frame = getFrame(binding);
             FrameSlotAndDepth frameSlot = findFrameSlotOrNull(name, frame);
             if (frameSlot != null) {
                 return RubyArguments.getDeclarationFrame(frame, frameSlot.depth).getValue(frameSlot.slot);
@@ -293,9 +276,9 @@ public abstract class BindingNodes {
         public Object localVariableSetCached(DynamicObject binding, String name, Object value,
                 @Cached("name") String cachedName,
                 @Cached("getFrameDescriptor(binding)") FrameDescriptor cachedFrameDescriptor,
-                @Cached("findFrameSlotOrNull(name, getTopFrame(binding))") FrameSlotAndDepth cachedFrameSlot,
+                @Cached("findFrameSlotOrNull(name, getFrame(binding))") FrameSlotAndDepth cachedFrameSlot,
                 @Cached("createWriteNode(cachedFrameSlot)") WriteFrameSlotNode writeLocalVariableNode) {
-            final MaterializedFrame frame = RubyArguments.getDeclarationFrame(getTopFrame(binding), cachedFrameSlot.depth);
+            final MaterializedFrame frame = RubyArguments.getDeclarationFrame(getFrame(binding), cachedFrameSlot.depth);
             return writeLocalVariableNode.executeWrite(frame, value);
         }
 
@@ -308,25 +291,25 @@ public abstract class BindingNodes {
         public Object localVariableSetNewCached(DynamicObject binding, String name, Object value,
                 @Cached("name") String cachedName,
                 @Cached("getFrameDescriptor(binding)") FrameDescriptor cachedFrameDescriptor,
-                @Cached("findFrameSlotOrNull(name, getTopFrame(binding))") FrameSlotAndDepth cachedFrameSlot,
+                @Cached("findFrameSlotOrNull(name, getFrame(binding))") FrameSlotAndDepth cachedFrameSlot,
                 @Cached("newFrameDescriptor(getContext(), name)") FrameDescriptor newDescriptor,
                 @Cached("findFrameSlot(name, newDescriptor)") FrameSlotAndDepth newFrameSlot,
                 @Cached("createWriteNode(newFrameSlot)") WriteFrameSlotNode writeLocalVariableNode) {
-            final MaterializedFrame frame = newExtrasFrame(binding, newDescriptor);
+            final MaterializedFrame frame = newFrame(binding, newDescriptor);
             return writeLocalVariableNode.executeWrite(frame, value);
         }
 
         @TruffleBoundary
         @Specialization(guards = "!hiddenVariable(name)")
         public Object localVariableSetUncached(DynamicObject binding, String name, Object value) {
-            MaterializedFrame frame = getTopFrame(binding);
+            MaterializedFrame frame = getFrame(binding);
             final FrameSlotAndDepth frameSlot = findFrameSlotOrNull(name, frame);
             final FrameSlot slot;
             if (frameSlot != null) {
                 frame = RubyArguments.getDeclarationFrame(frame, frameSlot.depth);
                 slot = frameSlot.slot;
             } else {
-                frame = newExtrasFrame(binding, newFrameDescriptor(getContext(), name));
+                frame = newFrame(binding, newFrameDescriptor(getContext(), name));
                 slot = frame.getFrameDescriptor().findFrameSlot(name);
             }
             frame.setObject(slot, value);
@@ -353,7 +336,7 @@ public abstract class BindingNodes {
 
         @Specialization
         public DynamicObject localVariables(DynamicObject binding) {
-            return listLocalVariables(getContext(), getTopFrame(binding));
+            return listLocalVariables(getContext(), getFrame(binding));
         }
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -503,7 +503,7 @@ public abstract class KernelNodes {
                 @Cached("createCallTarget(cachedRootNode)") CallTarget cachedCallTarget,
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode,
                 @Cached("create()") RopeNodes.EqualNode equalNode) {
-            final MaterializedFrame parentFrame = BindingNodes.getTopFrame(binding);
+            final MaterializedFrame parentFrame = BindingNodes.getFrame(binding);
             return eval(self, cachedRootNode, cachedCallTarget, callNode, parentFrame);
         }
 
@@ -531,7 +531,7 @@ public abstract class KernelNodes {
                 @Cached("createCallTarget(rootNodeToEval)") CallTarget cachedCallTarget,
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode,
                 @Cached("create()") RopeNodes.EqualNode equalNode) {
-            final MaterializedFrame parentFrame = BindingNodes.newExtrasFrame(binding,
+            final MaterializedFrame parentFrame = BindingNodes.newFrame(binding,
                     newBindingDescriptor);
             return eval(self, rootNodeToEval, cachedCallTarget, callNode, parentFrame);
         }
@@ -562,12 +562,12 @@ public abstract class KernelNodes {
                 Rope file,
                 int line,
                 boolean ownScopeForAssignments) {
-            final MaterializedFrame frame = BindingNodes.newExtrasFrame(getContext(), BindingNodes.getTopFrame(binding));
+            final MaterializedFrame frame = BindingNodes.newFrame(getContext(), BindingNodes.getFrame(binding));
             final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(frame);
             final FrameDescriptor descriptor = frame.getFrameDescriptor();
             RubyRootNode rootNode = buildRootNode(source, frame, file, line, false);
             if (!frameHasOnlySelf(descriptor)) {
-                Layouts.BINDING.setExtras(binding, frame);
+                Layouts.BINDING.setFrame(binding, frame);
             }
             return getContext().getCodeLoader().prepareExecute(
                     ParserContext.EVAL, declarationContext, rootNode, frame, self);
@@ -595,7 +595,7 @@ public abstract class KernelNodes {
         }
 
         protected RootNodeWrapper compileSource(Rope sourceText, MaterializedFrame parentFrame, FrameDescriptor additionalVariables, Rope file, int line) {
-            return compileSource(sourceText, BindingNodes.newExtrasFrame(parentFrame, additionalVariables), file, line);
+            return compileSource(sourceText, BindingNodes.newFrame(parentFrame, additionalVariables), file, line);
         }
 
         protected CallTarget createCallTarget(RootNodeWrapper rootNode) {
@@ -616,7 +616,7 @@ public abstract class KernelNodes {
         }
 
         protected MaterializedFrame getBindingFrame(DynamicObject binding) {
-            return BindingNodes.getTopFrame(binding);
+            return BindingNodes.getFrame(binding);
         }
 
         protected int getCacheLimit() {

--- a/test/truffle/compiler/pe/core/binding_pe.rb
+++ b/test/truffle/compiler/pe/core/binding_pe.rb
@@ -9,13 +9,18 @@
 # Kernel#binding
 example "x = 14; binding.local_variable_get(:x)", 14
 
-# TODO DM 12-Apr-17 Proc creation is not constant, so bindings on procs cannot be yet.
+# get on dup
+
+example "x = 14; binding.dup.local_variable_get(:x)", 14
 
 # Proc#binding
 example "x = 14; p = Proc.new { }; p.binding.local_variable_get(:x)", 14
 
 # set + get
 example "b = binding; b.local_variable_set(:x, 14); b.local_variable_get(:x)", 14
+
+# set + get on dup
+example "b = binding.dup; b.local_variable_set(:x, 14); b.local_variable_get(:x)", 14
 
 # get (2 levels)
 example "x = 14; y = nil; 1.times { y = binding.local_variable_get(:x) }; y", 14


### PR DESCRIPTION
'Binding#dup` created new frames in both the old and new binding to ensure the shared frame descriptor would not be mutated by eval. Now eval has been rewritten I believe the extra frame creation can be removed, and thus eval on duped bindings can be corrected PE'd