### PR TITLE
Add back in a removed workaround for ReferenceQueue#remove not working in AOT.

### DIFF
--- a/src/main/java/org/truffleruby/core/FinalizationService.java
+++ b/src/main/java/org/truffleruby/core/FinalizationService.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.core;
 
+import com.oracle.truffle.api.TruffleOptions;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.thread.ThreadManager;
@@ -110,6 +111,11 @@ public class FinalizationService {
         context.send(finalizerThread, "internal_thread_initialize", null);
 
         ThreadManager.initialize(finalizerThread, context, null, "finalizer", () -> {
+            if (TruffleOptions.AOT) {
+                // Temporary workaround for GR-5440.
+                return;
+            }
+
             while (true) {
                 final FinalizerReference finalizerReference = (FinalizerReference) context.getThreadManager().runUntilResult(null,
                         () -> finalizerQueue.remove());


### PR DESCRIPTION
I opted to just restore the functionality we had previously. Explicit GC should also do the trick, but I don't know all the interactions and we're close to a release.