### PR TITLE
Re-enable MRI and JRuby benchmarks.

### DIFF
--- a/ci.hocon
+++ b/ci.hocon
@@ -181,13 +181,39 @@ graal-vm-snapshot: {
   }
 }
 
+jruby-benchmark: {
+  setup: ${common-base.prelude}
+
+  downloads: {
+    JRUBY_HOME: {name: jruby, version: "9.1.12.0"}
+  }
+
+  environment: {
+    HOST_VM: server,
+    HOST_VM_CONFIG: default
+    GUEST_VM: jruby,
+    GUEST_VM_CONFIG: indy,
+    RUBY_BIN: "$JRUBY_HOME/bin/jruby",
+    JT_BENCHMARK_RUBY: "$JRUBY_HOME/bin/jruby",
+    JRUBY_OPTS="-Xcompile.invokedynamic=true"
+  }
+}
+
+
 mri-benchmark: {
+  setup: ${common-base.prelude}
+
+  downloads: {
+    MRI_HOME: {name: ruby, version: "2.3.3"}
+  }
+
   environment: {
     HOST_VM: mri,
     HOST_VM_CONFIG: default
     GUEST_VM: mri,
     GUEST_VM_CONFIG: default,
-    JT_BENCHMARK_RUBY: ruby
+    RUBY_BIN: "$MRI_HOME/bin/ruby",
+    JT_BENCHMARK_RUBY: "$MRI_HOME/bin/ruby"
   }
 }
 
@@ -399,6 +425,12 @@ server-benchmarks: {
   timelimit: "00:20:00"
 }
 
