### PR TITLE
Make Ruby strings unbox to Java strings

### DIFF
--- a/doc/user/interop.md
+++ b/doc/user/interop.md
@@ -41,14 +41,14 @@ Call `size` on the object.
 
 ### `IS_BOXED`
 
-Returns true only for instances of `String` with a length of 1, which allows
-them to be unboxed as a character, or objects that respond to `unbox`.
+Returns true only for instances of `String`, `Rubinius::FFI::Pointer` and
+objects that respond to `unbox`.
 
 ### `UNBOX`
 
-For a `String`, returns the first character. Unboxing empty strings is not
-supported and will cause an `UnsupportedMessageException`. For all other objects
-calls `unbox`.
+For a `String`, produces a `java.lang.String`, similar to
+`Truffle::Interop.to_java_string`. For a `Rubinius::FFI::Pointer`, produces the
+address as a `long`. For all other objects calls `unbox`.
 
 ### `IS_POINTER`
 

--- a/spec/truffle/interop/boxed_spec.rb
+++ b/spec/truffle/interop/boxed_spec.rb
@@ -10,16 +10,23 @@ require_relative '../../ruby/spec_helper'
 
 describe "Truffle::Interop.boxed?" do
   
-  it "returns false for empty strings" do
-    Truffle::Interop.boxed?('').should be_false
+  it "returns true for strings" do
+    Truffle::Interop.boxed?('tests').should be_true
   end
-    
-  it "returns true for strings with one byte" do
-    Truffle::Interop.boxed?('1').should be_true
+  
+  it "returns true for Rubinius::FFI::Pointer objects" do
+    Truffle::Interop.boxed?(Rubinius::FFI::Pointer.new(0)).should be_true
   end
-    
-  it "returns false for strings with two bytes" do
-    Truffle::Interop.boxed?('12').should be_false
+
+  it "returns true for objects that respond to #unbox" do
+    unboxable = Object.new
+    def unboxable.unbox
+    end
+    Truffle::Interop.boxed?(unboxable).should be_true
+  end
+  
+  it "returns false for other objects" do
+    Truffle::Interop.boxed?(Object.new).should be_false
   end
 
 end

--- a/spec/truffle/interop/unbox_spec.rb
+++ b/spec/truffle/interop/unbox_spec.rb
@@ -33,17 +33,15 @@ describe "Truffle::Interop.unbox" do
   it "passes through false" do
     Truffle::Interop.unbox(false).should == false
   end
-  
-  it "doesn't work on empty strings" do
-    lambda { Truffle::Interop.unbox('') }.should raise_error(ArgumentError)
+    
+  it "unboxes a Ruby string to a Java string" do
+    unboxed = Truffle::Interop.unbox('test')
+    Truffle::Interop.java_string?(unboxed).should be_true
+    Truffle::Interop.from_java_string(unboxed).should == 'test'
   end
     
-  it "returns the first byte on strings with one byte" do
-    Truffle::Interop.unbox('1').should == '1'.ord
-  end
-    
-  it "returns the first byte on strings with two bytes" do
-    Truffle::Interop.unbox('1').should == '1'.ord
+  it "unboxes a pointer to the address" do
+    Truffle::Interop.unbox(Rubinius::FFI::Pointer.new(1024)).should == 1024
   end
     
   it "is not supported for nil" do

--- a/src/main/java/org/truffleruby/interop/RubyMessageResolution.java
+++ b/src/main/java/org/truffleruby/interop/RubyMessageResolution.java
@@ -28,8 +28,6 @@ import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.cast.NameToJavaStringNode;
-import org.truffleruby.core.rope.Rope;
-import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyObjectType;
 import org.truffleruby.language.control.RaiseException;

--- a/src/test/java/org/truffleruby/MiscTest.java
+++ b/src/test/java/org/truffleruby/MiscTest.java
@@ -20,20 +20,21 @@ public class MiscTest {
 
     @Test
     public void testMembersAndStringUnboxing() {
-        Context context = Context.create();
-        Value result = context.eval("ruby", "Truffle::Interop.object_literal(id: 42, text: '42', arr: [1,42,3])");
-        assertTrue(result.hasMembers());
+        try (Context context = Context.create()) {
+            Value result = context.eval("ruby", "Truffle::Interop.object_literal(id: 42, text: '42', arr: [1,42,3])");
+            assertTrue(result.hasMembers());
 
-        int id = result.getMember("id").asInt();
-        assertEquals(42, id);
+            int id = result.getMember("id").asInt();
+            assertEquals(42, id);
 
-        String text = result.getMember("text").asString();
-        assertEquals("42", text);
+            String text = result.getMember("text").asString();
+            assertEquals("42", text);
 
-        Value array = result.getMember("arr");
-        assertTrue(array.hasArrayElements());
-        assertEquals(3, array.getArraySize());
-        assertEquals(42, array.getArrayElement(1).asInt());
+            Value array = result.getMember("arr");
+            assertTrue(array.hasArrayElements());
+            assertEquals(3, array.getArraySize());
+            assertEquals(42, array.getArrayElement(1).asInt());
+        }
     }
 
 }

--- a/src/test/java/org/truffleruby/MiscTest.java
+++ b/src/test/java/org/truffleruby/MiscTest.java
@@ -21,11 +21,7 @@ public class MiscTest {
     @Test
     public void testMembersAndStringUnboxing() {
         Context context = Context.create();
-        Value result = context.eval("ruby", "o = Struct.new(:id, :text, :arr).new(" +
-                "42, "       +
-                "'42', "     +
-                "[1,42,3] " +
-                ")");
+        Value result = context.eval("ruby", "Truffle::Interop.object_literal(id: 42, text: '42', arr: [1,42,3])");
         assertTrue(result.hasMembers());
 
         int id = result.getMember("id").asInt();

--- a/src/test/java/org/truffleruby/MiscTest.java
+++ b/src/test/java/org/truffleruby/MiscTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MiscTest {
+
+    @Test
+    public void testMembersAndStringUnboxing() {
+        Context context = Context.create();
+        Value result = context.eval("ruby", "o = Struct.new(:id, :text, :arr).new(" +
+                "42, "       +
+                "'42', "     +
+                "[1,42,3] " +
+                ")");
+        assertTrue(result.hasMembers());
+
+        int id = result.getMember("id").asInt();
+        assertEquals(42, id);
+
+        String text = result.getMember("text").asString();
+        assertEquals("42", text);
+
+        Value array = result.getMember("arr");
+        assertTrue(array.hasArrayElements());
+        assertEquals(3, array.getArraySize());
+        assertEquals(42, array.getArrayElement(1).asInt());
+    }
+
+}


### PR DESCRIPTION
In the past someone wanted our unbox behaviour to return the first character as a byte. I can't really remember why, but the old TCK still runs, so seems fine to switch.