### PR TITLE
Lazily load RubyGems

### DIFF
--- a/lib/mri/rubygems/requirement.rb
+++ b/lib/mri/rubygems/requirement.rb
@@ -4,7 +4,15 @@ require "rubygems/deprecate"
 
 # If we're being loaded after yaml was already required, then
 # load our yaml + workarounds now.
-Gem.load_yaml if defined? ::YAML
+if defined? ::YAML
+  # Truffle: this is conditional because at this point #gem cannot be defined (it is
+  # defined after loading rubygems/core_ext/kernel_gem which comes after this file).
+  # In the case of lazy RubyGems, #gem exists but is a stub while loading RubyGems,
+  # which would cause a stack overflow. Removing #gem is not OK for concurrency.
+  unless defined?(gem) && Truffle::Boot.get_option('rubygems.lazy')
+    Gem.load_yaml
+  end
+end
 
 ##
 # A Requirement is a set of one or more version restrictions. It supports a

--- a/lib/patches/stdlib/rubygems.rb
+++ b/lib/patches/stdlib/rubygems.rb
@@ -1,3 +1,13 @@
 require 'openssl-stubs' if Truffle::Boot.patching_openssl_enabled?
+
 Truffle::Patching.require_original __FILE__
 Truffle::Patching.install_gem_activation_hook if Truffle::Boot.get_option 'patching'
+
+# Because did_you_mean was required directly without RubyGems
+if Truffle::Boot.get_option 'did_you_mean'
+  begin
+    gem 'did_you_mean'
+  rescue LoadError => e
+    Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"
+  end
+end

--- a/lib/patches/stdlib/rubygems/defaults/operating_system.rb
+++ b/lib/patches/stdlib/rubygems/defaults/operating_system.rb
@@ -1,0 +1,1 @@
+# Empty file to avoid raising a LoadError while loading RubyGems

--- a/lib/patches/stdlib/rubygems/defaults/operating_system.rb
+++ b/lib/patches/stdlib/rubygems/defaults/operating_system.rb
@@ -1,1 +1,2 @@
 # Empty file to avoid raising a LoadError while loading RubyGems
+# Lazy RubyGems also relies on this

--- a/lib/patches/stdlib/rubygems/defaults/truffleruby.rb
+++ b/lib/patches/stdlib/rubygems/defaults/truffleruby.rb
@@ -1,0 +1,1 @@
+# Empty file to avoid raising a LoadError while loading RubyGems

--- a/lib/patches/stdlib/rubygems/defaults/truffleruby.rb
+++ b/lib/patches/stdlib/rubygems/defaults/truffleruby.rb
@@ -1,1 +1,2 @@
 # Empty file to avoid raising a LoadError while loading RubyGems
+# Lazy RubyGems also relies on this

--- a/lib/truffle/truffle/lazy-rubygems.rb
+++ b/lib/truffle/truffle/lazy-rubygems.rb
@@ -1,0 +1,28 @@
+module Kernel
+  # Take this alias name so RubyGems will reuse this copy
+  # and skip the method below once RubyGems is loaded.
+  alias :gem_original_require :require
+
+  $truffle_loading_rubygems = false
+
+  private def require(path)
+    return gem_original_require(path) if $truffle_loading_rubygems
+
+    begin
+      gem_original_require(path)
+    rescue LoadError
+      $truffle_loading_rubygems = true
+      require 'rubygems'
+      require path
+    end
+  end
+
+  private def gem(*args)
+    require 'rubygems'
+    gem(*args)
+  end
+end
+
+class Object
+  autoload :Gem, 'rubygems'
+end

--- a/lib/truffle/truffle/lazy-rubygems.rb
+++ b/lib/truffle/truffle/lazy-rubygems.rb
@@ -3,15 +3,10 @@ module Kernel
   # and skip the method below once RubyGems is loaded.
   alias :gem_original_require :require
 
