### PR TITLE
Add a custom wrapper node for instrumentation of RescueNodes.

### DIFF
--- a/src/main/java/org/truffleruby/language/exceptions/RescueNode.java
+++ b/src/main/java/org/truffleruby/language/exceptions/RescueNode.java
@@ -11,6 +11,7 @@ package org.truffleruby.language.exceptions;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.Instrumentable;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import org.truffleruby.core.cast.BooleanCastNode;
@@ -20,6 +21,7 @@ import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
 
+@Instrumentable(factory = RescueNodeWrapper.class)
 public abstract class RescueNode extends RubyNode {
 
     @Child private RubyNode rescueBody;

--- a/src/main/java/org/truffleruby/language/exceptions/RescueNodeWrapper.java
+++ b/src/main/java/org/truffleruby/language/exceptions/RescueNodeWrapper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+
+package org.truffleruby.language.exceptions;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.InstrumentableFactory;
+import com.oracle.truffle.api.instrumentation.ProbeNode;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.NodeCost;
+import com.oracle.truffle.api.object.DynamicObject;
+
+public class RescueNodeWrapper implements InstrumentableFactory<RescueNode> {
+
+    @Override
+    public WrapperNode createWrapper(RescueNode delegateNode, ProbeNode probeNode) {
+        return new RescueNodeWrapper0(delegateNode, probeNode);
+    }
+
+    private static final class RescueNodeWrapper0 extends RescueNode implements WrapperNode {
+
+        @Child private RescueNode delegateNode;
+        @Child private ProbeNode probeNode;
+
+        private RescueNodeWrapper0(RescueNode delegateNode, ProbeNode probeNode) {
+            super(null);
+            this.delegateNode = delegateNode;
+            this.probeNode = probeNode;
+        }
+
+        @Override
+        public Node getDelegateNode() {
+            return delegateNode;
+        }
+
+        @Override
+        public ProbeNode getProbeNode() {
+            return probeNode;
+        }
+
+        @Override
+        public NodeCost getCost() {
+            return NodeCost.NONE;
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            try {
+                probeNode.onEnter(frame);
+                Object returnValue = delegateNode.execute(frame);
+                probeNode.onReturnValue(frame, returnValue);
+                return returnValue;
+            } catch (Throwable t) {
+                probeNode.onReturnExceptional(frame, t);
+                throw t;
+            }
+        }
+
+        @Override
+        public void executeVoid(VirtualFrame frame) {
+            try {
+                probeNode.onEnter(frame);
+                delegateNode.executeVoid(frame);
+                probeNode.onReturnValue(frame, null);
+            } catch (Throwable t) {
+                probeNode.onReturnExceptional(frame, t);
+                throw t;
+            }
+        }
+
+        @Override
+        public boolean canHandle(VirtualFrame frame, DynamicObject exception) {
+            return delegateNode.canHandle(frame, exception);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This fixes a problem whereby we couldn't instrument `TryNode` because the `rescueParts` field is typed as `RescueNode` instead of `RubyNode`. I'm not thrilled at providing our own wrapper class instead of a generated one, but it seemed the cleanest solution. At the core of the problem is `RescueNode#canHandle`, which isn't really a Truffle call so the generated wrapper won't generate a delegated method for it. I could push the `@Instrumentable` annotation onto each of the `RescueNode` subclasses, so they inherit their concrete `canHandle` implementation, but then the wrapper would be using state from outside the delegate and we'd have to clone nodes.

I'm open to other options, but this seems to be the least disruptive.