### PR TITLE
Add fast paths for remaining slow Binding methods.

### DIFF
--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -182,27 +182,13 @@ public abstract class BindingNodes {
         @Specialization(guards = {
                 "name == cachedName",
                 "!hiddenVariable(cachedName)",
-                "cachedFrameSlot != null",
                 "getFrameDescriptor(binding) == descriptor"
         }, limit = "getCacheLimit()")
-        public Object localVariableDefinedCached(DynamicObject binding, String name,
+        public boolean localVariableDefinedCached(DynamicObject binding, String name,
                 @Cached("name") String cachedName,
                 @Cached("getFrameDescriptor(binding)") FrameDescriptor descriptor,
                 @Cached("findFrameSlotOrNull(name, getFrame(binding))") FrameSlotAndDepth cachedFrameSlot) {
-            return true;
-        }
-
-        @Specialization(guards = {
-                "name == cachedName",
-                "!hiddenVariable(cachedName)",
-                "cachedFrameSlot == null",
-                "getFrameDescriptor(binding) == descriptor"
-        }, limit = "getCacheLimit()")
-        public Object localVariableNotDefinedCached(DynamicObject binding, String name,
-                @Cached("name") String cachedName,
-                @Cached("getFrameDescriptor(binding)") FrameDescriptor descriptor,
-                @Cached("findFrameSlotOrNull(name, getFrame(binding))") FrameSlotAndDepth cachedFrameSlot) {
-            return false;
+            return cachedFrameSlot != null;
         }
 
         @TruffleBoundary
@@ -372,7 +358,7 @@ public abstract class BindingNodes {
             return names;
         }
 
-        @Specialization
+        @Specialization(replaces = "localVariablesCached")
         public DynamicObject localVariables(DynamicObject binding) {
             return listLocalVariables(getContext(), getFrame(binding));
         }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -34,6 +34,7 @@ import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.builtins.PrimitiveNode;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.Hashing;
+import org.truffleruby.core.array.ArrayHelpers;
 import org.truffleruby.core.array.ArrayUtils;
 import org.truffleruby.core.basicobject.BasicObjectNodes;
 import org.truffleruby.core.basicobject.BasicObjectNodes.ObjectIDNode;
@@ -976,18 +977,6 @@ public abstract class KernelNodes {
         protected boolean isCloningEnabled() {
             return coreLibrary().isCloningEnabled();
         }
-    }
-
-    @CoreMethod(names = "local_variables", isModuleFunction = true)
-    public abstract static class LocalVariablesNode extends CoreMethodArrayArgumentsNode {
-
-        @TruffleBoundary
-        @Specialization
-        public DynamicObject localVariables() {
-            final Frame frame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameInstance.FrameAccess.READ_ONLY);
-            return BindingNodes.LocalVariablesNode.listLocalVariables(getContext(), frame);
-        }
-
     }
 
     @CoreMethod(names = "__method__", isModuleFunction = true)

--- a/src/main/ruby/core/binding.rb
+++ b/src/main/ruby/core/binding.rb
@@ -10,4 +10,9 @@ class Binding
   def eval(code, file = nil, line = nil)
     Kernel.eval(code, self, file, line)
   end
+
+  def local_variables
+    Truffle.invoke_primitive(:local_variable_names, self).dup
+  end
+  Truffle::Graal.always_split(method(:local_variables))
 end

--- a/src/main/ruby/core/kernel.rb
+++ b/src/main/ruby/core/kernel.rb
@@ -366,6 +366,12 @@ module Kernel
   end
   module_function :load
 
+  def local_variables
+    Truffle::invoke_primitive(:caller_binding).local_variables
+  end
+  module_function :local_variables
+  Truffle::Graal.always_split(method(:local_variables))
+
   def loop
     return to_enum(:loop) { Float::INFINITY } unless block_given?
 

--- a/src/main/ruby/core/kernel.rb
+++ b/src/main/ruby/core/kernel.rb
@@ -367,7 +367,7 @@ module Kernel
   module_function :load
 
   def local_variables
-    Truffle::invoke_primitive(:caller_binding).local_variables
+    Truffle.invoke_primitive(:caller_binding).local_variables
   end
   module_function :local_variables
   Truffle::Graal.always_split(method(:local_variables))

--- a/test/truffle/compiler/pe/core/binding_pe.rb
+++ b/test/truffle/compiler/pe/core/binding_pe.rb
@@ -30,3 +30,15 @@ example "x = 14; 1.times { binding.local_variable_set(:x, 15) }; x", 15
 
 # get + set (2 levels)
 example "x = 14; y = nil; 1.times { binding.local_variable_set(:x, 15); y = binding.local_variable_get(:x) }; y", 15
+
+# defined
+
+example "x = 14; b = binding; b.local_variable_defined?(:x)", true
+
+# not defined
+
+example "x = 14; b = binding; b.local_variable_defined?(:y)", false
+
+# local_variables
+
+tagged example "x = 14; y = 15; binding.local_variables[1]", :x


### PR DESCRIPTION
Make the remaining methods on Binding fast. Doesn't quite make `Binding#local_variables` pass a PE test, but still much faster than it was.