### PR TITLE
Add st

### DIFF
--- a/lib/cext/ccan/build_assert/build_assert.h
+++ b/lib/cext/ccan/build_assert/build_assert.h
@@ -1,0 +1,40 @@
+/* CC0 (Public domain) - see ccan/licenses/CC0 file for details */
+#ifndef CCAN_BUILD_ASSERT_H
+#define CCAN_BUILD_ASSERT_H
+
+/**
+ * BUILD_ASSERT - assert a build-time dependency.
+ * @cond: the compile-time condition which must be true.
+ *
+ * Your compile will fail if the condition isn't true, or can't be evaluated
+ * by the compiler.  This can only be used within a function.
+ *
+ * Example:
+ *	#include <stddef.h>
+ *	...
+ *	static char *foo_to_char(struct foo *foo)
+ *	{
+ *		// This code needs string to be at start of foo.
+ *		BUILD_ASSERT(offsetof(struct foo, string) == 0);
+ *		return (char *)foo;
+ *	}
+ */
+#define BUILD_ASSERT(cond) \
+	do { (void) sizeof(char [1 - 2*!(cond)]); } while(0)
+
+/**
+ * BUILD_ASSERT_OR_ZERO - assert a build-time dependency, as an expression.
+ * @cond: the compile-time condition which must be true.
+ *
+ * Your compile will fail if the condition isn't true, or can't be evaluated
+ * by the compiler.  This can be used in an expression: its value is "0".
+ *
+ * Example:
+ *	#define foo_to_char(foo)					\
+ *		 ((char *)(foo)						\
+ *		  + BUILD_ASSERT_OR_ZERO(offsetof(struct foo, string) == 0))
+ */
+#define BUILD_ASSERT_OR_ZERO(cond) \
+	(sizeof(char [1 - 2*!(cond)]) - 1)
+
+#endif /* CCAN_BUILD_ASSERT_H */

--- a/lib/cext/ccan/check_type/check_type.h
+++ b/lib/cext/ccan/check_type/check_type.h
@@ -1,0 +1,63 @@
+/* CC0 (Public domain) - see ccan/licenses/CC0 file for details */
+#ifndef CCAN_CHECK_TYPE_H
+#define CCAN_CHECK_TYPE_H
+
+/**
+ * check_type - issue a warning or build failure if type is not correct.
+ * @expr: the expression whose type we should check (not evaluated).
+ * @type: the exact type we expect the expression to be.
+ *
+ * This macro is usually used within other macros to try to ensure that a macro
+ * argument is of the expected type.  No type promotion of the expression is
+ * done: an unsigned int is not the same as an int!
+ *
+ * check_type() always evaluates to 0.
+ *
+ * If your compiler does not support typeof, then the best we can do is fail
+ * to compile if the sizes of the types are unequal (a less complete check).
+ *
+ * Example:
+ *	// They should always pass a 64-bit value to _set_some_value!
+ *	#define set_some_value(expr)			\
+ *		_set_some_value((check_type((expr), uint64_t), (expr)))
+ */
+
+/**
+ * check_types_match - issue a warning or build failure if types are not same.
+ * @expr1: the first expression (not evaluated).
+ * @expr2: the second expression (not evaluated).
+ *
+ * This macro is usually used within other macros to try to ensure that
+ * arguments are of identical types.  No type promotion of the expressions is
+ * done: an unsigned int is not the same as an int!
+ *
+ * check_types_match() always evaluates to 0.
+ *
+ * If your compiler does not support typeof, then the best we can do is fail
+ * to compile if the sizes of the types are unequal (a less complete check).
+ *
+ * Example:
+ *	// Do subtraction to get to enclosing type, but make sure that
+ *	// pointer is of correct type for that member.
+ *	#define container_of(mbr_ptr, encl_type, mbr)			\
+ *		(check_types_match((mbr_ptr), &((encl_type *)0)->mbr),	\
+ *		 ((encl_type *)						\
+ *		  ((char *)(mbr_ptr) - offsetof(enclosing_type, mbr))))
+ */
+#if HAVE_TYPEOF
+#define check_type(expr, type)			\
+	((typeof(expr) *)0 != (type *)0)
+
+#define check_types_match(expr1, expr2)		\
+	((typeof(expr1) *)0 != (typeof(expr2) *)0)
+#else
+#include "ccan/build_assert/build_assert.h"
+/* Without typeof, we can only test the sizes. */
+#define check_type(expr, type)					\
+	BUILD_ASSERT_OR_ZERO(sizeof(expr) == sizeof(type))
+
+#define check_types_match(expr1, expr2)				\
+	BUILD_ASSERT_OR_ZERO(sizeof(expr1) == sizeof(expr2))
+#endif /* HAVE_TYPEOF */
+
+#endif /* CCAN_CHECK_TYPE_H */

--- a/lib/cext/ccan/container_of/container_of.h
+++ b/lib/cext/ccan/container_of/container_of.h
@@ -1,0 +1,142 @@
+/* CC0 (Public domain) - see ccan/licenses/CC0 file for details */
+#ifndef CCAN_CONTAINER_OF_H
+#define CCAN_CONTAINER_OF_H
+#include "ccan/check_type/check_type.h"
+
+/**
+ * container_of - get pointer to enclosing structure
+ * @member_ptr: pointer to the structure member
+ * @containing_type: the type this member is within
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does pointer
+ * subtraction to return the pointer to the enclosing type.
+ *
+ * Example:
+ *	struct foo {
+ *		int fielda, fieldb;
+ *		// ...
+ *	};
+ *	struct info {
+ *		int some_other_field;
+ *		struct foo my_foo;
+ *	};
+ *
+ *	static struct info *foo_to_info(struct foo *foo)
+ *	{
+ *		return container_of(foo, struct info, my_foo);
+ *	}
+ */
+#define container_of(member_ptr, containing_type, member)		\
+	 ((containing_type *)						\
+	  ((char *)(member_ptr)						\
+	   - container_off(containing_type, member))			\
+	  + check_types_match(*(member_ptr), ((containing_type *)0)->member))
+
+
+/**
+ * container_of_or_null - get pointer to enclosing structure, or NULL
+ * @member_ptr: pointer to the structure member
+ * @containing_type: the type this member is within
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does pointer
+ * subtraction to return the pointer to the enclosing type, unless it
+ * is given NULL, in which case it also returns NULL.
+ *
+ * Example:
+ *	struct foo {
+ *		int fielda, fieldb;
+ *		// ...
+ *	};
+ *	struct info {
+ *		int some_other_field;
+ *		struct foo my_foo;
+ *	};
+ *
+ *	static struct info *foo_to_info_allowing_null(struct foo *foo)
+ *	{
+ *		return container_of_or_null(foo, struct info, my_foo);
+ *	}
+ */
+static inline char *container_of_or_null_(void *member_ptr, size_t offset)
+{
+	return member_ptr ? (char *)member_ptr - offset : NULL;
+}
+#define container_of_or_null(member_ptr, containing_type, member)	\
+	((containing_type *)						\
+	 container_of_or_null_(member_ptr,				\
+			       container_off(containing_type, member))	\
+	 + check_types_match(*(member_ptr), ((containing_type *)0)->member))
+
+/**
+ * container_off - get offset to enclosing structure
+ * @containing_type: the type this member is within
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does
+ * typechecking and figures out the offset to the enclosing type.
+ *
+ * Example:
+ *	struct foo {
+ *		int fielda, fieldb;
+ *		// ...
+ *	};
+ *	struct info {
+ *		int some_other_field;
+ *		struct foo my_foo;
+ *	};
+ *
+ *	static struct info *foo_to_info(struct foo *foo)
+ *	{
+ *		size_t off = container_off(struct info, my_foo);
+ *		return (void *)((char *)foo - off);
+ *	}
+ */
+#define container_off(containing_type, member)	\
+	offsetof(containing_type, member)
+
+/**
+ * container_of_var - get pointer to enclosing structure using a variable
+ * @member_ptr: pointer to the structure member
+ * @container_var: a pointer of same type as this member's container
+ * @member: the name of this member within the structure.
+ *
+ * Given a pointer to a member of a structure, this macro does pointer
+ * subtraction to return the pointer to the enclosing type.
+ *
+ * Example:
+ *	static struct info *foo_to_i(struct foo *foo)
+ *	{
+ *		struct info *i = container_of_var(foo, i, my_foo);
+ *		return i;
+ *	}
+ */
+#if HAVE_TYPEOF
+#define container_of_var(member_ptr, container_var, member) \
+	container_of(member_ptr, typeof(*container_var), member)
+#else
+#define container_of_var(member_ptr, container_var, member)	\
+	((void *)((char *)(member_ptr)	-			\
+		  container_off_var(container_var, member)))
+#endif
+
+/**
+ * container_off_var - get offset of a field in enclosing structure
+ * @container_var: a pointer to a container structure
+ * @member: the name of a member within the structure.
+ *
+ * Given (any) pointer to a structure and a its member name, this
+ * macro does pointer subtraction to return offset of member in a
+ * structure memory layout.
+ *
+ */
+#if HAVE_TYPEOF
+#define container_off_var(var, member)		\
+	container_off(typeof(*var), member)
+#else
+#define container_off_var(var, member)			\
+	((const char *)&(var)->member - (const char *)(var))
+#endif
+
+#endif /* CCAN_CONTAINER_OF_H */

