### PR TITLE
Patch C ext for "not an integer constant" error

### DIFF
--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -399,6 +399,11 @@ VALUE rb_tr_get_default_rs(void);
 
 // END from tool/generate-cext-constants.rb
 
+#define Qfalse_int_const 0
+#define Qtrue_int_const 2
+#define Qnil_int_const 4
+int rb_tr_to_int_const(VALUE value);
+
 #define rb_defout rb_stdout
 
 // Conversions

--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -27,6 +27,8 @@ extern "C" {
 
 #include <ctype.h>
 #include <limits.h>
+// Included by ruby/io.h in MRI
+#include <errno.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -1862,6 +1862,18 @@ void rb_bug(const char *fmt, ...) {
   rb_tr_error("rb_bug not yet implemented");
 }
 
+int rb_tr_to_int_const(VALUE value) {
+  if (value == Qfalse) {
+    return Qfalse_int_const;
+  } else if (value == Qtrue) {
+    return Qtrue_int_const;
+  } else if (value == Qnil) {
+    return Qnil_int_const;
+  } else {
+    return 8;
+  }
+}
+
 VALUE rb_enumeratorize(VALUE obj, VALUE meth, int argc, const VALUE *argv) {
   return (VALUE) truffle_invoke(RUBY_CEXT, "rb_enumeratorize", obj, meth, rb_ary_new4(argc, argv));
 }

--- a/test/truffle/cexts/test-preprocess.rb
+++ b/test/truffle/cexts/test-preprocess.rb
@@ -13,6 +13,11 @@ def test(input, expected=input)
   raise "expected #{expected.inspect}, got #{got.inspect}" unless got == expected
 end
 
+def test_patch(file, input, expected)
+  got = patch(file, input)
+  raise "expected #{expected.inspect}, got #{got.inspect}" unless got == expected
+end
+
 test '  VALUE args[6], failed, a1, a2, a3, a4, a5, a6;',        '  VALUE failed, a1, a2, a3, a4, a5, a6; VALUE *args = truffle_managed_malloc(6 * sizeof(VALUE));'
 test '  VALUE args, failed, a1, a2, a3, a4, a5, a6;'
 test '  VALUE a,b[2],c;',                                       '  VALUE a, c; VALUE *b = truffle_managed_malloc(2 * sizeof(VALUE));'
@@ -20,3 +25,18 @@ test '  VALUEx, b, c;'
 test '  VALUE *argv = alloca(sizeof(VALUE) * argc);',           '  VALUE *argv = truffle_managed_malloc(sizeof(VALUE) * argc);'
 test '  VALUE *arg_v = (VALUE*) alloca(sizeof(VALUE) * argc);', '  VALUE *arg_v = truffle_managed_malloc(sizeof(VALUE) * argc);'
 test '  long *argv = alloca(sizeof(long) * argc);'
+
+SWITCH_ONE_ACTUAL = <<-EOF
+  switch (rb_range_beg_len(arg, &beg, &len, (long)node_set->nodeNr, 0)) {
+  case Qfalse:
+    break;
+  case Qnil:
+EOF
+
+SWITCH_ONE_EXPECTED = <<-EOF
+  switch (rb_tr_to_int_const(rb_range_beg_len(arg, &beg, &len, (long)node_set->nodeNr, 0))) {
+  case Qfalse_int_const:
+    break;
+  case Qnil_int_const:
+EOF
+test_patch 'xml_node_set.c', SWITCH_ONE_ACTUAL, SWITCH_ONE_EXPECTED

--- a/test/truffle/cexts/test-preprocess.rb
+++ b/test/truffle/cexts/test-preprocess.rb
@@ -13,8 +13,8 @@ def test(input, expected=input)
   raise "expected #{expected.inspect}, got #{got.inspect}" unless got == expected
 end
 
-def test_patch(file, input, expected)
-  got = patch(file, input)
+def test_patch(file, directory, input, expected)
+  got = patch(file, input, directory)
   raise "expected #{expected.inspect}, got #{got.inspect}" unless got == expected
 end
 
@@ -39,4 +39,4 @@ SWITCH_ONE_EXPECTED = <<-EOF
     break;
   case Qnil_int_const:
 EOF
-test_patch 'xml_node_set.c', SWITCH_ONE_ACTUAL, SWITCH_ONE_EXPECTED
+test_patch 'xml_node_set.c', 'ext/nokogiri', SWITCH_ONE_ACTUAL, SWITCH_ONE_EXPECTED


### PR DESCRIPTION
`Nokogiri` compiles after this change:
`NOKOGIRI_USE_SYSTEM_LIBRARIES=1 TRUFFLERUBY_CEXT_ENABLED=true ./bin/ruby -S gem install nokogiri -V -N --backtrace
`