### PR TITLE
Parse without RubyContext

### DIFF
--- a/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
@@ -26,6 +26,7 @@ import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.string.ISO_8859_16;
+import org.truffleruby.core.string.StringOperations;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -63,6 +64,25 @@ public class EncodingManager {
         final DynamicObject string = context.getFrozenStrings().getFrozenString(cachedRope);
 
         return Layouts.ENCODING.createEncoding(context.getCoreLibrary().getEncodingFactory(), encoding, string, dummy);
+    }
+
+    public static Encoding getEncoding(String name) {
+        return getEncoding(StringOperations.encodeRope(name, USASCIIEncoding.INSTANCE, CodeRange.CR_7BIT));
+    }
+
+    @TruffleBoundary
+    public static Encoding getEncoding(Rope name) {
+        EncodingDB.Entry entry = EncodingDB.getEncodings().get(name.getBytes());
+
+        if (entry == null) {
+            entry = EncodingDB.getAliases().get(name.getBytes());
+        }
+
+        if (entry != null) {
+            return entry.getEncoding();
+        }
+
+        return null;
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/regexp/RegexpOptions.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpOptions.java
@@ -17,8 +17,8 @@ import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.EUCJPEncoding;
 import org.jcodings.specific.UTF8Encoding;
-import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
+import org.truffleruby.core.encoding.EncodingManager;
 import org.truffleruby.core.string.KCode;
 import org.truffleruby.parser.ReOptions;
 
@@ -153,7 +153,7 @@ public class RegexpOptions implements Cloneable {
             return EUCJPEncoding.INSTANCE;
         } else if (explicitKCode == KCode.SJIS) {
             setFixed(true);
-            return Layouts.ENCODING.getEncoding(runtime.getEncodingManager().getRubyEncoding(WINDOWS31J));
+            return EncodingManager.getEncoding(WINDOWS31J);
         } else if (explicitKCode == KCode.UTF8) {
             setFixed(true);
             return UTF8Encoding.INSTANCE;

--- a/src/main/java/org/truffleruby/core/regexp/RegexpOptions.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpOptions.java
@@ -17,7 +17,7 @@ import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.EUCJPEncoding;
 import org.jcodings.specific.UTF8Encoding;
-import org.truffleruby.core.encoding.EncodingManager;
+import org.jcodings.specific.Windows_31JEncoding;
 import org.truffleruby.core.string.KCode;
 import org.truffleruby.parser.ReOptions;
 
@@ -152,7 +152,7 @@ public class RegexpOptions implements Cloneable {
             return EUCJPEncoding.INSTANCE;
         } else if (explicitKCode == KCode.SJIS) {
             setFixed(true);
-            return EncodingManager.getEncoding(WINDOWS31J);
+            return Windows_31JEncoding.INSTANCE;
         } else if (explicitKCode == KCode.UTF8) {
             setFixed(true);
             return UTF8Encoding.INSTANCE;

--- a/src/main/java/org/truffleruby/core/regexp/RegexpOptions.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpOptions.java
@@ -17,7 +17,6 @@ import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.EUCJPEncoding;
 import org.jcodings.specific.UTF8Encoding;
-import org.truffleruby.RubyContext;
 import org.truffleruby.core.encoding.EncodingManager;
 import org.truffleruby.core.string.KCode;
 import org.truffleruby.parser.ReOptions;
@@ -139,7 +138,7 @@ public class RegexpOptions implements Cloneable {
         return multiline && ignorecase && extended;
     }
 
-    public Encoding setup(RubyContext runtime) {
+    public Encoding setup() {
         KCode explicitKCode = getExplicitKCode();
 
         // None will not set fixed

--- a/src/main/java/org/truffleruby/parser/TranslatorDriver.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorDriver.java
@@ -287,14 +287,22 @@ public class TranslatorDriver {
             switch (e.getPid()) {
                 case UNKNOWN_ENCODING:
                 case NOT_ASCII_COMPATIBLE:
-                    throw new RaiseException(context.getCoreExceptions().argumentError(e.getMessage(), null));
+                    if (context != null) {
+                        throw new RaiseException(context.getCoreExceptions().argumentError(e.getMessage(), null));
+                    } else {
+                        throw e;
+                    }
                 default:
                     StringBuilder buffer = new StringBuilder(100);
                     buffer.append(e.getFile()).append(':');
                     buffer.append(e.getLine()).append(": ");
                     buffer.append(e.getMessage());
 
-                    throw new RaiseException(context.getCoreExceptions().syntaxError(buffer.toString(), null));
+                    if (context != null) {
+                        throw new RaiseException(context.getCoreExceptions().syntaxError(buffer.toString(), null));
+                    } else {
+                        throw new UnsupportedOperationException(buffer.toString(), e);
+                    }
             }
         }
 

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -453,10 +453,27 @@ public class RubyLexer {
 
     protected void setEncoding(Rope name) {
         final RubyContext context = parserSupport.getConfiguration().getContext();
-        Encoding newEncoding = Layouts.ENCODING.getEncoding(context.getEncodingManager().getRubyEncoding(RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name)));
+        final Encoding newEncoding = parserSupport.getEncoding(name);
 
-        if (newEncoding == null) throw new RaiseException(context.getCoreExceptions().argumentError("unknown encoding name: " + RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name), null));
-        if (!newEncoding.isAsciiCompatible()) throw new RaiseException(context.getCoreExceptions().argumentError(RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name) + " is not ASCII compatible", null));
+        if (newEncoding == null) {
+            final String message = "unknown encoding name: " + RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name);
+
+            if (context != null) {
+                throw new RaiseException(context.getCoreExceptions().argumentError(message, null));
+            } else {
+                throw new UnsupportedOperationException(message);
+            }
+        }
+
+        if (!newEncoding.isAsciiCompatible()) {
+            final String message = RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name) + " is not ASCII compatible";
+
+            if (context != null) {
+                throw new RaiseException(context.getCoreExceptions().argumentError(message, null));
+            } else {
+                throw new UnsupportedOperationException(message);
+            }
+        }
 
         setEncoding(newEncoding);
     }

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -456,26 +456,22 @@ public class RubyLexer {
         final Encoding newEncoding = parserSupport.getEncoding(name);
 
         if (newEncoding == null) {
-            final String message = "unknown encoding name: " + RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name);
-
-            if (context != null) {
-                throw new RaiseException(context.getCoreExceptions().argumentError(message, null));
-            } else {
-                throw new UnsupportedOperationException(message);
-            }
+            throw argumentError(context, "unknown encoding name: " + RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name));
         }
 
         if (!newEncoding.isAsciiCompatible()) {
-            final String message = RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name) + " is not ASCII compatible";
-
-            if (context != null) {
-                throw new RaiseException(context.getCoreExceptions().argumentError(message, null));
-            } else {
-                throw new UnsupportedOperationException(message);
-            }
+            throw argumentError(context, RopeOperations.decodeRope(StandardCharsets.ISO_8859_1, name) + " is not ASCII compatible");
         }
 
         setEncoding(newEncoding);
