### PR TITLE
Do not call DispatchNode#getHeadNode() on the fast path

### DIFF
--- a/src/main/java/org/truffleruby/language/dispatch/DispatchHeadNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchHeadNode.java
@@ -30,7 +30,7 @@ public class DispatchHeadNode extends RubyBaseNode {
         this.onlyCallPublic = onlyCallPublic;
         this.missingBehavior = missingBehavior;
         this.dispatchAction = dispatchAction;
-        first = new UnresolvedDispatchNode(ignoreVisibility, missingBehavior, dispatchAction);
+        first = new UnresolvedDispatchNode(ignoreVisibility, onlyCallPublic, missingBehavior, dispatchAction);
     }
 
     public Object dispatch(
@@ -48,7 +48,7 @@ public class DispatchHeadNode extends RubyBaseNode {
     }
 
     public void reset(String reason) {
-        first.replace(new UnresolvedDispatchNode(ignoreVisibility, missingBehavior, dispatchAction), reason);
+        first.replace(new UnresolvedDispatchNode(ignoreVisibility, onlyCallPublic, missingBehavior, dispatchAction), reason);
     }
 
     public DispatchNode getFirstDispatchNode() {

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -9,7 +9,6 @@
  */
 package org.truffleruby.language.dispatch;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.language.dispatch;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
@@ -48,9 +49,10 @@ public abstract class DispatchNode extends RubyNode {
             VirtualFrame frame,
             Object receiver,
             String name,
-            boolean ignoreVisibility) {
+            boolean ignoreVisibility,
+            boolean onlyCallPublic) {
         final MethodLookupResult method = LookupMethodNode.lookupMethodWithVisibility(getContext(),
-                frame, receiver, name, ignoreVisibility, getHeadNode().onlyCallPublic);
+                frame, receiver, name, ignoreVisibility, onlyCallPublic);
         if (dispatchAction == DispatchAction.RESPOND_TO_METHOD && method.isDefined() && method.getMethod().isUnimplemented()) {
             return method.withNoMethod();
         }

--- a/src/main/java/org/truffleruby/language/dispatch/UnresolvedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/UnresolvedDispatchNode.java
@@ -77,28 +77,28 @@ public final class UnresolvedDispatchNode extends DispatchNode {
 
             // We need a new node to handle this case.
 
-            final DispatchNode newDispathNode;
+            final DispatchNode newDispatchNode;
 
             if (depth == getContext().getOptions().DISPATCH_CACHE) {
-                newDispathNode = new UncachedDispatchNode(ignoreVisibility, onlyCallPublic, getDispatchAction(), missingBehavior);
+                newDispatchNode = new UncachedDispatchNode(ignoreVisibility, onlyCallPublic, getDispatchAction(), missingBehavior);
             } else {
                 depth++;
                 if (RubyGuards.isForeignObject(receiverObject)) {
-                    newDispathNode = new CachedForeignDispatchNode(getContext(), first, methodName);
+                    newDispatchNode = new CachedForeignDispatchNode(getContext(), first, methodName);
                 } else if (RubyGuards.isRubyBasicObject(receiverObject)) {
-                    newDispathNode = doDynamicObject(frame, first, receiverObject, methodName, argumentsObjects);
+                    newDispatchNode = doDynamicObject(frame, first, receiverObject, methodName, argumentsObjects);
                 } else {
-                    newDispathNode = doUnboxedObject(frame, first, receiverObject, methodName);
+                    newDispatchNode = doUnboxedObject(frame, first, receiverObject, methodName);
                 }
             }
 
-            first.replace(newDispathNode);
+            first.replace(newDispatchNode);
 
-            if (newDispathNode instanceof CachedDispatchNode) {
-                ((CachedDispatchNode) newDispathNode).reassessSplittingInliningStrategy();
+            if (newDispatchNode instanceof CachedDispatchNode) {
+                ((CachedDispatchNode) newDispatchNode).reassessSplittingInliningStrategy();
             }
 
-            return newDispathNode;
+            return newDispatchNode;
         });
 
         return dispatch.executeDispatch(frame, receiverObject, methodName, blockObject, argumentsObjects);


### PR DESCRIPTION
* lookup() is used on the fast path of UncachedDispatchNode.
* Partial Evaluation no longer folds NodeUtil.getParent() (GR-5372).
* It's easier to just keep the boolean as a field in the two nodes that need it.