### PR TITLE
Ensure to promptly dispose() the RubyContext in our Java tests

### DIFF
--- a/src/test/java/org/truffleruby/PolyglotIOTest.java
+++ b/src/test/java/org/truffleruby/PolyglotIOTest.java
@@ -29,9 +29,11 @@ public class PolyglotIOTest extends RubyTest {
                 .setIn(in)
                 .build();
 
-        engine.eval(Source.newBuilder("puts STDIN.read(3)").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
-
-        engine.dispose();
+        try {
+            engine.eval(Source.newBuilder("puts STDIN.read(3)").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
+        } finally {
+            engine.dispose();
+        }
 
         assertEquals("abc\n", out.toString());
     }
@@ -44,9 +46,11 @@ public class PolyglotIOTest extends RubyTest {
                 .setOut(out)
                 .build();
 
-        engine.eval(Source.newBuilder("puts 'abc'").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
-
-        engine.dispose();
+        try {
+            engine.eval(Source.newBuilder("puts 'abc'").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
+        } finally {
+            engine.dispose();
+        }
 
         assertEquals("abc\n", out.toString());
     }
@@ -59,9 +63,11 @@ public class PolyglotIOTest extends RubyTest {
                 .setErr(err)
                 .build();
 
-        engine.eval(Source.newBuilder("STDERR.puts 'abc'").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
-
-        engine.dispose();
+        try {
+            engine.eval(Source.newBuilder("STDERR.puts 'abc'").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
+        } finally {
+            engine.dispose();
+        }
 
         assertEquals("abc\n", err.toString());
     }

--- a/src/test/java/org/truffleruby/RubyTest.java
+++ b/src/test/java/org/truffleruby/RubyTest.java
@@ -55,8 +55,11 @@ public abstract class RubyTest {
     protected void testInEngine(Runnable test) {
         final PolyglotEngine engine = setupConfig(PolyglotEngine.newBuilder())
                 .globalSymbol("action", JavaInterop.asTruffleFunction(Runnable.class, test)).build();
-
-        engine.eval(Source.newBuilder("Truffle::Interop.import('action').call").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
+        try {
+            engine.eval(Source.newBuilder("Truffle::Interop.import('action').call").name("test.rb").mimeType(RubyLanguage.MIME_TYPE).build());
+        } finally {
+            engine.dispose();
+        }
     }
 
     public static Builder setupConfig(PolyglotEngine.Builder builder) {

--- a/src/test/java/org/truffleruby/tck/RubyTckTest.java
+++ b/src/test/java/org/truffleruby/tck/RubyTckTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -47,14 +48,18 @@ public class RubyTckTest extends TruffleTCK {
     @Override
     protected synchronized PolyglotEngine prepareVM() throws Exception {
         if (engine == null) {
-            engine = prepareVM(PolyglotEngine.newBuilder());
+            engine = spawnNewEngine(PolyglotEngine.newBuilder());
         }
-
         return engine;
     }
 
     @Override
     protected PolyglotEngine prepareVM(PolyglotEngine.Builder preparedBuilder) throws Exception {
+        // Create a new VM, on its own thread
+        return spawnNewEngine(preparedBuilder.executor(Executors.newSingleThreadExecutor()));
+    }
+
+    private PolyglotEngine spawnNewEngine(PolyglotEngine.Builder preparedBuilder) {
         final PolyglotEngine engine = RubyTest.setupConfig(preparedBuilder).build();
         engine.eval(getSource("src/test/ruby/tck.rb"));
         engine.eval(RubyTest.RESOLVE_LAZY_NODES);


### PR DESCRIPTION
* Create extra PolyglotEngines on separate threads in TCK.