### PR TITLE
Move automatic OPENSSL_PREFIX into extconfs

### DIFF
--- a/src/main/c/openssl/extconf.rb
+++ b/src/main/c/openssl/extconf.rb
@@ -28,6 +28,12 @@ have_flags = %w[
 
 $CFLAGS += " #{have_flags.map { |h| "-DHAVE_#{h}" }.join(' ')}"
 
+MAC = `uname`.chomp == 'Darwin'
+
+if MAC && !ENV['OPENSSL_PREFIX']
+  ENV['OPENSSL_PREFIX'] = '/usr/local/opt/openssl'
+end
+
 if ENV['OPENSSL_PREFIX']
   $CFLAGS += " -I #{ENV['OPENSSL_PREFIX']}/include"
 end

--- a/test/truffle/cexts/xopenssl/ext/xopenssl/extconf.rb
+++ b/test/truffle/cexts/xopenssl/ext/xopenssl/extconf.rb
@@ -1,5 +1,11 @@
 require 'mkmf'
 
+MAC = `uname`.chomp == 'Darwin'
+
+if MAC && !ENV['OPENSSL_PREFIX']
+  ENV['OPENSSL_PREFIX'] = '/usr/local/opt/openssl'
+end
+
 if ENV['OPENSSL_PREFIX']
   $CFLAGS += " -I #{ENV['OPENSSL_PREFIX']}/include"
   $LIBS += " -l #{ENV['OPENSSL_PREFIX']}/lib/libssl.#{RbConfig::CONFIG['NATIVE_DLEXT']}"


### PR DESCRIPTION
Because we don't always compile via `jt` now. This functionality used to be there but was lost when we move C extension compilation into `Makefiles`.