### PR TITLE
Run mx sforceimports on jt build

### DIFF
--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -487,6 +487,7 @@ module Commands
     when 'options'
       sh 'tool/generate-options.rb'
     when nil
+      mx 'sforceimports'
       mx 'build', '--force-javac', '--warning-as-error'
     else
       raise ArgumentError, project


### PR DESCRIPTION
* So Truffle cannot be a different version.
* Does not require the network if the version already exists locally.
* Use "mx build" directly if building with a different Truffle version is intended.