+    }
+
+    private RuntimeException argumentError(RubyContext context, String message) {
+        if (context != null) {
+            return new RaiseException(context.getCoreExceptions().argumentError(message, null));
+        } else {
+            return new UnsupportedOperationException(message);
+        }
     }
 
     public StrTerm getStrTerm() {

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -1466,7 +1466,7 @@ public class ParserSupport {
     // MRI: reg_fragment_setenc_gen
     public Rope setRegexpEncoding(RegexpParseNode end, Rope value) {
         RegexpOptions options = end.getOptions();
-        Encoding optionsEncoding = options.setup(configuration.getContext()) ;
+        Encoding optionsEncoding = options.setup() ;
 
         // Change encoding to one specified by regexp options as long as the string is compatible.
         if (optionsEncoding != null) {
@@ -1553,7 +1553,7 @@ public class ParserSupport {
     // regexp options encoding so dregexps can end up starting with the
     // right encoding.
     private Rope createMaster(RegexpOptions options) {
-        Encoding encoding = options.setup(configuration.getContext());
+        Encoding encoding = options.setup();
 
         Rope rope = RopeOperations.create(new byte[]{}, encoding == null ? ASCIIEncoding.INSTANCE : encoding, CR_UNKNOWN);
         return rope;

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -38,6 +38,7 @@ package org.truffleruby.parser.parser;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.truffleruby.RubyContext;
+import org.truffleruby.core.encoding.EncodingManager;
 import org.truffleruby.core.regexp.ClassicRegexp;
 import org.truffleruby.core.regexp.RegexpOptions;
 import org.truffleruby.core.rope.CodeRange;
@@ -1457,7 +1458,11 @@ public class ParserSupport {
         lexer.compile_error(PID.REGEXP_ENCODING_MISMATCH, "regexp encoding option '" + optionsEncodingChar(optionEncoding) +
                 "' differs from source encoding '" + encoding + "'");
     }
-    
+
+    public Encoding getEncoding(Rope name) {
+        return EncodingManager.getEncoding(name);
+    }
+
     // MRI: reg_fragment_setenc_gen
     public Rope setRegexpEncoding(RegexpParseNode end, Rope value) {
         RegexpOptions options = end.getOptions();

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -39,6 +39,8 @@
  ***** END LICENSE BLOCK *****/
 package org.truffleruby.parser.parser;
 
+import org.jcodings.Encoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.RopeConstants;
@@ -155,7 +157,7 @@ public class RubyParser {
         support.setWarnings(warnings);
         lexer.setWarnings(warnings);
     }
-					// line 159 "-"
+					// line 161 "-"
   // %token constants
   public static final int kCLASS = 257;
   public static final int kMODULE = 258;
@@ -4020,7 +4022,8 @@ states[519] = new ParserState() {
 };
 states[520] = new ParserState() {
   @Override public Object execute(ParserSupport support, RubyLexer lexer, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = new FileParseNode(lexer.getPosition(), RopeOperations.create(lexer.getFile().getBytes(), support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding(), CR_UNKNOWN));
+                    Encoding encoding = support.getConfiguration().getContext() == null ? UTF8Encoding.INSTANCE : support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding();
+                    yyVal = new FileParseNode(lexer.getPosition(), RopeOperations.create(lexer.getFile().getBytes(), encoding, CR_UNKNOWN));
     return yyVal;
   }
 };
@@ -4660,7 +4663,7 @@ states[644] = new ParserState() {
   }
 };
 }
-					// line 2572 "RubyParser.y"
+					// line 2575 "RubyParser.y"
 
     /** The parse method use an lexer stream and parse it to an AST node 
      * structure
@@ -4675,4 +4678,4 @@ states[644] = new ParserState() {
         return support.getResult();
     }
 }
-					// line 10081 "-"
+					// line 10084 "-"

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -42,6 +42,7 @@ package org.truffleruby.parser.parser;
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.RubyContext;
+import org.truffleruby.core.encoding.EncodingManager;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.RopeConstants;
 import org.truffleruby.core.rope.RopeOperations;
@@ -132,6 +133,8 @@ import org.truffleruby.parser.lexer.RubyLexer;
 import org.truffleruby.parser.lexer.StrTerm;
 import org.truffleruby.parser.lexer.SyntaxException.PID;
 
+import java.nio.charset.Charset;
+
 import static org.truffleruby.core.rope.CodeRange.CR_UNKNOWN;
 import static org.truffleruby.parser.lexer.RubyLexer.EXPR_BEG;
 import static org.truffleruby.parser.lexer.RubyLexer.EXPR_END;
@@ -157,7 +160,7 @@ public class RubyParser {
         support.setWarnings(warnings);
         lexer.setWarnings(warnings);
     }
-					// line 161 "-"
+					// line 164 "-"
   // %token constants
   public static final int kCLASS = 257;
   public static final int kMODULE = 258;
@@ -4022,7 +4025,7 @@ states[519] = new ParserState() {
 };
 states[520] = new ParserState() {
   @Override public Object execute(ParserSupport support, RubyLexer lexer, Object yyVal, Object[] yyVals, int yyTop) {
-                    Encoding encoding = support.getConfiguration().getContext() == null ? UTF8Encoding.INSTANCE : support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding();
+                    Encoding encoding = support.getConfiguration().getContext() == null ? EncodingManager.getEncoding(Charset.defaultCharset().name()) : support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding();
                     yyVal = new FileParseNode(lexer.getPosition(), RopeOperations.create(lexer.getFile().getBytes(), encoding, CR_UNKNOWN));
     return yyVal;
   }
@@ -4663,7 +4666,7 @@ states[644] = new ParserState() {
   }
 };
 }
-					// line 2575 "RubyParser.y"
+					// line 2578 "RubyParser.y"
 
     /** The parse method use an lexer stream and parse it to an AST node 
      * structure
@@ -4678,4 +4681,4 @@ states[644] = new ParserState() {
         return support.getResult();
     }
 }
-					// line 10084 "-"
+					// line 10087 "-"

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -39,6 +39,7 @@ package org.truffleruby.parser.parser;
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.RubyContext;
+import org.truffleruby.core.encoding.EncodingManager;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.RopeConstants;
 import org.truffleruby.core.rope.RopeOperations;
@@ -128,6 +129,8 @@ import org.truffleruby.parser.lexer.LexerSource;
 import org.truffleruby.parser.lexer.RubyLexer;
 import org.truffleruby.parser.lexer.StrTerm;
 import org.truffleruby.parser.lexer.SyntaxException.PID;
+
+import java.nio.charset.Charset;
 
 import static org.truffleruby.core.rope.CodeRange.CR_UNKNOWN;
 import static org.truffleruby.parser.lexer.RubyLexer.EXPR_BEG;
@@ -2151,7 +2154,7 @@ var_ref         : /*mri:user_variable*/ tIDENTIFIER {
                     $$ = new FalseParseNode(lexer.getPosition());
                 }
                 | k__FILE__ {
-                    Encoding encoding = support.getConfiguration().getContext() == null ? UTF8Encoding.INSTANCE : support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding();
+                    Encoding encoding = support.getConfiguration().getContext() == null ? EncodingManager.getEncoding(Charset.defaultCharset().name()) : support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding();
                     $$ = new FileParseNode(lexer.getPosition(), RopeOperations.create(lexer.getFile().getBytes(), encoding, CR_UNKNOWN));
                 }
                 | k__LINE__ {

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -36,6 +36,8 @@
  ***** END LICENSE BLOCK *****/
 package org.truffleruby.parser.parser;
 
+import org.jcodings.Encoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.RopeConstants;
@@ -2149,7 +2151,8 @@ var_ref         : /*mri:user_variable*/ tIDENTIFIER {
                     $$ = new FalseParseNode(lexer.getPosition());
                 }
                 | k__FILE__ {
-                    $$ = new FileParseNode(lexer.getPosition(), RopeOperations.create(lexer.getFile().getBytes(), support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding(), CR_UNKNOWN));
+                    Encoding encoding = support.getConfiguration().getContext() == null ? UTF8Encoding.INSTANCE : support.getConfiguration().getContext().getEncodingManager().getLocaleEncoding();
+                    $$ = new FileParseNode(lexer.getPosition(), RopeOperations.create(lexer.getFile().getBytes(), encoding, CR_UNKNOWN));
                 }
                 | k__LINE__ {
                     $$ = new FixnumParseNode(lexer.getPosition(), lexer.tokline.toSourceSection(lexer.getSource()).getStartLine());


### PR DESCRIPTION
There's a decent chance I didn't catch every path in our parser that could require a `RubyContext`, but these changes (along with others not related to the parser) do allow everything in `lib/` to be parsed during AOT image build. This also fixes that problem we had a while back where adding an encoding magic comment to any of the core files caused AOT image building to break.