-  $truffle_loading_rubygems = false
-
   private def require(path)
-    return gem_original_require(path) if $truffle_loading_rubygems
-
     begin
       gem_original_require(path)
     rescue LoadError
-      $truffle_loading_rubygems = true
       require 'rubygems'
       require path
     end

--- a/lib/truffle/truffle/patching.rb
+++ b/lib/truffle/truffle/patching.rb
@@ -48,7 +48,7 @@ module Truffle::Patching
       break path if File.file?(path)
     end
 
-    require original
+    Kernel.require original
   end
 
   def install_gem_activation_hook

--- a/src/launcher/java/org/truffleruby/launcher/options/Options.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/Options.java
@@ -36,6 +36,7 @@ public class Options {
     public final String[] ARGV_GLOBAL_FLAGS;
     public final boolean FROZEN_STRING_LITERALS;
     public final boolean RUBYGEMS;
+    public final boolean LAZY_RUBYGEMS;
     public final boolean PATCHING;
     public final boolean PATCHING_OPENSSL;
     public final boolean DID_YOU_MEAN;
@@ -145,6 +146,7 @@ public class Options {
         ARGV_GLOBAL_FLAGS = builder.getOrDefault(OptionsCatalog.ARGV_GLOBAL_FLAGS);
         FROZEN_STRING_LITERALS = builder.getOrDefault(OptionsCatalog.FROZEN_STRING_LITERALS);
         RUBYGEMS = builder.getOrDefault(OptionsCatalog.RUBYGEMS);
+        LAZY_RUBYGEMS = builder.getOrDefault(OptionsCatalog.LAZY_RUBYGEMS);
         PATCHING = builder.getOrDefault(OptionsCatalog.PATCHING);
         PATCHING_OPENSSL = builder.getOrDefault(OptionsCatalog.PATCHING_OPENSSL);
         DID_YOU_MEAN = builder.getOrDefault(OptionsCatalog.DID_YOU_MEAN);
@@ -276,6 +278,8 @@ public class Options {
                 return FROZEN_STRING_LITERALS;
             case "ruby.rubygems":
                 return RUBYGEMS;
+            case "ruby.rubygems.lazy":
+                return LAZY_RUBYGEMS;
             case "ruby.patching":
                 return PATCHING;
             case "ruby.patching_openssl":

--- a/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
@@ -96,6 +96,10 @@ public class OptionsCatalog {
             "ruby.rubygems",
             "Use RubyGems",
             true);
+    public static final BooleanOptionDescription LAZY_RUBYGEMS = new BooleanOptionDescription(
+            "ruby.rubygems.lazy",
+            "Load RubyGems lazily on first failing require",
+            true);
     public static final BooleanOptionDescription PATCHING = new BooleanOptionDescription(
             "ruby.patching",
             "Use patching",
@@ -487,6 +491,8 @@ public class OptionsCatalog {
                 return FROZEN_STRING_LITERALS;
             case "ruby.rubygems":
                 return RUBYGEMS;
+            case "ruby.rubygems.lazy":
+                return LAZY_RUBYGEMS;
             case "ruby.patching":
                 return PATCHING;
             case "ruby.patching_openssl":
@@ -688,6 +694,7 @@ public class OptionsCatalog {
             ARGV_GLOBAL_FLAGS,
             FROZEN_STRING_LITERALS,
             RUBYGEMS,
+            LAZY_RUBYGEMS,
             PATCHING,
             PATCHING_OPENSSL,
             DID_YOU_MEAN,

--- a/src/main/ruby/post-boot/post-boot.rb
+++ b/src/main/ruby/post-boot/post-boot.rb
@@ -27,7 +27,11 @@ if Truffle::Boot.get_option 'rubygems'
   begin
     Truffle::Boot.print_time_metric :'before-rubygems'
     begin
-      require 'rubygems'
+      if Truffle::Boot.get_option 'rubygems.lazy'
+        require 'truffle/lazy-rubygems'
+      else
+        require 'rubygems'
+      end
     ensure
       Truffle::Boot.print_time_metric :'after-rubygems'
     end
@@ -35,21 +39,22 @@ if Truffle::Boot.get_option 'rubygems'
     Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"
   else
     # TODO (pitr-ch 17-Feb-2017): remove the warning when we can integrate with ruby managers
-    unless Gem.dir.include?(Truffle::Boot.ruby_home)
+    gem_dir = ENV['GEM_HOME'] || "#{Truffle::Boot.ruby_home}/lib/ruby/gems/2.3.0"
+    unless gem_dir.include?(Truffle::Boot.ruby_home)
       bad_gem_home = false
 
       # rbenv does not set GEM_HOME
       # rbenv-gemset has to be installed which does set GEM_HOME, it's in the subdir of Truffle::Boot.ruby_home
       # rbenv/versions/<ruby>/gemsets
-      bad_gem_home ||= Gem.dir.include?('rbenv/versions') && !Gem.dir.include?('rbenv/versions/truffleruby')
+      bad_gem_home ||= gem_dir.include?('rbenv/versions') && !gem_dir.include?('rbenv/versions/truffleruby')
 
       # rvm stores gems at .rvm/gems/<ruby>@<gemset-name>
-      bad_gem_home ||= Gem.dir.include?('rvm/gems') && !Gem.dir.include?('rvm/gems/truffleruby')
+      bad_gem_home ||= gem_dir.include?('rvm/gems') && !gem_dir.include?('rvm/gems/truffleruby')
 
       # chruby stores gem in ~/.gem/<ruby>/<version>
-      bad_gem_home ||= Gem.dir.include?('.gem') && !Gem.dir.include?('.gems/truffleruby')
+      bad_gem_home ||= gem_dir.include?('.gem') && !gem_dir.include?('.gems/truffleruby')
 
-      warn "[ruby] WARN A nonstandard GEM_HOME is set #{Gem.dir}" if $VERBOSE || bad_gem_home
+      warn "[ruby] WARN A nonstandard GEM_HOME is set #{gem_dir}" if $VERBOSE || bad_gem_home
       if bad_gem_home
         warn "[ruby] WARN The bad GEM_HOME may come from a ruby manager, make sure you've called one of: " +
                  '`rvm use system`, `rbenv system`, or `chruby system` to clear the environment.'
@@ -60,7 +65,7 @@ if Truffle::Boot.get_option 'rubygems'
 
     if Truffle::Boot.get_option 'did_you_mean'
       begin
-        gem 'did_you_mean'
+        $LOAD_PATH << "#{Truffle::Boot.ruby_home}/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib"
         require 'did_you_mean'
       rescue LoadError => e
         Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -20,6 +20,7 @@ ARGV_GLOBAL_FLAGS: [argv_global_flags, string-array, [], Parsed options from scr
 
 FROZEN_STRING_LITERALS: [frozen_string_literals, boolean, false, Use frozen string literals]
 RUBYGEMS: [rubygems, boolean, true, Use RubyGems]
+LAZY_RUBYGEMS: [rubygems.lazy, boolean, true, Load RubyGems lazily on first failing require]
 PATCHING: [patching, boolean, true, Use patching]
 PATCHING_OPENSSL: [patching_openssl, boolean, false, Use openssl patching]
 DID_YOU_MEAN: [did_you_mean, boolean, true, Use did_you_mean]


### PR DESCRIPTION
* Load it on failing #require, on access to the Gem constant,  and on Kernel#gem.
* require "rubygems" loads a lot like the 3000-lines specification.rb  and does a lot of initialization.
* Determine Gem.dir without needing RubyGems.
* Load did_you_mean by just adding its lib/ dir on `$LOAD_PATH`.
* Gains around 300-600ms of startup depending on disk and CPU.