### PR TITLE
Updates versions in Docker and fix locale setup

### DIFF
--- a/test/truffle/docker/ubuntu/Dockerfile
+++ b/test/truffle/docker/ubuntu/Dockerfile
@@ -2,12 +2,15 @@ FROM ubuntu:16.04
 
 MAINTAINER chris.seaton@oracle.com
 
+RUN apt-get update
+
 # We need a conventional locale for testing
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
 # Tools we will need to get and run our tests
-RUN apt-get update
-RUN apt-get install -y git=1:2.7.4-0ubuntu1.1
+RUN apt-get install -y git=1:2.7.4-0ubuntu1.2
 
 # We need a system libssl for openssl
 RUN apt-get install -y libssl-dev=1.0.2g-1ubuntu4.8

--- a/tool/docker/ubuntu/Dockerfile
+++ b/tool/docker/ubuntu/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH=$PATH:/build/mx
 # Build a JDK with JVMCI
 RUN hg clone http://hg.openjdk.java.net/graal/graal-jvmci-8
 RUN cd graal-jvmci-8 && mx build
-ENV JAVA_HOME=/build/graal-jvmci-8/jdk1.8.0_131/product
+ENV JAVA_HOME=/build/graal-jvmci-8/openjdk1.8.0_131/product
 
 # Build the Graal compiler
 RUN git clone https://github.com/graalvm/graal.git

--- a/tool/docker/ubuntu/Dockerfile
+++ b/tool/docker/ubuntu/Dockerfile
@@ -10,10 +10,10 @@ RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
 # To clone source repositories
-RUN apt-get install -y git=1:2.7.4-0ubuntu1.1 mercurial=3.7.3-1ubuntu1
+RUN apt-get install -y git=1:2.7.4-0ubuntu1.2 mercurial=3.7.3-1ubuntu1
 
 # To bootstrap our own JVMCI-comptaible JDK we need a JDK
-RUN apt-get install -y openjdk-8-jdk=8u131-b11-0ubuntu1.16.04.2 openjdk-8-source=8u131-b11-0ubuntu1.16.04.2
+RUN apt-get install -y openjdk-8-jdk=8u131-b11-2ubuntu1.16.04.3 openjdk-8-source=8u131-b11-2ubuntu1.16.04.3
 
 # Other dependencies for building a JDK
 RUN apt-get install -y make=4.1-6 gcc=4:5.3.1-1ubuntu1 g++=4:5.3.1-1ubuntu1

--- a/tool/docker/ubuntu/Dockerfile
+++ b/tool/docker/ubuntu/Dockerfile
@@ -2,10 +2,12 @@ FROM ubuntu:16.04
 
 MAINTAINER chris.seaton@oracle.com
 
-# We need a conventional locale for testing
-ENV LANG=en_US.UTF-8
-
 RUN apt-get update
+
+# We need a conventional locale for testing
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # To clone source repositories
 RUN apt-get install -y git=1:2.7.4-0ubuntu1.1 mercurial=3.7.3-1ubuntu1


### PR DESCRIPTION
The old versions could no longer be installed as they don't exist anymore it seems:
```
E: Version '1:2.7.4-0ubuntu1.1' for 'git' was not found
```

The `en_US.UTF-8` locale needs to be generated, it's not in the image.