### PR TITLE
Rename interop #send to #__send__

### DIFF
--- a/doc/user/interop.md
+++ b/doc/user/interop.md
@@ -311,7 +311,7 @@ an integer, or anything else
 `object.inspect` produces a simple string of the format
 `#<Truffle::Interop::Foreign:system-identity-hash-code>`
 
-`object.send(name, *args)` works in the same way as literal method call on the
+`object.__send__(name, *args)` works in the same way as literal method call on the
 foreign object, including allowing the special-forms listed above (see
 [notes on method resolution](#notes-on-method-resolution)).
 

--- a/spec/truffle/interop/send_spec.rb
+++ b/spec/truffle/interop/send_spec.rb
@@ -8,10 +8,10 @@
 
 require_relative '../../ruby/spec_helper'
 
-describe "Interop #send" do
+describe "Interop #__send__" do
 
   it "can call special forms like outgoing #inspect" do
-    Truffle::Debug.foreign_object.send(:inspect).should =~ /#<Truffle::Interop::Foreign@\h+>/
+    Truffle::Debug.foreign_object.__send__(:inspect).should =~ /#<Truffle::Interop::Foreign@\h+>/
   end
 
 end

--- a/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -453,9 +453,8 @@ public abstract class TruffleDebugNodes {
             
         }
 
-        @TruffleBoundary
         @Specialization
-        public Object resolveLazyNodes() {
+        public Object foreignObject() {
             return new ForeignObject();
         }
 

--- a/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
+++ b/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
@@ -129,7 +129,7 @@ public abstract class OutgoingForeignCallNode extends RubyNode {
             return new RespondToOutgoingNode();
         } else if (name.equals("inspect")) {
             return new InspectOutgoingNode();
-        } else if (name.equals("send")) {
+        } else if (name.equals("__send__")) {
             return new SendOutgoingNode();
         } else if (name.equals("nil?") && argsLength == 0) {
             return new IsNilOutgoingNode();

--- a/src/main/ruby/core/type.rb
+++ b/src/main/ruby/core/type.rb
@@ -324,7 +324,7 @@ module Rubinius
     def self.check_funcall_default(recv, meth, args, default)
       if Truffle::Interop.foreign?(recv)
         if recv.respond_to?(meth)
-          return recv.send(meth)
+          return recv.__send__(meth)
         else
           return default
         end


### PR DESCRIPTION
* Avoids conflicts with potential foreign methods named "send".
* Faithful to other usages of #__send__ for conversion in Ruby.