+other-ruby-server-benchmarks: ${server-benchmarks} {
+  run: [
+    ${bench.cmd} [server, --, --no-core-load-path]
+  ] ${post-process-and-upload-results}
+}
+
 svm-server-benchmarks: ${server-benchmarks} {
   run: [
     ${bench.cmd} [server, --, --aot]
@@ -551,7 +583,8 @@ builds: [
   {name: ruby-metrics-svm-graal-core} ${common} ${svm-graal-core-bench} ${svm-bench-caps} ${truffleruby} ${svm-metrics},
   {name: ruby-metrics-svm-graal-enterprise} ${common} ${svm-graal-enterprise-bench} ${svm-bench-caps} ${truffleruby} ${svm-metrics},
 
-  //{name: ruby-benchmarks-classic-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${classic-benchmarks},
+  {name: ruby-benchmarks-classic-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${classic-benchmarks},
+  {name: ruby-benchmarks-classic-jruby} ${common} ${weekly-bench-caps} ${jruby-benchmark} ${classic-benchmarks},
   //{name: ruby-benchmarks-classic-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${truffleruby} ${classic-benchmarks},
   {name: ruby-benchmarks-classic-graal-core} ${common} ${graal-core} ${bench-caps} ${truffleruby} ${classic-benchmarks},
   {name: ruby-benchmarks-classic-graal-core-solaris} ${common-solaris} ${graal-core} ${daily-bench-caps-solaris} ${truffleruby} ${classic-benchmarks-solaris},
@@ -563,7 +596,8 @@ builds: [
   {name: ruby-benchmarks-classic-svm-graal-enterprise} ${common} ${svm-graal-enterprise-bench} ${bench-caps} ${truffleruby} ${classic-benchmarks} {timelimit: "01:10:00"},
 
 
-  //{name: ruby-benchmarks-chunky-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${chunky-benchmarks},
+  {name: ruby-benchmarks-chunky-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${chunky-benchmarks},
+  {name: ruby-benchmarks-chunky-jruby} ${common} ${weekly-bench-caps} ${jruby-benchmark} ${chunky-benchmarks},
   //{name: ruby-benchmarks-chunky-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${truffleruby} ${chunky-benchmarks},
   {name: ruby-benchmarks-chunky-graal-core} ${common} ${graal-core} ${bench-caps} ${truffleruby} ${chunky-benchmarks},
   {name: ruby-benchmarks-chunky-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${truffleruby} ${chunky-benchmarks},
@@ -573,7 +607,8 @@ builds: [
   {name: ruby-benchmarks-chunky-svm-graal-enterprise} ${common} ${svm-graal-enterprise-bench} ${bench-caps} ${truffleruby} ${chunky-benchmarks},
 
 
-  //{name: ruby-benchmarks-psd-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${psd-benchmarks},
+  {name: ruby-benchmarks-psd-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${psd-benchmarks},
+  {name: ruby-benchmarks-psd-jruby} ${common} ${weekly-bench-caps} ${jruby-benchmark} ${psd-benchmarks},
   //{name: ruby-benchmarks-psd-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${truffleruby} ${psd-benchmarks},
   {name: ruby-benchmarks-psd-graal-core} ${common} ${graal-core} ${bench-caps} ${truffleruby} ${psd-benchmarks},
   {name: ruby-benchmarks-psd-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${truffleruby} ${psd-benchmarks},
@@ -583,7 +618,8 @@ builds: [
   {name: ruby-benchmarks-psd-svm-graal-enterprise} ${common} ${svm-graal-enterprise-bench} ${bench-caps} ${truffleruby} ${psd-benchmarks},
 
 
-  //{name: ruby-benchmarks-asciidoctor-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${asciidoctor-benchmarks},
+  {name: ruby-benchmarks-asciidoctor-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${asciidoctor-benchmarks},
+  {name: ruby-benchmarks-asciidoctor-jruby} ${common} ${weekly-bench-caps} ${jruby-benchmark} ${asciidoctor-benchmarks},
   //{name: ruby-benchmarks-asciidoctor-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${truffleruby} ${asciidoctor-benchmarks},
   {name: ruby-benchmarks-asciidoctor-graal-core} ${common} ${graal-core} ${bench-caps} ${truffleruby} ${asciidoctor-benchmarks},
   {name: ruby-benchmarks-asciidoctor-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${truffleruby} ${asciidoctor-benchmarks},
@@ -593,7 +629,8 @@ builds: [
   {name: ruby-benchmarks-asciidoctor-svm-graal-enterprise} ${common} ${svm-graal-enterprise-bench} ${bench-caps} ${truffleruby} ${asciidoctor-benchmarks},
 
 
-  //{name: ruby-benchmarks-other-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${other-benchmarks},
+  {name: ruby-benchmarks-other-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${other-benchmarks},
+  {name: ruby-benchmarks-other-jruby} ${common} ${weekly-bench-caps} ${jruby-benchmark} ${other-benchmarks},
   //{name: ruby-benchmarks-other-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${truffleruby} ${other-benchmarks},
   {name: ruby-benchmarks-other-graal-core} ${common} ${graal-core} ${bench-caps} ${truffleruby} ${other-benchmarks},
   {name: ruby-benchmarks-other-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${truffleruby} ${other-benchmarks},
@@ -603,6 +640,8 @@ builds: [
   {name: ruby-benchmarks-other-svm-graal-enterprise} ${common} ${svm-graal-enterprise-bench} ${bench-caps} ${truffleruby} ${other-benchmarks-svm},
 
 
+  {name: ruby-benchmarks-server-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${other-ruby-server-benchmarks},
+  {name: ruby-benchmarks-server-jruby} ${common} ${weekly-bench-caps} ${jruby-benchmark} ${other-ruby-server-benchmarks},
   //{name: ruby-benchmarks-server-no-graal} ${common} ${no-graal} ${weekly-bench-caps} ${truffleruby} ${server-benchmarks},
   {name: ruby-benchmarks-server-graal-core} ${common} ${graal-core} ${bench-caps} ${truffleruby} ${server-benchmarks},
   {name: ruby-benchmarks-server-graal-enterprise} ${common} ${graal-enterprise} ${daily-bench-caps} ${truffleruby} ${server-benchmarks},
@@ -615,4 +654,5 @@ builds: [
 
 
   {name: ruby-benchmarks-cext} ${common} ${daily-bench-caps} ${truffleruby-cexts} ${cext-benchmarks},
+  //{name: ruby-benchmarks-cext-mri} ${common} ${weekly-bench-caps} ${mri-benchmark} ${cext-benchmarks},
 ]

--- a/tool/fail-if-any-failed.rb
+++ b/tool/fail-if-any-failed.rb
@@ -37,6 +37,9 @@ known_failures = [
   # SVM (GR-5089)
   ["svm", "graal-enterprise", "jruby", "truffle", "classic", "red-black"],
   ["svm", "graal-enterprise", "jruby", "truffle", "classic", "richards"],
+
+  # JRuby
+  ["server", "default", "jruby", "indy", "micro", "micro/core/file.rb:core-read-gigabyte"]
 ]
 
 if File.exist?('failures')

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -542,7 +542,12 @@ module Commands
         jruby_args.push(*javacmd_options)
       end
     else
-      jruby_args << '-Xgraal.warn_unless=false'
+      if ENV["RUBY_BIN"]
+        # Assume if RUBY_BIN is set and '--graal' is not, that we're running
+        # a non-TruffleRuby, such as MRI.
+      else
+        jruby_args << '-Xgraal.warn_unless=false'
+      end
     end
 
     if args.delete('--stress')


### PR DESCRIPTION
This adds back in weekly benchmarks for JRuby and MRI. Please check that I have the VM and VM config options correct. I think I got them right, but I might've gotten the host VM for JRuby wrong.

Note that there's a behavioral change to "jt ruby" in here to support running the server benchmarks in MRI. Previously, we treated every `RUBY_BIN` setting as if it understood our various `-X` options. I changed it such that if `RUBY_BIN` is set, but `--graal` isn't provided, no TruffleRuby options are set. Really, we should find a better way to run the server benchmarks, I think, but this change seemed to be the least disruptive.