### PR TITLE
Move Darwin tests to the new Darwin infrastructure

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -61,16 +61,10 @@ common-solaris: ${common-base} {
 }
 
 common-darwin: ${common-base} {
-  packages: {
-    # Homebrew doesn't support versions.
-    llvm: ""
-    openssl: ""
-  }
-
   environment: {
     # Homebrew does not put llvm on the PATH by default
-    PATH: "$PWD/homebrew/opt/llvm/bin:$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH"
-    OPENSSL_PREFIX: "$PWD/homebrew/opt/openssl"
+    PATH: "/usr/local/opt/llvm/bin:$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH"
+    OPENSSL_PREFIX: "/usr/local/opt/openssl"
   }
 }
 
@@ -219,7 +213,7 @@ gate-caps: {
 }
 
 gate-caps-darwin: {
-  capabilities: [darwin, amd64]
+  capabilities: [darwin_next, macmini7_1]
   targets: [gate, post-push]
   environment: {
     REPORT_GITHUB_STATUS: "true"


### PR DESCRIPTION
* No need for packages anymore, openssl and llvm are installed globally.
* Much faster gate times due to not needing to download & build packages.