### PR TITLE
Fix generalization of writing object fields when adding a new field

### DIFF
--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -209,7 +209,7 @@ public abstract class BasicObjectNodes {
 
             if (id == 0) {
                 final long newId = getContext().getObjectSpaceManager().getNextObjectID();
-                writeObjectIdNode.execute(object, newId);
+                writeObjectIdNode.write(object, newId);
                 return newId;
             }
 

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -331,7 +331,7 @@ public abstract class KernelNodes {
 
             for (int i = 0; i < properties.length; i++) {
                 final Object value = readFieldNodes[i].execute(self);
-                writeFieldNodes[i].execute(newObject, value);
+                writeFieldNodes[i].write(newObject, value);
             }
 
             return newObject;
@@ -1804,7 +1804,7 @@ public abstract class KernelNodes {
             }
 
             checkFrozen(object);
-            writeTaintNode.execute(object, false);
+            writeTaintNode.write(object, false);
             return object;
         }
 

--- a/src/main/java/org/truffleruby/interop/ForeignWriteStringCachedHelperNode.java
+++ b/src/main/java/org/truffleruby/interop/ForeignWriteStringCachedHelperNode.java
@@ -48,7 +48,7 @@ abstract class ForeignWriteStringCachedHelperNode extends RubyNode {
             boolean isIVar,
             Object value,
             @Cached("createWriteObjectFieldNode(stringName)") WriteObjectFieldNode writeObjectFieldNode) {
-        writeObjectFieldNode.execute(receiver, value);
+        writeObjectFieldNode.write(receiver, value);
         return value;
     }
 

--- a/src/main/java/org/truffleruby/language/exceptions/SetExceptionVariableNode.java
+++ b/src/main/java/org/truffleruby/language/exceptions/SetExceptionVariableNode.java
@@ -68,7 +68,7 @@ public class SetExceptionVariableNode extends Node {
             writeDollarBang = insert(WriteObjectFieldNodeGen.create("$!"));
         }
 
-        writeDollarBang.execute(threadLocals, value);
+        writeDollarBang.write(threadLocals, value);
     }
 
     private Object readDollarBang(DynamicObject threadLocals) {

--- a/src/main/java/org/truffleruby/language/objects/FreezeNode.java
+++ b/src/main/java/org/truffleruby/language/objects/FreezeNode.java
@@ -61,7 +61,7 @@ public abstract class FreezeNode extends RubyNode {
     public Object freeze(
             DynamicObject object,
             @Cached("createWriteFrozenNode()") WriteObjectFieldNode writeFrozenNode) {
-        writeFrozenNode.execute(object, true);
+        writeFrozenNode.write(object, true);
         return object;
     }
 

--- a/src/main/java/org/truffleruby/language/objects/ObjectIVarSetNode.java
+++ b/src/main/java/org/truffleruby/language/objects/ObjectIVarSetNode.java
@@ -34,7 +34,7 @@ public abstract class ObjectIVarSetNode extends RubyNode {
     public Object ivarSetCached(DynamicObject object, Object name, Object value,
             @Cached("name") Object cachedName,
             @Cached("createWriteFieldNode(checkName(cachedName, object))") WriteObjectFieldNode writeObjectFieldNode) {
-        writeObjectFieldNode.execute(object, value);
+        writeObjectFieldNode.write(object, value);
         return value;
     }
 

--- a/src/main/java/org/truffleruby/language/objects/TaintNode.java
+++ b/src/main/java/org/truffleruby/language/objects/TaintNode.java
@@ -76,7 +76,7 @@ public abstract class TaintNode extends RubyNode {
             }
         }
 
-        writeTaintNode.execute(object, true);
+        writeTaintNode.write(object, true);
         return object;
     }
 

--- a/src/main/java/org/truffleruby/language/objects/WriteInstanceVariableNode.java
+++ b/src/main/java/org/truffleruby/language/objects/WriteInstanceVariableNode.java
@@ -43,7 +43,7 @@ public class WriteInstanceVariableNode extends RubyNode {
                 writeNode = insert(WriteObjectFieldNodeGen.create(name));
             }
 
-            writeNode.execute((DynamicObject) object, value);
+            writeNode.write((DynamicObject) object, value);
         } else {
             throw new RaiseException(coreExceptions().frozenError(object, this));
         }


### PR DESCRIPTION
* The problem arises when we already have a specialization (say int),
  and then on another object we try to write another primitive type (say double).
  At that point we want to add a specialization adding the field as Object.
  We pass an explicit generalize flag in that case to use an Object location.
  We cannot just write a random Object and then the real value as that
  would write an out-of-thin-air value on the object.

cc @woess 