--- a/lib/cext/ccan/list/list.h
+++ b/lib/cext/ccan/list/list.h
@@ -1,0 +1,773 @@
+/* Licensed under BSD-MIT - see ccan/licenses/BSD-MIT file for details */
+#ifndef CCAN_LIST_H
+#define CCAN_LIST_H
+#include <assert.h>
+#include "ccan/str/str.h"
+#include "ccan/container_of/container_of.h"
+#include "ccan/check_type/check_type.h"
+
+/**
+ * struct list_node - an entry in a doubly-linked list
+ * @next: next entry (self if empty)
+ * @prev: previous entry (self if empty)
+ *
+ * This is used as an entry in a linked list.
+ * Example:
+ *	struct child {
+ *		const char *name;
+ *		// Linked list of all us children.
+ *		struct list_node list;
+ *	};
+ */
+struct list_node
+{
+	struct list_node *next, *prev;
+};
+
+/**
+ * struct list_head - the head of a doubly-linked list
+ * @h: the list_head (containing next and prev pointers)
+ *
+ * This is used as the head of a linked list.
+ * Example:
+ *	struct parent {
+ *		const char *name;
+ *		struct list_head children;
+ *		unsigned int num_children;
+ *	};
+ */
+struct list_head
+{
+	struct list_node n;
+};
+
+#define LIST_LOC __FILE__  ":" stringify(__LINE__)
+#define list_debug(h, loc) ((void)loc, h)
+#define list_debug_node(n, loc) ((void)loc, n)
+
+/**
+ * LIST_HEAD_INIT - initializer for an empty list_head
+ * @name: the name of the list.
+ *
+ * Explicit initializer for an empty list.
+ *
+ * See also:
+ *	LIST_HEAD, list_head_init()
+ *
+ * Example:
+ *	static struct list_head my_list = LIST_HEAD_INIT(my_list);
+ */
+#define LIST_HEAD_INIT(name) { { &name.n, &name.n } }
+
+/**
+ * LIST_HEAD - define and initialize an empty list_head
+ * @name: the name of the list.
+ *
+ * The LIST_HEAD macro defines a list_head and initializes it to an empty
+ * list.  It can be prepended by "static" to define a static list_head.
+ *
+ * See also:
+ *	LIST_HEAD_INIT, list_head_init()
+ *
+ * Example:
+ *	static LIST_HEAD(my_global_list);
+ */
+#define LIST_HEAD(name) \
+	struct list_head name = LIST_HEAD_INIT(name)
+
+/**
+ * list_head_init - initialize a list_head
+ * @h: the list_head to set to the empty list
+ *
+ * Example:
+ *	...
+ *	struct parent *parent = malloc(sizeof(*parent));
+ *
+ *	list_head_init(&parent->children);
+ *	parent->num_children = 0;
+ */
+static inline void list_head_init(struct list_head *h)
+{
+	h->n.next = h->n.prev = &h->n;
+}
+
+/**
+ * list_node_init - initialize a list_node
+ * @n: the list_node to link to itself.
+ *
+ * You don't need to use this normally!  But it lets you list_del(@n)
+ * safely.
+ */
+static inline void list_node_init(struct list_node *n)
+{
+	n->next = n->prev = n;
+}
+
+/**
+ * list_add_after - add an entry after an existing node in a linked list
+ * @h: the list_head to add the node to (for debugging)
+ * @p: the existing list_node to add the node after
+ * @n: the new list_node to add to the list.
+ *
+ * The existing list_node must already be a member of the list.
+ * The new list_node does not need to be initialized; it will be overwritten.
+ *
+ * Example:
+ *	struct child c1, c2, c3;
+ *	LIST_HEAD(h);
+ *
+ *	list_add_tail(&h, &c1.list);
+ *	list_add_tail(&h, &c3.list);
+ *	list_add_after(&h, &c1.list, &c2.list);
+ */
+#define list_add_after(h, p, n) list_add_after_(h, p, n, LIST_LOC)
+static inline void list_add_after_(struct list_head *h,
+				   struct list_node *p,
+				   struct list_node *n,
+				   const char *abortstr)
+{
+	n->next = p->next;
+	n->prev = p;
+	p->next->prev = n;
+	p->next = n;
+	(void)list_debug(h, abortstr);
+}
+
+/**
+ * list_add - add an entry at the start of a linked list.
+ * @h: the list_head to add the node to
+ * @n: the list_node to add to the list.
+ *
+ * The list_node does not need to be initialized; it will be overwritten.
+ * Example:
+ *	struct child *child = malloc(sizeof(*child));
+ *
+ *	child->name = "marvin";
+ *	list_add(&parent->children, &child->list);
+ *	parent->num_children++;
+ */
+#define list_add(h, n) list_add_(h, n, LIST_LOC)
+static inline void list_add_(struct list_head *h,
+			     struct list_node *n,
+			     const char *abortstr)
+{
+	list_add_after_(h, &h->n, n, abortstr);
+}
+
+/**
+ * list_add_before - add an entry before an existing node in a linked list
+ * @h: the list_head to add the node to (for debugging)
+ * @p: the existing list_node to add the node before
+ * @n: the new list_node to add to the list.
+ *
+ * The existing list_node must already be a member of the list.
+ * The new list_node does not need to be initialized; it will be overwritten.
+ *
+ * Example:
+ *	list_head_init(&h);
+ *	list_add_tail(&h, &c1.list);
+ *	list_add_tail(&h, &c3.list);
+ *	list_add_before(&h, &c3.list, &c2.list);
+ */
+#define list_add_before(h, p, n) list_add_before_(h, p, n, LIST_LOC)
+static inline void list_add_before_(struct list_head *h,
+				    struct list_node *p,
+				    struct list_node *n,
+				    const char *abortstr)
+{
+	n->next = p;
+	n->prev = p->prev;
+	p->prev->next = n;
+	p->prev = n;
+	(void)list_debug(h, abortstr);
+}
+
+/**
+ * list_add_tail - add an entry at the end of a linked list.
+ * @h: the list_head to add the node to
+ * @n: the list_node to add to the list.
+ *
+ * The list_node does not need to be initialized; it will be overwritten.
+ * Example:
+ *	list_add_tail(&parent->children, &child->list);
+ *	parent->num_children++;
+ */
+#define list_add_tail(h, n) list_add_tail_(h, n, LIST_LOC)
+static inline void list_add_tail_(struct list_head *h,
+				  struct list_node *n,
+				  const char *abortstr)
+{
+	list_add_before_(h, &h->n, n, abortstr);
+}
+
+/**
+ * list_empty - is a list empty?
+ * @h: the list_head
+ *
+ * If the list is empty, returns true.
+ *
+ * Example:
+ *	assert(list_empty(&parent->children) == (parent->num_children == 0));
+ */
+#define list_empty(h) list_empty_(h, LIST_LOC)
+static inline int list_empty_(const struct list_head *h, const char* abortstr)
+{
+	(void)list_debug(h, abortstr);
+	return h->n.next == &h->n;
+}
+
+/**
+ * list_empty_nodebug - is a list empty (and don't perform debug checks)?
+ * @h: the list_head
+ *
+ * If the list is empty, returns true.
+ * This differs from list_empty() in that if CCAN_LIST_DEBUG is set it
+ * will NOT perform debug checks. Only use this function if you REALLY
+ * know what you're doing.
+ *
+ * Example:
+ *	assert(list_empty_nodebug(&parent->children) == (parent->num_children == 0));
+ */
+#ifndef CCAN_LIST_DEBUG
+#define list_empty_nodebug(h) list_empty(h)
+#else
+static inline int list_empty_nodebug(const struct list_head *h)
+{
+	return h->n.next == &h->n;
+}
+#endif
+
+/**
+ * list_del - delete an entry from an (unknown) linked list.
+ * @n: the list_node to delete from the list.
+ *
+ * Note that this leaves @n in an undefined state; it can be added to
+ * another list, but not deleted again.
+ *
+ * See also:
+ *	list_del_from(), list_del_init()
+ *
+ * Example:
+ *	list_del(&child->list);
+ *	parent->num_children--;
+ */
+#define list_del(n) list_del_(n, LIST_LOC)
+static inline void list_del_(struct list_node *n, const char* abortstr)
+{
+	(void)list_debug_node(n, abortstr);
+	n->next->prev = n->prev;
+	n->prev->next = n->next;
+#ifdef CCAN_LIST_DEBUG
+	/* Catch use-after-del. */
+	n->next = n->prev = NULL;
+#endif
+}
+
+/**
+ * list_del_init - delete a node, and reset it so it can be deleted again.
+ * @n: the list_node to be deleted.
+ *
+ * list_del(@n) or list_del_init() again after this will be safe,
+ * which can be useful in some cases.
+ *
+ * See also:
+ *	list_del_from(), list_del()
+ *
+ * Example:
+ *	list_del_init(&child->list);
+ *	parent->num_children--;
+ */
+#define list_del_init(n) list_del_init_(n, LIST_LOC)
+static inline void list_del_init_(struct list_node *n, const char *abortstr)
+{
+	list_del_(n, abortstr);
+	list_node_init(n);
+}
+
+/**
+ * list_del_from - delete an entry from a known linked list.
+ * @h: the list_head the node is in.
+ * @n: the list_node to delete from the list.
+ *
+ * This explicitly indicates which list a node is expected to be in,
+ * which is better documentation and can catch more bugs.
+ *
+ * See also: list_del()
+ *
+ * Example:
+ *	list_del_from(&parent->children, &child->list);
+ *	parent->num_children--;
+ */
+static inline void list_del_from(struct list_head *h, struct list_node *n)
+{
+#ifdef CCAN_LIST_DEBUG
+	{
+		/* Thorough check: make sure it was in list! */
+		struct list_node *i;
+		for (i = h->n.next; i != n; i = i->next)
+			assert(i != &h->n);
+	}
+#endif /* CCAN_LIST_DEBUG */
+
+	/* Quick test that catches a surprising number of bugs. */
+	assert(!list_empty(h));
+	list_del(n);
+}
+
+/**
+ * list_swap - swap out an entry from an (unknown) linked list for a new one.
+ * @o: the list_node to replace from the list.
+ * @n: the list_node to insert in place of the old one.
+ *
+ * Note that this leaves @o in an undefined state; it can be added to
+ * another list, but not deleted/swapped again.
+ *
+ * See also:
+ *	list_del()
+ *
+ * Example:
+ *	struct child x1, x2;
+ *	LIST_HEAD(xh);
+ *
+ *	list_add(&xh, &x1.list);
+ *	list_swap(&x1.list, &x2.list);
+ */
+#define list_swap(o, n) list_swap_(o, n, LIST_LOC)
+static inline void list_swap_(struct list_node *o,
+			      struct list_node *n,
+			      const char* abortstr)
+{
+	(void)list_debug_node(o, abortstr);
+	*n = *o;
+	n->next->prev = n;
+	n->prev->next = n;
+#ifdef CCAN_LIST_DEBUG
+	/* Catch use-after-del. */
+	o->next = o->prev = NULL;
+#endif
+}
+
+/**
+ * list_entry - convert a list_node back into the structure containing it.
+ * @n: the list_node
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * Example:
+ *	// First list entry is children.next; convert back to child.
+ *	child = list_entry(parent->children.n.next, struct child, list);
+ *
+ * See Also:
+ *	list_top(), list_for_each()
+ */
+#define list_entry(n, type, member) container_of(n, type, member)
+
+/**
+ * list_top - get the first entry in a list
+ * @h: the list_head
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * If the list is empty, returns NULL.
+ *
+ * Example:
+ *	struct child *first;
+ *	first = list_top(&parent->children, struct child, list);
+ *	if (!first)
+ *		printf("Empty list!\n");
+ */
+#define list_top(h, type, member)					\
+	((type *)list_top_((h), list_off_(type, member)))
+
+static inline const void *list_top_(const struct list_head *h, size_t off)
+{
+	if (list_empty(h))
+		return NULL;
+	return (const char *)h->n.next - off;
+}
+
+/**
+ * list_pop - remove the first entry in a list
+ * @h: the list_head
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * If the list is empty, returns NULL.
+ *
+ * Example:
+ *	struct child *one;
+ *	one = list_pop(&parent->children, struct child, list);
+ *	if (!one)
+ *		printf("Empty list!\n");
+ */
+#define list_pop(h, type, member)					\
+	((type *)list_pop_((h), list_off_(type, member)))
+
+static inline const void *list_pop_(const struct list_head *h, size_t off)
+{
+	struct list_node *n;
+
+	if (list_empty(h))
+		return NULL;
+	n = h->n.next;
+	list_del(n);
+	return (const char *)n - off;
+}
+
+/**
+ * list_tail - get the last entry in a list
+ * @h: the list_head
+ * @type: the type of the entry
+ * @member: the list_node member of the type
+ *
+ * If the list is empty, returns NULL.
+ *
+ * Example:
+ *	struct child *last;
+ *	last = list_tail(&parent->children, struct child, list);
+ *	if (!last)
+ *		printf("Empty list!\n");
+ */
+#define list_tail(h, type, member) \
+	((type *)list_tail_((h), list_off_(type, member)))
+
+static inline const void *list_tail_(const struct list_head *h, size_t off)
+{
+	if (list_empty(h))
+		return NULL;
+	return (const char *)h->n.prev - off;
+}
+
+/**
+ * list_for_each - iterate through a list.
+ * @h: the list_head (warning: evaluated multiple times!)
+ * @i: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list.  It's
+ * a for loop, so you can break and continue as normal.
+ *
+ * Example:
+ *	list_for_each(&parent->children, child, list)
+ *		printf("Name: %s\n", child->name);
+ */
+#define list_for_each(h, i, member)					\
+	list_for_each_off(h, i, list_off_var_(i, member))
+
+/**
+ * list_for_each_rev - iterate through a list backwards.
+ * @h: the list_head
+ * @i: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list.  It's
+ * a for loop, so you can break and continue as normal.
+ *
+ * Example:
+ *	list_for_each_rev(&parent->children, child, list)
+ *		printf("Name: %s\n", child->name);
+ */
+#define list_for_each_rev(h, i, member)					\
+	list_for_each_rev_off(h, i, list_off_var_(i, member))
+
+/**
+ * list_for_each_rev_safe - iterate through a list backwards,
+ * maybe during deletion
+ * @h: the list_head
+ * @i: the structure containing the list_node
+ * @nxt: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list backwards.
+ * It's a for loop, so you can break and continue as normal.  The extra
+ * variable * @nxt is used to hold the next element, so you can delete @i
+ * from the list.
+ *
+ * Example:
+ *	struct child *next;
+ *	list_for_each_rev_safe(&parent->children, child, next, list) {
+ *		printf("Name: %s\n", child->name);
+ *	}
+ */
+#define list_for_each_rev_safe(h, i, nxt, member)			\
+	list_for_each_rev_safe_off(h, i, nxt, list_off_var_(i, member))
+
+/**
+ * list_for_each_safe - iterate through a list, maybe during deletion
+ * @h: the list_head
+ * @i: the structure containing the list_node
+ * @nxt: the structure containing the list_node
+ * @member: the list_node member of the structure
+ *
+ * This is a convenient wrapper to iterate @i over the entire list.  It's
+ * a for loop, so you can break and continue as normal.  The extra variable
+ * @nxt is used to hold the next element, so you can delete @i from the list.
+ *
+ * Example:
+ *	list_for_each_safe(&parent->children, child, next, list) {
+ *		list_del(&child->list);
+ *		parent->num_children--;
+ *	}
+ */
+#define list_for_each_safe(h, i, nxt, member)				\
+	list_for_each_safe_off(h, i, nxt, list_off_var_(i, member))
+
+/**
+ * list_next - get the next entry in a list
+ * @h: the list_head
+ * @i: a pointer to an entry in the list.
+ * @member: the list_node member of the structure
+ *
+ * If @i was the last entry in the list, returns NULL.
+ *
+ * Example:
+ *	struct child *second;
+ *	second = list_next(&parent->children, first, list);
+ *	if (!second)
+ *		printf("No second child!\n");
+ */
+#define list_next(h, i, member)						\
+	((list_typeof(i))list_entry_or_null(list_debug(h,		\
+					    __FILE__ ":" stringify(__LINE__)), \
+					    (i)->member.next,		\
+					    list_off_var_((i), member)))
+
+/**
+ * list_prev - get the previous entry in a list
+ * @h: the list_head
+ * @i: a pointer to an entry in the list.
+ * @member: the list_node member of the structure
+ *
+ * If @i was the first entry in the list, returns NULL.
+ *
+ * Example:
+ *	first = list_prev(&parent->children, second, list);
+ *	if (!first)
+ *		printf("Can't go back to first child?!\n");
+ */
+#define list_prev(h, i, member)						\
+	((list_typeof(i))list_entry_or_null(list_debug(h,		\
+					    __FILE__ ":" stringify(__LINE__)), \
+					    (i)->member.prev,		\
+					    list_off_var_((i), member)))
+
+/**
+ * list_append_list - empty one list onto the end of another.
+ * @to: the list to append into
+ * @from: the list to empty.
+ *
+ * This takes the entire contents of @from and moves it to the end of
+ * @to.  After this @from will be empty.
+ *
+ * Example:
+ *	struct list_head adopter;
+ *
+ *	list_append_list(&adopter, &parent->children);
+ *	assert(list_empty(&parent->children));
+ *	parent->num_children = 0;
+ */
+#define list_append_list(t, f) list_append_list_(t, f,			\
+				   __FILE__ ":" stringify(__LINE__))
+static inline void list_append_list_(struct list_head *to,
+				     struct list_head *from,
+				     const char *abortstr)
+{
+	struct list_node *from_tail = list_debug(from, abortstr)->n.prev;
+	struct list_node *to_tail = list_debug(to, abortstr)->n.prev;
+
+	/* Sew in head and entire list. */
+	to->n.prev = from_tail;
+	from_tail->next = &to->n;
+	to_tail->next = &from->n;
+	from->n.prev = to_tail;
+
+	/* Now remove head. */
+	list_del(&from->n);
+	list_head_init(from);
+}
+
+/**
+ * list_prepend_list - empty one list into the start of another.
+ * @to: the list to prepend into
+ * @from: the list to empty.
+ *
+ * This takes the entire contents of @from and moves it to the start
+ * of @to.  After this @from will be empty.
+ *
+ * Example:
+ *	list_prepend_list(&adopter, &parent->children);
+ *	assert(list_empty(&parent->children));
+ *	parent->num_children = 0;
+ */
+#define list_prepend_list(t, f) list_prepend_list_(t, f, LIST_LOC)
+static inline void list_prepend_list_(struct list_head *to,
+				      struct list_head *from,
+				      const char *abortstr)
+{
+	struct list_node *from_tail = list_debug(from, abortstr)->n.prev;
+	struct list_node *to_head = list_debug(to, abortstr)->n.next;
+
+	/* Sew in head and entire list. */
+	to->n.next = &from->n;
+	from->n.prev = &to->n;
+	to_head->prev = from_tail;
+	from_tail->next = to_head;
+
+	/* Now remove head. */
+	list_del(&from->n);
+	list_head_init(from);
+}
+
+/* internal macros, do not use directly */
+#define list_for_each_off_dir_(h, i, off, dir)				\
+	for (i = list_node_to_off_(list_debug(h, LIST_LOC)->n.dir,	\
+				   (off));				\
+	list_node_from_off_((void *)i, (off)) != &(h)->n;		\
+	i = list_node_to_off_(list_node_from_off_((void *)i, (off))->dir, \
+			      (off)))
+
+#define list_for_each_safe_off_dir_(h, i, nxt, off, dir)		\
+	for (i = list_node_to_off_(list_debug(h, LIST_LOC)->n.dir,	\
+				   (off)),				\
+	nxt = list_node_to_off_(list_node_from_off_(i, (off))->dir,	\
+				(off));					\
+	list_node_from_off_(i, (off)) != &(h)->n;			\
+	i = nxt,							\
+	nxt = list_node_to_off_(list_node_from_off_(i, (off))->dir,	\
+				(off)))
+
+/**
+ * list_for_each_off - iterate through a list of memory regions.
+ * @h: the list_head
+ * @i: the pointer to a memory region wich contains list node data.
+ * @off: offset(relative to @i) at which list node data resides.
+ *
+ * This is a low-level wrapper to iterate @i over the entire list, used to
+ * implement all oher, more high-level, for-each constructs. It's a for loop,
+ * so you can break and continue as normal.
+ *
+ * WARNING! Being the low-level macro that it is, this wrapper doesn't know
+ * nor care about the type of @i. The only assumtion made is that @i points
+ * to a chunk of memory that at some @offset, relative to @i, contains a
+ * properly filled `struct node_list' which in turn contains pointers to
+ * memory chunks and it's turtles all the way down. Whith all that in mind
+ * remember that given the wrong pointer/offset couple this macro will
+ * happilly churn all you memory untill SEGFAULT stops it, in other words
+ * caveat emptor.
+ *
+ * It is worth mentioning that one of legitimate use-cases for that wrapper
+ * is operation on opaque types with known offset for `struct list_node'
+ * member(preferably 0), because it allows you not to disclose the type of
+ * @i.
+ *
+ * Example:
+ *	list_for_each_off(&parent->children, child,
+ *				offsetof(struct child, list))
+ *		printf("Name: %s\n", child->name);
+ */
+#define list_for_each_off(h, i, off)                                    \
+	list_for_each_off_dir_((h),(i),(off),next)
+
+/**
+ * list_for_each_rev_off - iterate through a list of memory regions backwards
+ * @h: the list_head
+ * @i: the pointer to a memory region wich contains list node data.
+ * @off: offset(relative to @i) at which list node data resides.
+ *
+ * See list_for_each_off for details
+ */
+#define list_for_each_rev_off(h, i, off)                                    \
+	list_for_each_off_dir_((h),(i),(off),prev)
+
+/**
+ * list_for_each_safe_off - iterate through a list of memory regions, maybe
+ * during deletion
+ * @h: the list_head
+ * @i: the pointer to a memory region wich contains list node data.
+ * @nxt: the structure containing the list_node
+ * @off: offset(relative to @i) at which list node data resides.
+ *
+ * For details see `list_for_each_off' and `list_for_each_safe'
+ * descriptions.
+ *
+ * Example:
+ *	list_for_each_safe_off(&parent->children, child,
+ *		next, offsetof(struct child, list))
+ *		printf("Name: %s\n", child->name);
+ */
+#define list_for_each_safe_off(h, i, nxt, off)                          \
+	list_for_each_safe_off_dir_((h),(i),(nxt),(off),next)
+
+/**
+ * list_for_each_rev_safe_off - iterate backwards through a list of
+ * memory regions, maybe during deletion
+ * @h: the list_head
+ * @i: the pointer to a memory region wich contains list node data.
+ * @nxt: the structure containing the list_node
+ * @off: offset(relative to @i) at which list node data resides.
+ *
+ * For details see `list_for_each_rev_off' and `list_for_each_rev_safe'
+ * descriptions.
+ *
+ * Example:
+ *	list_for_each_rev_safe_off(&parent->children, child,
+ *		next, offsetof(struct child, list))
+ *		printf("Name: %s\n", child->name);
+ */
+#define list_for_each_rev_safe_off(h, i, nxt, off)                      \
+	list_for_each_safe_off_dir_((h),(i),(nxt),(off),prev)
+
+/* Other -off variants. */
+#define list_entry_off(n, type, off)		\
+	((type *)list_node_from_off_((n), (off)))
+
+#define list_head_off(h, type, off)		\
+	((type *)list_head_off((h), (off)))
+
+#define list_tail_off(h, type, off)		\
+	((type *)list_tail_((h), (off)))
+
+#define list_add_off(h, n, off)                 \
+	list_add((h), list_node_from_off_((n), (off)))
+
+#define list_del_off(n, off)                    \
+	list_del(list_node_from_off_((n), (off)))
+
+#define list_del_from_off(h, n, off)			\
+	list_del_from(h, list_node_from_off_((n), (off)))
+
+/* Offset helper functions so we only single-evaluate. */
+static inline void *list_node_to_off_(struct list_node *node, size_t off)
+{
+	return (void *)((char *)node - off);
+}
+static inline struct list_node *list_node_from_off_(void *ptr, size_t off)
+{
+	return (struct list_node *)((char *)ptr + off);
+}
+
+/* Get the offset of the member, but make sure it's a list_node. */
+#define list_off_(type, member)					\
+	(container_off(type, member) +				\
+	 check_type(((type *)0)->member, struct list_node))
+
+#define list_off_var_(var, member)			\
+	(container_off_var(var, member) +		\
+	 check_type(var->member, struct list_node))
+
+#if HAVE_TYPEOF
+#define list_typeof(var) typeof(var)
+#else
+#define list_typeof(var) void *
+#endif
+
+/* Returns member, or NULL if at end of list. */
+static inline void *list_entry_or_null(const struct list_head *h,
+				       const struct list_node *n,
+				       size_t off)
+{
+	if (n == &h->n)
+		return NULL;
+	return (char *)n - off;
+}
+#endif /* CCAN_LIST_H */

