### PR TITLE
Fix RubySL::Socket::Foreign.ip_to_bytes in rubysl-socket

### DIFF
--- a/lib/rubysl/rubysl-socket/lib/rubysl/socket/foreign.rb
+++ b/lib/rubysl/rubysl-socket/lib/rubysl/socket/foreign.rb
@@ -321,6 +321,12 @@ module RubySL
       def self.ip_to_bytes(family, address)
         size = 16
 
+        # Truffle: handle ip_address like "fe80::e93d:a67f:89bc:d21%wlp2s0"
+        # which contains the interface name after the %
+        if i = address.rindex('%')
+          address = address[0...i]
+        end
+
         memory_pointer(:pointer, size) do |pointer|
           status = inet_pton(family, address, pointer)
 


### PR DESCRIPTION
* Socket.ip_address_list can return addresses with the
  interface name in it. Verified on MRI with
  $ ruby -rsocket -e 'p Socket.ip_address_list'
* Addrinfo#ipv6_loopback?, #ipv6_linklocal?, etc expect ip_to_bytes
  to work with such addresses.