### PR TITLE
Do not deploy if it was already deployed

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -480,7 +480,7 @@ test-compilation-flags: {
 
 deploy-binaries-with-rewrites: {
   run: [
-    [mx, deploy-binary-if-master, truffleruby-binary-snapshots]
+    [mx, deploy-binary-if-master, "--skip-existing", truffleruby-binary-snapshots]
   ]
 }
 


### PR DESCRIPTION
* Avoids deploying platform-independent distributions multiple times.