--- a/lib/cext/ccan/str/str.h
+++ b/lib/cext/ccan/str/str.h
@@ -1,0 +1,16 @@
+/* CC0 (Public domain) - see ccan/licenses/CC0 file for details */
+#ifndef CCAN_STR_H
+#define CCAN_STR_H
+/**
+ * stringify - Turn expression into a string literal
+ * @expr: any C expression
+ *
+ * Example:
+ *	#define PRINT_COND_IF_FALSE(cond) \
+ *		((cond) || printf("%s is false!", stringify(cond)))
+ */
+#define stringify(expr)		stringify_1(expr)
+/* Double-indirection required to stringify expansions */
+#define stringify_1(expr)	#expr
+
+#endif /* CCAN_STR_H */

--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -42,6 +42,8 @@ extern "C" {
 // Used in st.h
 #define RUBY_SYMBOL_EXPORT_BEGIN
 #define RUBY_SYMBOL_EXPORT_END
+
+// Assume an LP64 integer and pointer data model
 #define SIZEOF_LONG 8
 #define SIZEOF_LONG_LONG 8
 #define SIZEOF_VOIDP 8

--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -38,6 +38,16 @@ extern "C" {
 
 #include <truffle.h>
 
+
+// Used in st.h
+#define RUBY_SYMBOL_EXPORT_BEGIN
+#define RUBY_SYMBOL_EXPORT_END
+#define SIZEOF_LONG 8
+#define SIZEOF_LONG_LONG 8
+#define SIZEOF_VOIDP 8
+
+#include "ruby/st.h"
+
 // Support
 
 #define RUBY_CEXT (void *)truffle_import_cached("ruby_cext")
@@ -90,6 +100,10 @@ typedef st_data_t st_index_t;
 
 NORETURN(VALUE rb_f_notimplement(int args_count, const VALUE *args, VALUE object));
 
+#ifndef offsetof
+#define offsetof(p_type,field) ((size_t)&(((p_type *)0)->field))
+#endif
+
 // Non-standard
 
 NORETURN(void rb_tr_error(const char *message));
@@ -140,6 +154,12 @@ void rb_free_tmp_buffer(VALUE *buffer_pointer);
 #define ALLOCV(v, n)                RB_ALLOCV(v, n)
 #define ALLOCV_N(type, v, n)        RB_ALLOCV_N(type, v, n)
 #define ALLOCV_END(v)               RB_ALLOCV_END(v)
+
+#define MEMZERO(p,type,n) memset((p), 0, sizeof(type)*(n))
+#define MEMCPY(p1,p2,type,n) memcpy((p1), (p2), sizeof(type)*(n))
+#define MEMMOVE(p1,p2,type,n) memmove((p1), (p2), sizeof(type)*(n))
+#define MEMCMP(p1,p2,type,n) memcmp((p1), (p2), sizeof(type)*(n))
+
 
 // Types
 
@@ -885,10 +905,6 @@ void rb_hash_foreach(VALUE hash, int (*func)(ANYARGS), VALUE farg);
 VALUE rb_hash_size(VALUE hash);
 #define RHASH_SIZE(h) NUM2SIZET(rb_hash_size(h))
 #define rb_hash_dup(array) rb_obj_dup(array)
-
-// st.h
-
-enum st_retval {ST_CONTINUE, ST_STOP, ST_DELETE, ST_CHECK};
 
 // Class
 

--- a/lib/cext/ruby/backward/st.h
+++ b/lib/cext/ruby/backward/st.h
@@ -1,0 +1,1 @@
+#include "ruby/st.h"

--- a/lib/cext/ruby/st.h
+++ b/lib/cext/ruby/st.h
@@ -1,1 +1,158 @@
-#include "../ruby.h"
+/* This is a public domain general purpose hash table package written by Peter Moore @ UCB. */
+
+/* @(#) st.h 5.1 89/12/14 */
+
+#ifndef RUBY_ST_H
+#define RUBY_ST_H 1
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+#include "ruby/defines.h"
+
+RUBY_SYMBOL_EXPORT_BEGIN
+
+
+#if SIZEOF_LONG == SIZEOF_VOIDP
+typedef unsigned long st_data_t;
+#elif SIZEOF_LONG_LONG == SIZEOF_VOIDP
+typedef unsigned LONG_LONG st_data_t;
+#else
+# error ---->> st.c requires sizeof(void*) == sizeof(long) or sizeof(LONG_LONG) to be compiled. <<----
+#endif
+#define ST_DATA_T_DEFINED
+
+#ifndef CHAR_BIT
+# ifdef HAVE_LIMITS_H
+#  include <limits.h>
+# else
+#  define CHAR_BIT 8
+# endif
+#endif
+#ifndef _
+# define _(args) args
+#endif
+#ifndef ANYARGS
+# ifdef __cplusplus
+#   define ANYARGS ...
+# else
+#   define ANYARGS
+# endif
+#endif
+
+typedef struct st_table st_table;
+
+typedef st_data_t st_index_t;
+typedef int st_compare_func(st_data_t, st_data_t);
+typedef st_index_t st_hash_func(st_data_t);
+
+typedef char st_check_for_sizeof_st_index_t[SIZEOF_VOIDP == (int)sizeof(st_index_t) ? 1 : -1];
+#define SIZEOF_ST_INDEX_T SIZEOF_VOIDP
+
+struct st_hash_type {
+    int (*compare)(ANYARGS /*st_data_t, st_data_t*/); /* st_compare_func* */
+    st_index_t (*hash)(ANYARGS /*st_data_t*/);        /* st_hash_func* */
+};
+
+#define ST_INDEX_BITS (sizeof(st_index_t) * CHAR_BIT)
+
+#if defined(HAVE_BUILTIN___BUILTIN_CHOOSE_EXPR) && defined(HAVE_BUILTIN___BUILTIN_TYPES_COMPATIBLE_P)
+# define ST_DATA_COMPATIBLE_P(type) \
+   __builtin_choose_expr(__builtin_types_compatible_p(type, st_data_t), 1, 0)
+#else
+# define ST_DATA_COMPATIBLE_P(type) 0
+#endif
+
+struct st_table {
+    const struct st_hash_type *type;
+    st_index_t num_bins;
+    unsigned int entries_packed : 1;
+#ifdef __GNUC__
+    /*
+     * C spec says,
+     *   A bit-field shall have a type that is a qualified or unqualified
+     *   version of _Bool, signed int, unsigned int, or some other
+     *   implementation-defined type. It is implementation-defined whether
+     *   atomic types are permitted.
+     * In short, long and long long bit-field are implementation-defined
+     * feature. Therefore we want to suppress a warning explicitly.
+     */
+    __extension__
+#endif
+    st_index_t num_entries : ST_INDEX_BITS - 1;
+    union {
+	struct {
+	    struct st_table_entry **bins;
+	    void *private_list_head[2];
+	} big;
+	struct {
+	    struct st_packed_entry *entries;
+	    st_index_t real_entries;
+	} packed;
+    } as;
+};
+
+#define st_is_member(table,key) st_lookup((table),(key),(st_data_t *)0)
+
+enum st_retval {ST_CONTINUE, ST_STOP, ST_DELETE, ST_CHECK};
+
+st_table *st_init_table(const struct st_hash_type *);
+st_table *st_init_table_with_size(const struct st_hash_type *, st_index_t);
+st_table *st_init_numtable(void);
+st_table *st_init_numtable_with_size(st_index_t);
+st_table *st_init_strtable(void);
+st_table *st_init_strtable_with_size(st_index_t);
+st_table *st_init_strcasetable(void);
+st_table *st_init_strcasetable_with_size(st_index_t);
+int st_delete(st_table *, st_data_t *, st_data_t *); /* returns 0:notfound 1:deleted */
+int st_delete_safe(st_table *, st_data_t *, st_data_t *, st_data_t);
+int st_shift(st_table *, st_data_t *, st_data_t *); /* returns 0:notfound 1:deleted */
+int st_insert(st_table *, st_data_t, st_data_t);
+int st_insert2(st_table *, st_data_t, st_data_t, st_data_t (*)(st_data_t));
+int st_lookup(st_table *, st_data_t, st_data_t *);
+int st_get_key(st_table *, st_data_t, st_data_t *);
+typedef int st_update_callback_func(st_data_t *key, st_data_t *value, st_data_t arg, int existing);
+/* *key may be altered, but must equal to the old key, i.e., the
+ * results of hash() are same and compare() returns 0, otherwise the
+ * behavior is undefined */
+int st_update(st_table *table, st_data_t key, st_update_callback_func *func, st_data_t arg);
+int st_foreach(st_table *, int (*)(ANYARGS), st_data_t);
+int st_foreach_check(st_table *, int (*)(ANYARGS), st_data_t, st_data_t);
+int st_reverse_foreach(st_table *, int (*)(ANYARGS), st_data_t);
+st_index_t st_keys(st_table *table, st_data_t *keys, st_index_t size);
+st_index_t st_keys_check(st_table *table, st_data_t *keys, st_index_t size, st_data_t never);
+st_index_t st_values(st_table *table, st_data_t *values, st_index_t size);
+st_index_t st_values_check(st_table *table, st_data_t *values, st_index_t size, st_data_t never);
+void st_add_direct(st_table *, st_data_t, st_data_t);
+void st_free_table(st_table *);
+void st_cleanup_safe(st_table *, st_data_t);
+void st_clear(st_table *);
+st_table *st_copy(st_table *);
+int st_numcmp(st_data_t, st_data_t);
+st_index_t st_numhash(st_data_t);
+int st_locale_insensitive_strcasecmp(const char *s1, const char *s2);
+int st_locale_insensitive_strncasecmp(const char *s1, const char *s2, size_t n);
+#define st_strcasecmp st_locale_insensitive_strcasecmp
+#define st_strncasecmp st_locale_insensitive_strncasecmp
+size_t st_memsize(const st_table *);
+st_index_t st_hash(const void *ptr, size_t len, st_index_t h);
+st_index_t st_hash_uint32(st_index_t h, uint32_t i);
+st_index_t st_hash_uint(st_index_t h, st_index_t i);
+st_index_t st_hash_end(st_index_t h);
+st_index_t st_hash_start(st_index_t h);
+#define st_hash_start(h) ((st_index_t)(h))
+
+RUBY_SYMBOL_EXPORT_END
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+}  /* extern "C" { */
+#endif
+
+#endif /* RUBY_ST_H */

--- a/spec/ruby/optional/capi/ext/rubyspec.h
+++ b/spec/ruby/optional/capi/ext/rubyspec.h
@@ -501,6 +501,9 @@
 #define HAVE_RB_REG_OPTIONS                1
 #define HAVE_RB_REG_REGCOMP                1
 
+/* st */
+#define HAVE_RB_ST                         1
+
 /* String */
 #define HAVE_RB_CSTR2INUM                  1
 #define HAVE_RB_CSTR_TO_INUM               1

--- a/spec/ruby/optional/capi/ext/st_spec.c
+++ b/spec/ruby/optional/capi/ext/st_spec.c
@@ -1,0 +1,81 @@
+#include "ruby.h"
+#include "rubyspec.h"
+
+#include <string.h>
+#include <stdarg.h>
+
+#ifdef HAVE_RB_ST
+#include <ruby/st.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef HAVE_RB_ST
+VALUE st_spec_st_init_numtable(VALUE self) {
+  st_table *tbl = st_init_numtable();
+  int entries = tbl->num_entries;
+  st_free_table(tbl);
+  return INT2FIX(entries);
+}
+
+VALUE st_spec_st_init_numtable_with_size(VALUE self) {
+  st_table *tbl = st_init_numtable_with_size(128);
+  int entries = tbl->num_entries;
+  st_free_table(tbl);
+  return INT2FIX(entries);
+}
+
+VALUE st_spec_st_insert(VALUE self) {
+  st_table *tbl = st_init_numtable_with_size(128);
+  st_insert(tbl, 1, 1);
+  int entries = tbl->num_entries;
+  st_free_table(tbl);
+  return INT2FIX(entries);
+}
+
+static int sum(st_data_t key, st_data_t value, st_data_t arg) {
+  *(int*)arg += value;
+  return ST_CONTINUE;
+}
+
+VALUE st_spec_st_foreach(VALUE self) {
+  st_table *tbl = st_init_numtable_with_size(128);
+  st_insert(tbl, 1, 3);
+  st_insert(tbl, 2, 4);
+  int total = 0;
+  st_foreach(tbl, sum, (st_data_t)&total);
+  st_free_table(tbl);
+  return INT2FIX(total);
+}
+
+VALUE st_spec_st_lookup(VALUE self) {
+  st_table *tbl = st_init_numtable_with_size(128);
+  st_insert(tbl, 7, 42);
+  st_insert(tbl, 2, 4);
+  st_data_t result = (st_data_t)0;
+  st_lookup(tbl, (st_data_t)7, &result);
+  st_free_table(tbl);
+  return INT2FIX(result);
+}
+
+#endif
+
+void Init_st_spec(void) {
+  VALUE cls;
+  cls = rb_define_class("CApiStSpecs", rb_cObject);
+
+#ifdef HAVE_RB_ST
+  rb_define_method(cls, "st_init_numtable", st_spec_st_init_numtable, 0);
+  rb_define_method(cls, "st_init_numtable_with_size", st_spec_st_init_numtable_with_size, 0);
+  rb_define_method(cls, "st_insert", st_spec_st_insert, 0);
+  rb_define_method(cls, "st_foreach", st_spec_st_foreach, 0);
+  rb_define_method(cls, "st_lookup", st_spec_st_lookup, 0);
+#endif
+
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/spec/ruby/optional/capi/st_spec.rb
+++ b/spec/ruby/optional/capi/st_spec.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+require File.expand_path('../spec_helper', __FILE__)
+
+load_extension('st')
+
+describe "st hash table function" do
+  before :each do
+    @s = CApiStSpecs.new
+  end
+
+  describe "st_init_numtable" do
+    it "initializes without error" do
+      @s.st_init_numtable.should == 0
+    end
+  end
+  
+  describe "st_init_numtable_with_size" do
+    it "initializes without error" do
+      @s.st_init_numtable_with_size.should == 0
+    end
+  end
+
+  describe "st_insert" do
+    it "returns size 1 after insert" do
+      @s.st_insert.should == 1
+    end
+  end
+
+  describe "st_foreach" do
+    it "iterates over each pair of key and value" do
+      @s.st_foreach.should == 7
+    end
+  end
+
+  describe "st_lookup" do
+    it "returns the expected value" do
+      @s.st_lookup.should == 42
+    end
+  end
+
+end

--- a/src/main/c/cext/st.c
+++ b/src/main/c/cext/st.c
@@ -1,0 +1,1719 @@
+/* This is a public domain general purpose hash table package written by Peter Moore @ UCB. */
+
+/* static	char	sccsid[] = "@(#) st.c 5.1 89/12/14 Crucible"; */
+
+#ifdef NOT_RUBY
+#include "regint.h"
+#include "st.h"
+#else
+#include "internal.h"
+#endif
+
+#include <stdio.h>
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#include <string.h>
+#include "ccan/list/list.h"
+
+typedef struct st_table_entry st_table_entry;
+
+struct st_table_entry {
+    st_index_t hash;
+    st_data_t key;
+    st_data_t record;
+    st_table_entry *next;
+    struct list_node olist;
+};
+
+typedef struct st_packed_entry {
+    st_index_t hash;
+    st_data_t key, val;
+} st_packed_entry;
+
+#ifndef STATIC_ASSERT
+#define STATIC_ASSERT(name, expr) typedef int static_assert_##name##_check[(expr) ? 1 : -1]
+#endif
+
+#define ST_DEFAULT_MAX_DENSITY 5
+#define ST_DEFAULT_INIT_TABLE_SIZE 16
+#define ST_DEFAULT_PACKED_TABLE_SIZE 18
+#define PACKED_UNIT (int)(sizeof(st_packed_entry) / sizeof(st_table_entry*))
+#define MAX_PACKED_HASH (int)(ST_DEFAULT_PACKED_TABLE_SIZE * sizeof(st_table_entry*) / sizeof(st_packed_entry))
+
+STATIC_ASSERT(st_packed_entry, sizeof(st_packed_entry) == sizeof(st_table_entry*[PACKED_UNIT]));
+STATIC_ASSERT(st_packed_bins, sizeof(st_packed_entry[MAX_PACKED_HASH]) <= sizeof(st_table_entry*[ST_DEFAULT_PACKED_TABLE_SIZE]));
+
+    /*
+     * DEFAULT_MAX_DENSITY is the default for the largest we allow the
+     * average number of items per bin before increasing the number of
+     * bins
+     *
+     * DEFAULT_INIT_TABLE_SIZE is the default for the number of bins
+     * allocated initially
+     *
+     */
+
+#define type_numhash st_hashtype_num
+const struct st_hash_type st_hashtype_num = {
+    st_numcmp,
+    st_numhash,
+};
+
+/* extern int strcmp(const char *, const char *); */
+static st_index_t strhash(st_data_t);
+static const struct st_hash_type type_strhash = {
+    strcmp,
+    strhash,
+};
+
+static st_index_t strcasehash(st_data_t);
+static const struct st_hash_type type_strcasehash = {
+    st_locale_insensitive_strcasecmp,
+    strcasehash,
+};
+
+static void rehash(st_table *);
+
+#ifdef RUBY
+#undef malloc
+#undef realloc
+#undef calloc
+#undef free
+#define malloc xmalloc
+#define calloc xcalloc
+#define realloc xrealloc
+#define free(x) xfree(x)
+#endif
+
+#define EQUAL(table,x,ent) ((x)==(ent)->key || (*(table)->type->compare)((x),(ent)->key) == 0)
+
+#define do_hash(key,table) (st_index_t)(*(table)->type->hash)((key))
+#define hash_pos(h,n) ((h) & (n - 1))
+
+/* preparation for possible allocation improvements */
+#define st_alloc_entry() (st_table_entry *)malloc(sizeof(st_table_entry))
+#define st_free_entry(entry) free(entry)
+#define st_alloc_table() (st_table *)malloc(sizeof(st_table))
+#define st_dealloc_table(table) free(table)
+#define st_alloc_bins(size) (st_table_entry **)calloc(size, sizeof(st_table_entry *))
+#define st_free_bins(bins, size) free(bins)
+static inline st_table_entry**
+st_realloc_bins(st_table_entry **bins, st_index_t newsize, st_index_t oldsize)
+{
+    bins = (st_table_entry **)realloc(bins, newsize * sizeof(st_table_entry *));
+    MEMZERO(bins, st_table_entry*, newsize);
+    return bins;
+}
+
+/* Shortcut */
+#define bins as.big.bins
+#define real_entries as.packed.real_entries
+
+/* preparation for possible packing improvements */
+#define PACKED_BINS(table) ((table)->as.packed.entries)
+#define PACKED_ENT(table, i) PACKED_BINS(table)[i]
+#define PKEY(table, i) PACKED_ENT((table), (i)).key
+#define PVAL(table, i) PACKED_ENT((table), (i)).val
+#define PHASH(table, i) PACKED_ENT((table), (i)).hash
+#define PKEY_SET(table, i, v) (PKEY((table), (i)) = (v))
+#define PVAL_SET(table, i, v) (PVAL((table), (i)) = (v))
+#define PHASH_SET(table, i, v) (PHASH((table), (i)) = (v))
+
+/* this function depends much on packed layout, so that it placed here */
+static inline void
+remove_packed_entry(st_table *table, st_index_t i)
+{
+    table->real_entries--;
+    table->num_entries--;
+    if (i < table->real_entries) {
+	MEMMOVE(&PACKED_ENT(table, i), &PACKED_ENT(table, i+1),
+		st_packed_entry, table->real_entries - i);
+    }
+}
+
+static inline void
+remove_safe_packed_entry(st_table *table, st_index_t i, st_data_t never)
+{
+    table->num_entries--;
+    PKEY_SET(table, i, never);
+    PVAL_SET(table, i, never);
+    PHASH_SET(table, i, 0);
+}
+
+static st_index_t
+next_pow2(st_index_t x)
+{
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+#if SIZEOF_ST_INDEX_T == 8
+    x |= x >> 32;
+#endif
+    return x + 1;
+}
+
+static st_index_t
+new_size(st_index_t size)
+{
+    st_index_t n;
+
+    if (size && (size & ~(size - 1)) == size) /* already a power-of-two? */
+	return size;
+
+    n = next_pow2(size);
+    if (n > size)
+	return n;
+#ifndef NOT_RUBY
+    rb_raise(rb_eRuntimeError, "st_table too big");
+#endif
+    return -1;			/* should raise exception */
+}
+
+#ifdef HASH_LOG
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+static struct {
+    int all, total, num, str, strcase;
+}  collision;
+static int init_st = 0;
+
+static void
+stat_col(void)
+{
+    char fname[10+sizeof(long)*3];
+    FILE *f = fopen((snprintf(fname, sizeof(fname), "/tmp/col%ld", (long)getpid()), fname), "w");
+    fprintf(f, "collision: %d / %d (%6.2f)\n", collision.all, collision.total,
+	    ((double)collision.all / (collision.total)) * 100);
+    fprintf(f, "num: %d, str: %d, strcase: %d\n", collision.num, collision.str, collision.strcase);
+    fclose(f);
+}
+#endif
+
+static struct list_head *
+st_head(const st_table *tbl)
+{
+    uintptr_t addr = (uintptr_t)&tbl->as.big.private_list_head;
+    return (struct list_head *)addr;
+}
+
+st_table*
+st_init_table_with_size(const struct st_hash_type *type, st_index_t size)
+{
+    st_table *tbl;
+
+#ifdef HASH_LOG
+# if HASH_LOG+0 < 0
+    {
+	const char *e = getenv("ST_HASH_LOG");
+	if (!e || !*e) init_st = 1;
+    }
+# endif
+    if (init_st == 0) {
+	init_st = 1;
+	atexit(stat_col);
+    }
+#endif
+
+
+    tbl = st_alloc_table();
+    tbl->type = type;
+    tbl->num_entries = 0;
+    tbl->entries_packed = size <= MAX_PACKED_HASH;
+    if (tbl->entries_packed) {
+	size = ST_DEFAULT_PACKED_TABLE_SIZE;
+	tbl->real_entries = 0;
+    }
+    else {
+	size = new_size(size);	/* round up to power-of-two */
+	list_head_init(st_head(tbl));
+    }
+    tbl->num_bins = size;
+    tbl->bins = st_alloc_bins(size);
+
+    return tbl;
+}
+
+st_table*
+st_init_table(const struct st_hash_type *type)
+{
+    return st_init_table_with_size(type, 0);
+}
+
+st_table*
+st_init_numtable(void)
+{
+    return st_init_table(&type_numhash);
+}
+
+st_table*
+st_init_numtable_with_size(st_index_t size)
+{
+    return st_init_table_with_size(&type_numhash, size);
+}
+
+st_table*
+st_init_strtable(void)
+{
+    return st_init_table(&type_strhash);
+}
+
+st_table*
+st_init_strtable_with_size(st_index_t size)
+{
+    return st_init_table_with_size(&type_strhash, size);
+}
+
+st_table*
+st_init_strcasetable(void)
+{
+    return st_init_table(&type_strcasehash);
+}
+
+st_table*
+st_init_strcasetable_with_size(st_index_t size)
+{
+    return st_init_table_with_size(&type_strcasehash, size);
+}
+
+void
+st_clear(st_table *table)
+{
+    register st_table_entry *ptr = 0, *next;
+
+    if (table->entries_packed) {
+        table->num_entries = 0;
+        table->real_entries = 0;
+        return;
+    }
+
+    list_for_each_safe(st_head(table), ptr, next, olist) {
+	/* list_del is not needed */
+	st_free_entry(ptr);
+    }
+    table->num_entries = 0;
+    MEMZERO(table->bins, st_table_entry*, table->num_bins);
+    list_head_init(st_head(table));
+}
+
+void
+st_free_table(st_table *table)
+{
+    st_clear(table);
+    st_free_bins(table->bins, table->num_bins);
+    st_dealloc_table(table);
+}
+
+size_t
+st_memsize(const st_table *table)
+{
+    if (table->entries_packed) {
+	return table->num_bins * sizeof (void *) + sizeof(st_table);
+    }
+    else {
+	return table->num_entries * sizeof(struct st_table_entry) + table->num_bins * sizeof (void *) + sizeof(st_table);
+    }
+}
+
+#define PTR_NOT_EQUAL(table, ptr, hash_val, key) \
+((ptr) != 0 && ((ptr)->hash != (hash_val) || !EQUAL((table), (key), (ptr))))
+
+#ifdef HASH_LOG
+static void
+count_collision(const struct st_hash_type *type)
+{
+    collision.all++;
+    if (type == &type_numhash) {
+	collision.num++;
+    }
+    else if (type == &type_strhash) {
+	collision.strcase++;
+    }
+    else if (type == &type_strcasehash) {
+	collision.str++;
+    }
+}
+#define COLLISION (collision_check ? count_collision(table->type) : (void)0)
+#define FOUND_ENTRY (collision_check ? collision.total++ : (void)0)
+#else
+#define COLLISION
+#define FOUND_ENTRY
+#endif
+
+#define FIND_ENTRY(table, ptr, hash_val, bin_pos) \
+    ((ptr) = find_entry((table), key, (hash_val), ((bin_pos) = hash_pos(hash_val, (table)->num_bins))))
+
+static st_table_entry *
+find_entry(const st_table *table, st_data_t key, st_index_t hash_val,
+           st_index_t bin_pos)
+{
+    register st_table_entry *ptr = table->bins[bin_pos];
+    FOUND_ENTRY;
+    if (PTR_NOT_EQUAL(table, ptr, hash_val, key)) {
+	COLLISION;
+	while (PTR_NOT_EQUAL(table, ptr->next, hash_val, key)) {
+	    ptr = ptr->next;
+	}
+	ptr = ptr->next;
+    }
+    return ptr;
+}
+
+static inline st_index_t
+find_packed_index_from(const st_table *table, st_index_t hash_val,
+		       st_data_t key, st_index_t i)
+{
+    while (i < table->real_entries &&
+	   (PHASH(table, i) != hash_val || !EQUAL(table, key, &PACKED_ENT(table, i)))) {
+	i++;
+    }
+    return i;
+}
+
+static inline st_index_t
+find_packed_index(const st_table *table, st_index_t hash_val, st_data_t key)
+{
+    return find_packed_index_from(table, hash_val, key, 0);
+}
+
+#define collision_check 0
+
+int
+st_lookup(st_table *table, register st_data_t key, st_data_t *value)
+{
+    st_index_t hash_val;
+    register st_table_entry *ptr;
+
+    hash_val = do_hash(key, table);
+
+    if (table->entries_packed) {
+	st_index_t i = find_packed_index(table, hash_val, key);
+	if (i < table->real_entries) {
+	    if (value != 0) *value = PVAL(table, i);
+	    return 1;
+	}
+        return 0;
+    }
+
+    ptr = find_entry(table, key, hash_val, hash_pos(hash_val, table->num_bins));
+
+    if (ptr == 0) {
+	return 0;
+    }
+    else {
+	if (value != 0) *value = ptr->record;
+	return 1;
+    }
+}
+
+int
+st_get_key(st_table *table, register st_data_t key, st_data_t *result)
+{
+    st_index_t hash_val;
+    register st_table_entry *ptr;
+
+    hash_val = do_hash(key, table);
+
+    if (table->entries_packed) {
+	st_index_t i = find_packed_index(table, hash_val, key);
+	if (i < table->real_entries) {
+	    if (result != 0) *result = PKEY(table, i);
+	    return 1;
+	}
+        return 0;
+    }
+
+    ptr = find_entry(table, key, hash_val, hash_pos(hash_val, table->num_bins));
+
+    if (ptr == 0) {
+	return 0;
+    }
+    else {
+	if (result != 0)  *result = ptr->key;
+	return 1;
+    }
+}
+
+#undef collision_check
+#define collision_check 1
+
+static inline st_table_entry *
+new_entry(st_table * table, st_data_t key, st_data_t value,
+	st_index_t hash_val, register st_index_t bin_pos)
+{
+    register st_table_entry *entry = st_alloc_entry();
+
+    entry->next = table->bins[bin_pos];
+    table->bins[bin_pos] = entry;
+    entry->hash = hash_val;
+    entry->key = key;
+    entry->record = value;
+
+    return entry;
+}
+
+static inline void
+add_direct(st_table *table, st_data_t key, st_data_t value,
+	   st_index_t hash_val, register st_index_t bin_pos)
+{
+    register st_table_entry *entry;
+    if (table->num_entries > ST_DEFAULT_MAX_DENSITY * table->num_bins) {
+	rehash(table);
+        bin_pos = hash_pos(hash_val, table->num_bins);
+    }
+
+    entry = new_entry(table, key, value, hash_val, bin_pos);
+    list_add_tail(st_head(table), &entry->olist);
+    table->num_entries++;
+}
+
+static void
+unpack_entries(register st_table *table)
+{
+    st_index_t i;
+    st_packed_entry packed_bins[MAX_PACKED_HASH];
+    register st_table_entry *entry;
+    st_table tmp_table = *table;
+
+    MEMCPY(packed_bins, PACKED_BINS(table), st_packed_entry, MAX_PACKED_HASH);
+    table->as.packed.entries = packed_bins;
+    tmp_table.entries_packed = 0;
+#if ST_DEFAULT_INIT_TABLE_SIZE == ST_DEFAULT_PACKED_TABLE_SIZE
+    MEMZERO(tmp_table.bins, st_table_entry*, tmp_table.num_bins);
+#else
+    tmp_table.bins = st_realloc_bins(tmp_table.bins, ST_DEFAULT_INIT_TABLE_SIZE, tmp_table.num_bins);
+    tmp_table.num_bins = ST_DEFAULT_INIT_TABLE_SIZE;
+#endif
+
+    /*
+     * order is important here, we need to keep the original table
+     * walkable during GC (GC may be triggered by new_entry call)
+     */
+    i = 0;
+    list_head_init(st_head(&tmp_table));
+    do {
+	st_data_t key = packed_bins[i].key;
+	st_data_t val = packed_bins[i].val;
+	st_index_t hash = packed_bins[i].hash;
+	entry = new_entry(&tmp_table, key, val, hash,
+			  hash_pos(hash, ST_DEFAULT_INIT_TABLE_SIZE));
+	list_add_tail(st_head(&tmp_table), &entry->olist);
+    } while (++i < MAX_PACKED_HASH);
+    *table = tmp_table;
+    list_head_init(st_head(table));
+    list_append_list(st_head(table), st_head(&tmp_table));
+}
+
+static void
+add_packed_direct(st_table *table, st_data_t key, st_data_t value, st_index_t hash_val)
+{
+    if (table->real_entries < MAX_PACKED_HASH) {
+	st_index_t i = table->real_entries++;
+	PKEY_SET(table, i, key);
+	PVAL_SET(table, i, value);
+	PHASH_SET(table, i, hash_val);
+	table->num_entries++;
+    }
+    else {
+	unpack_entries(table);
+	add_direct(table, key, value, hash_val, hash_pos(hash_val, table->num_bins));
+    }
+}
+
+
+int
+st_insert(register st_table *table, register st_data_t key, st_data_t value)
+{
+    st_index_t hash_val;
+    register st_index_t bin_pos;
+    register st_table_entry *ptr;
+
+    hash_val = do_hash(key, table);
+
+    if (table->entries_packed) {
+	st_index_t i = find_packed_index(table, hash_val, key);
+	if (i < table->real_entries) {
+	    PVAL_SET(table, i, value);
+	    return 1;
+        }
+	add_packed_direct(table, key, value, hash_val);
+	return 0;
+    }
+
+    FIND_ENTRY(table, ptr, hash_val, bin_pos);
+
+    if (ptr == 0) {
+	add_direct(table, key, value, hash_val, bin_pos);
+	return 0;
+    }
+    else {
+	ptr->record = value;
+	return 1;
+    }
+}
+
+int
+st_insert2(register st_table *table, register st_data_t key, st_data_t value,
+	   st_data_t (*func)(st_data_t))
+{
+    st_index_t hash_val;
+    register st_index_t bin_pos;
+    register st_table_entry *ptr;
+
+    hash_val = do_hash(key, table);
+
+    if (table->entries_packed) {
+	st_index_t i = find_packed_index(table, hash_val, key);
+	if (i < table->real_entries) {
+	    PVAL_SET(table, i, value);
+	    return 1;
+	}
+	key = (*func)(key);
+	add_packed_direct(table, key, value, hash_val);
+	return 0;
+    }
+
+    FIND_ENTRY(table, ptr, hash_val, bin_pos);
+
+    if (ptr == 0) {
+	key = (*func)(key);
+	add_direct(table, key, value, hash_val, bin_pos);
+	return 0;
+    }
+    else {
+	ptr->record = value;
+	return 1;
+    }
+}
+
+void
+st_add_direct(st_table *table, st_data_t key, st_data_t value)
+{
+    st_index_t hash_val;
+
+    hash_val = do_hash(key, table);
+    if (table->entries_packed) {
+	add_packed_direct(table, key, value, hash_val);
+	return;
+    }
+
+    add_direct(table, key, value, hash_val, hash_pos(hash_val, table->num_bins));
+}
+
+static void
+rehash(register st_table *table)
+{
+    register st_table_entry *ptr = 0, **new_bins;
+    st_index_t new_num_bins, hash_val;
+
+    new_num_bins = new_size(table->num_bins+1);
+    new_bins = st_realloc_bins(table->bins, new_num_bins, table->num_bins);
+    table->num_bins = new_num_bins;
+    table->bins = new_bins;
+
+    list_for_each(st_head(table), ptr, olist) {
+	hash_val = hash_pos(ptr->hash, new_num_bins);
+	ptr->next = new_bins[hash_val];
+	new_bins[hash_val] = ptr;
+    }
+}
+
+st_table*
+st_copy(st_table *old_table)
+{
+    st_table *new_table;
+    st_table_entry *ptr = 0, *entry;
+    st_index_t num_bins = old_table->num_bins;
+
+    new_table = st_alloc_table();
+    if (new_table == 0) {
+	return 0;
+    }
+
+    *new_table = *old_table;
+    new_table->bins = st_alloc_bins(num_bins);
+
+    if (new_table->bins == 0) {
+	st_dealloc_table(new_table);
+	return 0;
+    }
+
+    if (old_table->entries_packed) {
+        MEMCPY(new_table->bins, old_table->bins, st_table_entry*, old_table->num_bins);
+        return new_table;
+    }
+
+    list_head_init(st_head(new_table));
+
+    list_for_each(st_head(old_table), ptr, olist) {
+	entry = new_entry(new_table, ptr->key, ptr->record, ptr->hash,
+			    hash_pos(ptr->hash, num_bins));
+	list_add_tail(st_head(new_table), &entry->olist);
+    }
+
+    return new_table;
+}
+
+static inline void
+remove_entry(st_table *table, st_table_entry *ptr)
+{
+    list_del(&ptr->olist);
+    table->num_entries--;
+}
+
+int
+st_delete(register st_table *table, register st_data_t *key, st_data_t *value)
+{
+    st_index_t hash_val;
+    st_table_entry **prev;
+    register st_table_entry *ptr;
+
+    hash_val = do_hash(*key, table);
+
+    if (table->entries_packed) {
+	st_index_t i = find_packed_index(table, hash_val, *key);
+	if (i < table->real_entries) {
+	    if (value != 0) *value = PVAL(table, i);
+	    *key = PKEY(table, i);
+	    remove_packed_entry(table, i);
+	    return 1;
+        }
+        if (value != 0) *value = 0;
+        return 0;
+    }
+
+    prev = &table->bins[hash_pos(hash_val, table->num_bins)];
+    for (;(ptr = *prev) != 0; prev = &ptr->next) {
+	if (EQUAL(table, *key, ptr)) {
+	    *prev = ptr->next;
+	    remove_entry(table, ptr);
+	    if (value != 0) *value = ptr->record;
+	    *key = ptr->key;
+	    st_free_entry(ptr);
+	    return 1;
+	}
+    }
+
+    if (value != 0) *value = 0;
+    return 0;
+}
+
+int
+st_delete_safe(register st_table *table, register st_data_t *key, st_data_t *value, st_data_t never)
+{
+    st_index_t hash_val;
+    register st_table_entry *ptr;
+
+    hash_val = do_hash(*key, table);
+
+    if (table->entries_packed) {
+	st_index_t i = find_packed_index(table, hash_val, *key);
+	if (i < table->real_entries) {
+	    if (value != 0) *value = PVAL(table, i);
+	    *key = PKEY(table, i);
+	    remove_safe_packed_entry(table, i, never);
+	    return 1;
+	}
+	if (value != 0) *value = 0;
+	return 0;
+    }
+
+    ptr = table->bins[hash_pos(hash_val, table->num_bins)];
+
+    for (; ptr != 0; ptr = ptr->next) {
+	if ((ptr->key != never) && EQUAL(table, *key, ptr)) {
+	    remove_entry(table, ptr);
+	    *key = ptr->key;
+	    if (value != 0) *value = ptr->record;
+	    ptr->key = ptr->record = never;
+	    return 1;
+	}
+    }
+
+    if (value != 0) *value = 0;
+    return 0;
+}
+
+int
+st_shift(register st_table *table, register st_data_t *key, st_data_t *value)
+{
+    st_table_entry *old;
+    st_table_entry **prev;
+    register st_table_entry *ptr;
+
+    if (table->num_entries == 0) {
+        if (value != 0) *value = 0;
+        return 0;
+    }
+
+    if (table->entries_packed) {
+        if (value != 0) *value = PVAL(table, 0);
+        *key = PKEY(table, 0);
+        remove_packed_entry(table, 0);
+        return 1;
+    }
+
+    old = list_pop(st_head(table), st_table_entry, olist);
+    table->num_entries--;
+    prev = &table->bins[hash_pos(old->hash, table->num_bins)];
+    while ((ptr = *prev) != old) prev = &ptr->next;
+    *prev = ptr->next;
+    if (value != 0) *value = ptr->record;
+    *key = ptr->key;
+    st_free_entry(ptr);
+    return 1;
+}
+
+void
+st_cleanup_safe(st_table *table, st_data_t never)
+{
+    st_table_entry *ptr, **last, *tmp;
+    st_index_t i;
+
+    if (table->entries_packed) {
+	st_index_t i = 0, j = 0;
+	while (PKEY(table, i) != never) {
+	    if (i++ == table->real_entries) return;
+	}
+	for (j = i; ++i < table->real_entries;) {
+	    if (PKEY(table, i) == never) continue;
+	    PACKED_ENT(table, j) = PACKED_ENT(table, i);
+	    j++;
+	}
+	table->real_entries = j;
+	/* table->num_entries really should be equal j at this moment, but let set it anyway */
+	table->num_entries = j;
+	return;
+    }
+
+    for (i = 0; i < table->num_bins; i++) {
+	ptr = *(last = &table->bins[i]);
+	while (ptr != 0) {
+	    if (ptr->key == never) {
+		tmp = ptr;
+		*last = ptr = ptr->next;
+		st_free_entry(tmp);
+	    }
+	    else {
+		ptr = *(last = &ptr->next);
+	    }
+	}
+    }
+}
+
+int
+st_update(st_table *table, st_data_t key, st_update_callback_func *func, st_data_t arg)
+{
+    st_index_t hash_val, bin_pos;
+    register st_table_entry *ptr, **last, *tmp;
+    st_data_t value = 0, old_key;
+    int retval, existing = 0;
+
+    hash_val = do_hash(key, table);
+
+    if (table->entries_packed) {
+	st_index_t i = find_packed_index(table, hash_val, key);
+	if (i < table->real_entries) {
+	    key = PKEY(table, i);
+	    value = PVAL(table, i);
+	    existing = 1;
+	}
+	{
+	    old_key = key;
+	    retval = (*func)(&key, &value, arg, existing);
+	    if (!table->entries_packed) {
+		FIND_ENTRY(table, ptr, hash_val, bin_pos);
+		goto unpacked;
+	    }
+	    switch (retval) {
+	      case ST_CONTINUE:
+		if (!existing) {
+		    add_packed_direct(table, key, value, hash_val);
+		    break;
+		}
+		if (old_key != key) {
+		    PKEY(table, i) = key;
+		}
+		PVAL_SET(table, i, value);
+		break;
+	      case ST_DELETE:
+		if (!existing) break;
+		remove_packed_entry(table, i);
+	    }
+	}
+	return existing;
+    }
+
+    FIND_ENTRY(table, ptr, hash_val, bin_pos);
+
+    if (ptr != 0) {
+	key = ptr->key;
+	value = ptr->record;
+	existing = 1;
+    }
+    {
+	old_key = key;
+	retval = (*func)(&key, &value, arg, existing);
+      unpacked:
+	switch (retval) {
+	  case ST_CONTINUE:
+	    if (!existing) {
+		add_direct(table, key, value, hash_val, hash_pos(hash_val, table->num_bins));
+		break;
+	    }
+	    if (old_key != key) {
+		ptr->key = key;
+	    }
+	    ptr->record = value;
+	    break;
+	  case ST_DELETE:
+	    if (!existing) break;
+	    last = &table->bins[bin_pos];
+	    for (; (tmp = *last) != 0; last = &tmp->next) {
+		if (ptr == tmp) {
+		    *last = ptr->next;
+		    remove_entry(table, ptr);
+		    st_free_entry(ptr);
+		    break;
+		}
+	    }
+	    break;
+	}
+	return existing;
+    }
+}
+
+int
+st_foreach_check(st_table *table, int (*func)(ANYARGS), st_data_t arg, st_data_t never)
+{
+    st_table_entry *ptr = 0, **last, *tmp, *next;
+    struct list_head *head;
+    enum st_retval retval;
+    st_index_t i;
+
+    if (table->entries_packed) {
+	for (i = 0; i < table->real_entries; i++) {
+	    st_data_t key, val;
+	    st_index_t hash;
+	    key = PKEY(table, i);
+	    val = PVAL(table, i);
+	    hash = PHASH(table, i);
+	    if (key == never) continue;
+	    retval = (*func)(key, val, arg, 0);
+	    if (!table->entries_packed) {
+		FIND_ENTRY(table, ptr, hash, i);
+		if (retval == ST_CHECK) {
+		    if (!ptr) goto deleted;
+		}
+		if (table->num_entries == 0) return 0;
+		head = st_head(table);
+		next = list_entry(ptr->olist.next, st_table_entry, olist);
+		goto unpacked;
+	    }
+	    switch (retval) {
+	      case ST_CHECK:	/* check if hash is modified during iteration */
+		if (PHASH(table, i) == 0 && PKEY(table, i) == never) {
+		    break;
+		}
+		i = find_packed_index_from(table, hash, key, i);
+		if (i >= table->real_entries) {
+		    i = find_packed_index(table, hash, key);
+		    if (i >= table->real_entries) goto deleted;
+		}
+		/* fall through */
+	      case ST_CONTINUE:
+		break;
+	      case ST_STOP:
+		return 0;
+	      case ST_DELETE:
+		remove_safe_packed_entry(table, i, never);
+		break;
+	    }
+	}
+	return 0;
+    }
+
+    head = st_head(table);
+    list_for_each_safe(head, ptr, next, olist) {
+	if (ptr->key != never) {
+	    i = hash_pos(ptr->hash, table->num_bins);
+	    retval = (*func)(ptr->key, ptr->record, arg, 0);
+	  unpacked:
+	    switch (retval) {
+	      case ST_CHECK:	/* check if hash is modified during iteration */
+		for (tmp = table->bins[i]; tmp != ptr; tmp = tmp->next) {
+		    if (!tmp) {
+		      deleted:
+			/* call func with error notice */
+			retval = (*func)(0, 0, arg, 1);
+			return 1;
+		    }
+		}
+		/* fall through */
+	      case ST_CONTINUE:
+		break;
+	      case ST_STOP:
+		return 0;
+	      case ST_DELETE:
+		last = &table->bins[hash_pos(ptr->hash, table->num_bins)];
+		for (; (tmp = *last) != 0; last = &tmp->next) {
+		    if (ptr == tmp) {
+			remove_entry(table, ptr);
+			ptr->key = ptr->record = never;
+			ptr->hash = 0;
+			break;
+		    }
+		}
+		if (table->num_entries == 0) return 0;
+	    }
+	}
+    }
+    return 0;
+}
+
+int
+st_foreach(st_table *table, int (*func)(ANYARGS), st_data_t arg)
+{
+    st_table_entry *ptr = 0, **last, *tmp, *next;
+    enum st_retval retval;
+    struct list_head *head;
+    st_index_t i;
+
+    if (table->entries_packed) {
+	for (i = 0; i < table->real_entries; i++) {
+	    st_data_t key, val;
+	    st_index_t hash;
+	    key = PKEY(table, i);
+	    val = PVAL(table, i);
+	    hash = PHASH(table, i);
+	    retval = (*func)(key, val, arg, 0);
+	    if (!table->entries_packed) {
+		FIND_ENTRY(table, ptr, hash, i);
+		if (!ptr) return 0;
+		head = st_head(table);
+		next = list_entry(ptr->olist.next, st_table_entry, olist);
+		goto unpacked;
+	    }
+	    switch (retval) {
+	      case ST_CONTINUE:
+		break;
+	      case ST_CHECK:
+	      case ST_STOP:
+		return 0;
+	      case ST_DELETE:
+		remove_packed_entry(table, i);
+		i--;
+		break;
+	    }
+	}
+	return 0;
+    }
+
+    head = st_head(table);
+    list_for_each_safe(head, ptr, next, olist) {
+	i = hash_pos(ptr->hash, table->num_bins);
+	retval = (*func)(ptr->key, ptr->record, arg, 0);
+      unpacked:
+	switch (retval) {
+	  case ST_CONTINUE:
+	    break;
+	  case ST_CHECK:
+	  case ST_STOP:
+	    return 0;
+	  case ST_DELETE:
+	    last = &table->bins[hash_pos(ptr->hash, table->num_bins)];
+	    for (; (tmp = *last) != 0; last = &tmp->next) {
+		if (ptr == tmp) {
+		    *last = ptr->next;
+		    remove_entry(table, ptr);
+		    st_free_entry(ptr);
+		    break;
+		}
+	    }
+	    if (table->num_entries == 0) return 0;
+	}
+    }
+    return 0;
+}
+
+static st_index_t
+get_keys(const st_table *table, st_data_t *keys, st_index_t size,
+         int check, st_data_t never)
+{
+    st_data_t key;
+    st_data_t *keys_start = keys;
+
+    if (table->entries_packed) {
+	st_index_t i;
+
+	if (size > table->real_entries) size = table->real_entries;
+	for (i = 0; i < size; i++) {
+	    key = PKEY(table, i);
+	    if (check && key == never) continue;
+	    *keys++ = key;
+	}
+    }
+    else {
+	st_table_entry *ptr = 0;
+	st_data_t *keys_end = keys + size;
+
+	list_for_each(st_head(table), ptr, olist) {
+	    if (keys >= keys_end) break;
+	    key = ptr->key;
+	    if (check && key == never) continue;
+	    *keys++ = key;
+	}
+    }
+
+    return keys - keys_start;
+}
+
+st_index_t
+st_keys(st_table *table, st_data_t *keys, st_index_t size)
+{
+    return get_keys(table, keys, size, 0, 0);
+}
+
+st_index_t
+st_keys_check(st_table *table, st_data_t *keys, st_index_t size, st_data_t never)
+{
+    return get_keys(table, keys, size, 1, never);
+}
+
+static st_index_t
+get_values(const st_table *table, st_data_t *values, st_index_t size,
+           int check, st_data_t never)
+{
+    st_data_t key;
+    st_data_t *values_start = values;
+
+    if (table->entries_packed) {
+	st_index_t i;
+
+	if (size > table->real_entries) size = table->real_entries;
+	for (i = 0; i < size; i++) {
+	    key = PKEY(table, i);
+	    if (check && key == never) continue;
+	    *values++ = PVAL(table, i);
+	}
+    }
+    else {
+	st_table_entry *ptr = 0;
+	st_data_t *values_end = values + size;
+
+	list_for_each(st_head(table), ptr, olist) {
+	    if (values >= values_end) break;
+	    key = ptr->key;
+	    if (check && key == never) continue;
+	    *values++ = ptr->record;
+	}
+    }
+
+    return values - values_start;
+}
+
+st_index_t
+st_values(st_table *table, st_data_t *values, st_index_t size)
+{
+    return get_values(table, values, size, 0, 0);
+}
+
+st_index_t
+st_values_check(st_table *table, st_data_t *values, st_index_t size, st_data_t never)
+{
+    return get_values(table, values, size, 1, never);
+}
+
+#if 0  /* unused right now */
+int
+st_reverse_foreach_check(st_table *table, int (*func)(ANYARGS), st_data_t arg, st_data_t never)
+{
+    st_table_entry *ptr, **last, *tmp, *next;
+    struct list_head *head;
+    enum st_retval retval;
+    st_index_t i;
+
+    if (table->entries_packed) {
+	for (i = table->real_entries; 0 < i;) {
+	    st_data_t key, val;
+	    st_index_t hash;
+	    --i;
+	    key = PKEY(table, i);
+	    val = PVAL(table, i);
+	    hash = PHASH(table, i);
+	    if (key == never) continue;
+	    retval = (*func)(key, val, arg, 0);
+	    if (!table->entries_packed) {
+		FIND_ENTRY(table, ptr, hash, i);
+		if (retval == ST_CHECK) {
+		    if (!ptr) goto deleted;
+		}
+		if (table->num_entries == 0) return 0;
+		head = st_head(table);
+		next = list_entry(ptr->olist.next, st_table_entry, olist);
+		goto unpacked;
+	    }
+	    switch (retval) {
+	      case ST_CHECK:	/* check if hash is modified during iteration */
+		if (PHASH(table, i) == 0 && PKEY(table, i) == never) {
+		    break;
+		}
+		i = find_packed_index_from(table, hash, key, i);
+		if (i >= table->real_entries) {
+		    i = find_packed_index(table, hash, key);
+		    if (i >= table->real_entries) goto deleted;
+		}
+		/* fall through */
+	      case ST_CONTINUE:
+		break;
+	      case ST_STOP:
+		return 0;
+	      case ST_DELETE:
+		remove_safe_packed_entry(table, i, never);
+		break;
+	    }
+	}
+	return 0;
+    }
+
+    head = st_head(table);
+    list_for_each_rev_safe(head, ptr, next, olist) {
+	if (ptr->key != never) {
+	    i = hash_pos(ptr->hash, table->num_bins);
+	    retval = (*func)(ptr->key, ptr->record, arg, 0);
+	  unpacked:
+	    switch (retval) {
+	      case ST_CHECK:	/* check if hash is modified during iteration */
+		for (tmp = table->bins[i]; tmp != ptr; tmp = tmp->next) {
+		    if (!tmp) {
+		      deleted:
+			/* call func with error notice */
+			retval = (*func)(0, 0, arg, 1);
+			return 1;
+		    }
+		}
+		/* fall through */
+	      case ST_CONTINUE:
+		break;
+	      case ST_STOP:
+		return 0;
+	      case ST_DELETE:
+		last = &table->bins[hash_pos(ptr->hash, table->num_bins)];
+		for (; (tmp = *last) != 0; last = &tmp->next) {
+		    if (ptr == tmp) {
+			remove_entry(table, ptr);
+			ptr->key = ptr->record = never;
+			ptr->hash = 0;
+			break;
+		    }
+		}
+		if (table->num_entries == 0) return 0;
+	    }
+	}
+    }
+    return 0;
+}
+
+int
+st_reverse_foreach(st_table *table, int (*func)(ANYARGS), st_data_t arg)
+{
+    st_table_entry *ptr, **last, *tmp, *next;
+    enum st_retval retval;
+    struct list_head *head;
+    st_index_t i;
+
+    if (table->entries_packed) {
+	for (i = table->real_entries; 0 < i;) {
+	    st_data_t key, val;
+	    st_index_t hash;
+	    --i;
+	    key = PKEY(table, i);
+	    val = PVAL(table, i);
+	    hash = PHASH(table, i);
+	    retval = (*func)(key, val, arg, 0);
+	    if (!table->entries_packed) {
+		FIND_ENTRY(table, ptr, hash, i);
+		if (!ptr) return 0;
+		head = st_head(table);
+		next = list_entry(ptr->olist.next, st_table_entry, olist);
+		goto unpacked;
+	    }
+	    switch (retval) {
+	      case ST_CONTINUE:
+		break;
+	      case ST_CHECK:
+	      case ST_STOP:
+		return 0;
+	      case ST_DELETE:
+		remove_packed_entry(table, i);
+		break;
+	    }
+	}
+	return 0;
+    }
+
+    head = st_head(table);
+    list_for_each_rev_safe(head, ptr, next, olist) {
+	i = hash_pos(ptr->hash, table->num_bins);
+	retval = (*func)(ptr->key, ptr->record, arg, 0);
+      unpacked:
+	switch (retval) {
+	  case ST_CONTINUE:
+	    break;
+	  case ST_CHECK:
+	  case ST_STOP:
+	    return 0;
+	  case ST_DELETE:
+	    last = &table->bins[hash_pos(ptr->hash, table->num_bins)];
+	    for (; (tmp = *last) != 0; last = &tmp->next) {
+		if (ptr == tmp) {
+		    *last = ptr->next;
+		    remove_entry(table, ptr);
+		    st_free_entry(ptr);
+		    break;
+		}
+	    }
+	    if (table->num_entries == 0) return 0;
+	}
+    }
+    return 0;
+}
+#endif
+
+/*
+ * hash_32 - 32 bit Fowler/Noll/Vo FNV-1a hash code
+ *
+ * @(#) $Hash32: Revision: 1.1 $
+ * @(#) $Hash32: Id: hash_32a.c,v 1.1 2003/10/03 20:38:53 chongo Exp $
+ * @(#) $Hash32: Source: /usr/local/src/cmd/fnv/RCS/hash_32a.c,v $
+ *
+ ***
+ *
+ * Fowler/Noll/Vo hash
+ *
+ * The basis of this hash algorithm was taken from an idea sent
+ * as reviewer comments to the IEEE POSIX P1003.2 committee by:
+ *
+ *      Phong Vo (http://www.research.att.com/info/kpv/)
+ *      Glenn Fowler (http://www.research.att.com/~gsf/)
+ *
+ * In a subsequent ballot round:
+ *
+ *      Landon Curt Noll (http://www.isthe.com/chongo/)
+ *
+ * improved on their algorithm.  Some people tried this hash
+ * and found that it worked rather well.  In an EMail message
+ * to Landon, they named it the ``Fowler/Noll/Vo'' or FNV hash.
+ *
+ * FNV hashes are designed to be fast while maintaining a low
+ * collision rate. The FNV speed allows one to quickly hash lots
+ * of data while maintaining a reasonable collision rate.  See:
+ *
+ *      http://www.isthe.com/chongo/tech/comp/fnv/index.html
+ *
+ * for more details as well as other forms of the FNV hash.
+ ***
+ *
+ * To use the recommended 32 bit FNV-1a hash, pass FNV1_32A_INIT as the
+ * Fnv32_t hashval argument to fnv_32a_buf() or fnv_32a_str().
+ *
+ ***
+ *
+ * Please do not copyright this code.  This code is in the public domain.
+ *
+ * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
+ * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+ * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ * By:
+ *	chongo <Landon Curt Noll> /\oo/\
+ *      http://www.isthe.com/chongo/
+ *
+ * Share and Enjoy!	:-)
+ */
+
+/*
+ * 32 bit FNV-1 and FNV-1a non-zero initial basis
+ *
+ * The FNV-1 initial basis is the FNV-0 hash of the following 32 octets:
+ *
+ *              chongo <Landon Curt Noll> /\../\
+ *
+ * NOTE: The \'s above are not back-slashing escape characters.
+ * They are literal ASCII  backslash 0x5c characters.
+ *
+ * NOTE: The FNV-1a initial basis is the same value as FNV-1 by definition.
+ */
+#define FNV1_32A_INIT 0x811c9dc5
+
+/*
+ * 32 bit magic FNV-1a prime
+ */
+#define FNV_32_PRIME 0x01000193
+
+#ifdef ST_USE_FNV1
+static st_index_t
+strhash(st_data_t arg)
+{
+    register const char *string = (const char *)arg;
+    register st_index_t hval = FNV1_32A_INIT;
+
+    /*
+     * FNV-1a hash each octet in the buffer
+     */
+    while (*string) {
+	/* xor the bottom with the current octet */
+	hval ^= (unsigned int)*string++;
+
+	/* multiply by the 32 bit FNV magic prime mod 2^32 */
+	hval *= FNV_32_PRIME;
+    }
+    return hval;
+}
+#else
+
+#ifndef UNALIGNED_WORD_ACCESS
+# if defined(__i386) || defined(__i386__) || defined(_M_IX86) || \
+     defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || \
+     defined(__powerpc64__) || \
+     defined(__mc68020__)
+#   define UNALIGNED_WORD_ACCESS 1
+# endif
+#endif
+#ifndef UNALIGNED_WORD_ACCESS
+# define UNALIGNED_WORD_ACCESS 0
+#endif
+
+/* MurmurHash described in http://murmurhash.googlepages.com/ */
+#ifndef MURMUR
+#define MURMUR 2
+#endif
+
+#define MurmurMagic_1 (st_index_t)0xc6a4a793
+#define MurmurMagic_2 (st_index_t)0x5bd1e995
+#if MURMUR == 1
+#define MurmurMagic MurmurMagic_1
+#elif MURMUR == 2
+#if SIZEOF_ST_INDEX_T > 4
+#define MurmurMagic ((MurmurMagic_1 << 32) | MurmurMagic_2)
+#else
+#define MurmurMagic MurmurMagic_2
+#endif
+#endif
+
+static inline st_index_t
+murmur(st_index_t h, st_index_t k, int r)
+{
+    const st_index_t m = MurmurMagic;
+#if MURMUR == 1
+    h += k;
+    h *= m;
+    h ^= h >> r;
+#elif MURMUR == 2
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+
+    h *= m;
+    h ^= k;
+#endif
+    return h;
+}
+
+static inline st_index_t
+murmur_finish(st_index_t h)
+{
+#if MURMUR == 1
+    h = murmur(h, 0, 10);
+    h = murmur(h, 0, 17);
+#elif MURMUR == 2
+    h ^= h >> 13;
+    h *= MurmurMagic;
+    h ^= h >> 15;
+#endif
+    return h;
+}
+
+#define murmur_step(h, k) murmur((h), (k), 16)
+
+#if MURMUR == 1
+#define murmur1(h) murmur_step((h), 16)
+#else
+#define murmur1(h) murmur_step((h), 24)
+#endif
+
+st_index_t
+st_hash(const void *ptr, size_t len, st_index_t h)
+{
+    const char *data = ptr;
+    st_index_t t = 0;
+
+    h += 0xdeadbeef;
+
+#define data_at(n) (st_index_t)((unsigned char)data[(n)])
+#define UNALIGNED_ADD_4 UNALIGNED_ADD(2); UNALIGNED_ADD(1); UNALIGNED_ADD(0)
+#if SIZEOF_ST_INDEX_T > 4
+#define UNALIGNED_ADD_8 UNALIGNED_ADD(6); UNALIGNED_ADD(5); UNALIGNED_ADD(4); UNALIGNED_ADD(3); UNALIGNED_ADD_4
+#if SIZEOF_ST_INDEX_T > 8
+#define UNALIGNED_ADD_16 UNALIGNED_ADD(14); UNALIGNED_ADD(13); UNALIGNED_ADD(12); UNALIGNED_ADD(11); \
+    UNALIGNED_ADD(10); UNALIGNED_ADD(9); UNALIGNED_ADD(8); UNALIGNED_ADD(7); UNALIGNED_ADD_8
+#define UNALIGNED_ADD_ALL UNALIGNED_ADD_16
+#endif
+#define UNALIGNED_ADD_ALL UNALIGNED_ADD_8
+#else
+#define UNALIGNED_ADD_ALL UNALIGNED_ADD_4
+#endif
+    if (len >= sizeof(st_index_t)) {
+#if !UNALIGNED_WORD_ACCESS
+	int align = (int)((st_data_t)data % sizeof(st_index_t));
+	if (align) {
+	    st_index_t d = 0;
+	    int sl, sr, pack;
+
+	    switch (align) {
+#ifdef WORDS_BIGENDIAN
+# define UNALIGNED_ADD(n) case SIZEOF_ST_INDEX_T - (n) - 1: \
+		t |= data_at(n) << CHAR_BIT*(SIZEOF_ST_INDEX_T - (n) - 2)
+#else
+# define UNALIGNED_ADD(n) case SIZEOF_ST_INDEX_T - (n) - 1:	\
+		t |= data_at(n) << CHAR_BIT*(n)
+#endif
+		UNALIGNED_ADD_ALL;
+#undef UNALIGNED_ADD
+	    }
+
+#ifdef WORDS_BIGENDIAN
+	    t >>= (CHAR_BIT * align) - CHAR_BIT;
+#else
+	    t <<= (CHAR_BIT * align);
+#endif
+
+	    data += sizeof(st_index_t)-align;
+	    len -= sizeof(st_index_t)-align;
+
+	    sl = CHAR_BIT * (SIZEOF_ST_INDEX_T-align);
+	    sr = CHAR_BIT * align;
+
+	    while (len >= sizeof(st_index_t)) {
+		d = *(st_index_t *)data;
+#ifdef WORDS_BIGENDIAN
+		t = (t << sr) | (d >> sl);
+#else
+		t = (t >> sr) | (d << sl);
+#endif
+		h = murmur_step(h, t);
+		t = d;
+		data += sizeof(st_index_t);
+		len -= sizeof(st_index_t);
+	    }
+
+	    pack = len < (size_t)align ? (int)len : align;
+	    d = 0;
+	    switch (pack) {
+#ifdef WORDS_BIGENDIAN
+# define UNALIGNED_ADD(n) case (n) + 1: \
+		d |= data_at(n) << CHAR_BIT*(SIZEOF_ST_INDEX_T - (n) - 1)
+#else
+# define UNALIGNED_ADD(n) case (n) + 1: \
+		d |= data_at(n) << CHAR_BIT*(n)
+#endif
+		UNALIGNED_ADD_ALL;
+#undef UNALIGNED_ADD
+	    }
+#ifdef WORDS_BIGENDIAN
+	    t = (t << sr) | (d >> sl);
+#else
+	    t = (t >> sr) | (d << sl);
+#endif
+
+#if MURMUR == 2
+	    if (len < (size_t)align) goto skip_tail;
+#endif
+	    h = murmur_step(h, t);
+	    data += pack;
+	    len -= pack;
+	}
+	else
+#endif
+	{
+	    do {
+		h = murmur_step(h, *(st_index_t *)data);
+		data += sizeof(st_index_t);
+		len -= sizeof(st_index_t);
+	    } while (len >= sizeof(st_index_t));
+	}
+    }
+
+    t = 0;
+    switch (len) {
+#ifdef WORDS_BIGENDIAN
+# define UNALIGNED_ADD(n) case (n) + 1: \
+	t |= data_at(n) << CHAR_BIT*(SIZEOF_ST_INDEX_T - (n) - 1)
+#else
+# define UNALIGNED_ADD(n) case (n) + 1: \
+	t |= data_at(n) << CHAR_BIT*(n)
+#endif
+	UNALIGNED_ADD_ALL;
+#undef UNALIGNED_ADD
+#if MURMUR == 1
+	h = murmur_step(h, t);
+#elif MURMUR == 2
+# if !UNALIGNED_WORD_ACCESS
+      skip_tail:
+# endif
+	h ^= t;
+	h *= MurmurMagic;
+#endif
+    }
+
+    return murmur_finish(h);
+}
+
+st_index_t
+st_hash_uint32(st_index_t h, uint32_t i)
+{
+    return murmur_step(h + i, 16);
+}
+
+st_index_t
+st_hash_uint(st_index_t h, st_index_t i)
+{
+    st_index_t v = 0;
+    h += i;
+#ifdef WORDS_BIGENDIAN
+#if SIZEOF_ST_INDEX_T*CHAR_BIT > 12*8
+    v = murmur1(v + (h >> 12*8));
+#endif
+#if SIZEOF_ST_INDEX_T*CHAR_BIT > 8*8
+    v = murmur1(v + (h >> 8*8));
+#endif
+#if SIZEOF_ST_INDEX_T*CHAR_BIT > 4*8
+    v = murmur1(v + (h >> 4*8));
+#endif
+#endif
+    v = murmur1(v + h);
+#ifndef WORDS_BIGENDIAN
+#if SIZEOF_ST_INDEX_T*CHAR_BIT > 4*8
+    v = murmur1(v + (h >> 4*8));
+#endif
+#if SIZEOF_ST_INDEX_T*CHAR_BIT > 8*8
+    v = murmur1(v + (h >> 8*8));
+#endif
+#if SIZEOF_ST_INDEX_T*CHAR_BIT > 12*8
+    v = murmur1(v + (h >> 12*8));
+#endif
+#endif
+    return v;
+}
+
+st_index_t
+st_hash_end(st_index_t h)
+{
+    h = murmur_step(h, 10);
+    h = murmur_step(h, 17);
+    return h;
+}
+
+#undef st_hash_start
+st_index_t
+st_hash_start(st_index_t h)
+{
+    return h;
+}
+
+static st_index_t
+strhash(st_data_t arg)
+{
+    register const char *string = (const char *)arg;
+    return st_hash(string, strlen(string), FNV1_32A_INIT);
+}
+#endif
+
+int
+st_locale_insensitive_strcasecmp(const char *s1, const char *s2)
+{
+    unsigned int c1, c2;
+
+    while (1) {
+        c1 = (unsigned char)*s1++;
+        c2 = (unsigned char)*s2++;
+        if (c1 == '\0' || c2 == '\0') {
+            if (c1 != '\0') return 1;
+            if (c2 != '\0') return -1;
+            return 0;
+        }
+        if ((unsigned int)(c1 - 'A') <= ('Z' - 'A')) c1 += 'a' - 'A';
+        if ((unsigned int)(c2 - 'A') <= ('Z' - 'A')) c2 += 'a' - 'A';
+        if (c1 != c2) {
+            if (c1 > c2)
+                return 1;
+            else
+                return -1;
+        }
+    }
+}
+
+int
+st_locale_insensitive_strncasecmp(const char *s1, const char *s2, size_t n)
+{
+    unsigned int c1, c2;
+
+    while (n--) {
+        c1 = (unsigned char)*s1++;
+        c2 = (unsigned char)*s2++;
+        if (c1 == '\0' || c2 == '\0') {
+            if (c1 != '\0') return 1;
+            if (c2 != '\0') return -1;
+            return 0;
+        }
+        if ((unsigned int)(c1 - 'A') <= ('Z' - 'A')) c1 += 'a' - 'A';
+        if ((unsigned int)(c2 - 'A') <= ('Z' - 'A')) c2 += 'a' - 'A';
+        if (c1 != c2) {
+            if (c1 > c2)
+                return 1;
+            else
+                return -1;
+        }
+    }
+    return 0;
+}
+
+static st_index_t
+strcasehash(st_data_t arg)
+{
+    register const char *string = (const char *)arg;
+    register st_index_t hval = FNV1_32A_INIT;
+
+    /*
+     * FNV-1a hash each octet in the buffer
+     */
+    while (*string) {
+	unsigned int c = (unsigned char)*string++;
+	if ((unsigned int)(c - 'A') <= ('Z' - 'A')) c += 'a' - 'A';
+	hval ^= c;
+
+	/* multiply by the 32 bit FNV magic prime mod 2^32 */
+	hval *= FNV_32_PRIME;
+    }
+    return hval;
+}
+
+int
+st_numcmp(st_data_t x, st_data_t y)
+{
+    return x != y;
+}
+
+st_index_t
+st_numhash(st_data_t n)
+{
+    enum {s1 = 11, s2 = 3};
+    return (st_index_t)((n>>s1|(n<<s2)) ^ (n>>s2));
+}

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -60,6 +60,7 @@ module RbConfig
       'DLDFLAGS'          => '',
       'DLEXT'             => 'su',
       'NATIVE_DLEXT'      => RUBY_PLATFORM.include?('darwin') ? 'dylib' : 'so',
+      'host_alias'        => '',
       'host_os'           => host_os,
       'host_cpu'          => host_cpu,
       'LIBEXT'            => 'c',


### PR DESCRIPTION
This is used in `nokogiri` and others.

`Nokogiri` should build after adding this with ` -- --use-system-libraries` arg or `NOKOGIRI_USE_SYSTEM_LIBRARIES=1` and the issue with ` “expression is not an integer constant expression” ` is resolved.