### PR TITLE
More user friendly jt test ecosystem

### DIFF
--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -48,7 +48,6 @@ end
 trap(:INT) {}
 
 module Utilities
-
   def self.truffle_version
     File.foreach("#{TRUFFLERUBY_DIR}/truffle/pom.rb") do |line|
       if /'truffle\.version' => '((?:\d+\.\d+|\h+)(?:-SNAPSHOT)?)'/ =~ line
@@ -968,7 +967,14 @@ module Commands
     single_test            = !args.empty?
     test_names             = single_test ? '{' + args.join(',') + '}' : '*'
 
-    success = Dir["#{tests_path}/#{test_names}.sh"].sort.all? do |test_script|
+    candidates = Dir["#{tests_path}/#{test_names}.sh"].sort
+    if candidates.empty?
+      targets = Dir["#{tests_path}/*.sh"].sort.map { |f| File.basename(f, ".*") }
+      puts "No targets found by pattern #{test_names}. Available targets: "
+      targets.each { |t| puts " * #{t}" }
+      exit 1
+    end
+    success = candidates.all? do |test_script|
       sh test_script, continue_on_failure: true
     end
     exit success


### PR DESCRIPTION
I saw @chrisseaton [tweets](https://twitter.com/ChrisGSeaton/status/891664692833378305) about Rails test suite running on Truffle, and I was excited to explore and see what tests I can fix.

I tried to run Rails tests:

```
$ jt test ecosystem rails
truffleruby-gem-test-pack-1
```

As I learned from `jt` sources, `rails` is not a valid test target. I should specify one of the scripts in `test/truffle/ecosystem/` (for instance `rails-app`)

With this PR, running `jt test ecosystem` with unknown target would print a better message that would hopefully help developer to run tests for the right component.

```
$ jt test ecosystem rails
No targets found by pattern {rails}. Available targets:
 * actionpack
 * actionview
 * activemodel
 * activesupport
 * algebrick
 * launchers
 * rails-app
 * railties
```