### PR TITLE
Remove the dependency on Pathname in patching

### DIFF
--- a/src/main/java/org/truffleruby/Log.java
+++ b/src/main/java/org/truffleruby/Log.java
@@ -33,7 +33,7 @@ public class Log extends RubyLogger {
         }
     }
 
-    private static final Set<String> displayedWarnings = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final Set<String> DISPLAYED_WARNINGS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public static final String KWARGS_NOT_OPTIMIZED_YET = "keyword arguments are not yet optimized";
 
@@ -43,7 +43,7 @@ public class Log extends RubyLogger {
      */
     @TruffleBoundary
     public static void performanceOnce(String message) {
-        if (displayedWarnings.add(message)) {
+        if (DISPLAYED_WARNINGS.add(message)) {
             LOGGER.log(PERFORMANCE, message);
         }
     }

--- a/src/main/ruby/post-boot/post-boot.rb
+++ b/src/main/ruby/post-boot/post-boot.rb
@@ -15,7 +15,7 @@ begin
   require 'unicode_normalize'
   if Truffle::Boot.get_option 'patching'
     require 'truffle/patching'
-    Truffle::Patching.insert_patching_dir 'stdlib', File.join(Truffle::Boot.ruby_home, 'lib/mri')
+    Truffle::Patching.insert_patching_dir 'stdlib', "#{Truffle::Boot.ruby_home}/lib/mri"
   end
 rescue LoadError => e
   Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"


### PR DESCRIPTION
* Pathname is very inefficient and uses loops even for trivial #join.
* Avoid globbing when Dir.foreach is enough.
* Saves around 50ms of startup time.