### PR TITLE
Fix jt install graal

### DIFF
--- a/doc/contributor/building-graal.md
+++ b/doc/contributor/building-graal.md
@@ -5,22 +5,32 @@ developing TruffleRuby, or possibly to modify Graal or Truffle, or to use
 developer tools that come with Graal such as the Ideal Graph Visualizer, then
 you should install Graal locally.
 
-Our workflow tool can install Graal automatically under the directory `graal`
-with:
+## Installing Graal with jt
+
+Our workflow tool can install Graal automatically under the directory
+`../graal/compiler` with:
 
 ```
 $ jt install graal
 ```
+
+You can then use `jt` to run TruffleRuby with Graal.
+
+```
+$ jt ruby --graal ...
+```
+
+## Building Graal manually
+
+If you want to build Graal by yourself, follow the instructions in the Graal
+repository.
+
+https://github.com/graalvm/graal
 
 You can then set the `GRAAL_HOME` environment variable to the location of the
 `compiler` directory inside the `graal` repository and use `jt` to run
 TruffleRuby.
 
 ```
-$ GRAAL_HOME=$PWD/graal/graal/compiler jt ruby --graal ...
+$ GRAAL_HOME=.../graal/compiler jt ruby --graal ...
 ```
-
-If you want to build Graal by yourself, follow the instructions in the Graal
-repository.
-
-https://github.com/graalvm/graal

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1518,7 +1518,7 @@ module Commands
     dir = File.expand_path("..", TRUFFLERUBY_DIR)
     Dir.chdir(dir) do
       if LINUX
-        jvmci_version = "jvmci-0.32"
+        jvmci_version = "jvmci-0.33"
         jvmci_grep = "#{dir}/openjdk1.8.0*#{jvmci_version}"
         if Dir[jvmci_grep].empty?
           puts "Downloading JDK8 with JVMCI"


### PR DESCRIPTION
* Install graal in ../graal/compiler.
* Reuse the graal repo checkout needed by truffle.
* Update the JVMCI version.
* Simplify instructions as ../graal/compiler is automatically discovered.