### PR TITLE
Nokogiri fixes

### DIFF
--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -675,7 +675,7 @@ int RB_FIXNUM_P(VALUE value) {
 }
 
 int RTEST(VALUE value) {
-  return truffle_invoke_b(RUBY_CEXT, "RTEST", value);
+  return value != NULL && truffle_invoke_b(RUBY_CEXT, "RTEST", value);
 }
 
 // Kernel

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -130,7 +130,7 @@ module Process
   #
   def self.setproctitle(title)
     val = Rubinius::Type.coerce_to(title, String, :to_str)
-    if !Truffle.aot? and RbConfig::CONFIG['host_os'] == 'linux' and File.readable?('/proc/self/maps')
+    if !Truffle.aot? and RbConfig::CONFIG['host_os'] =~ /linux/ and File.readable?('/proc/self/maps')
       setproctitle_linux_from_proc_maps(val)
     else
       Truffle.invoke_primitive(:vm_set_process_title, val)

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -130,7 +130,7 @@ module Process
   #
   def self.setproctitle(title)
     val = Rubinius::Type.coerce_to(title, String, :to_str)
-    if !Truffle.aot? and RbConfig::CONFIG['host_os'] =~ /linux/ and File.readable?('/proc/self/maps')
+    if !Truffle.aot? and RbConfig::CONFIG['host_os'].include?('linux') and File.readable?('/proc/self/maps')
       setproctitle_linux_from_proc_maps(val)
     else
       Truffle.invoke_primitive(:vm_set_process_title, val)

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -37,6 +37,11 @@ module RbConfig
   host_os  = Truffle::System.host_os
   host_cpu = Truffle::System.host_cpu
 
+  # host_os for linux systems is reported as linux-gnu rather than simply linux.
+  host_os = 'linux-gnu' if host_os == 'linux'
+
+  host_vendor = 'unknown'
+
   ruby_install_name = 'truffleruby'
 
   ruby_api_version = RUBY_VERSION.dup
@@ -47,6 +52,8 @@ module RbConfig
   ruby_version   = ruby_api_version
 
   arch         = "#{host_cpu}-#{host_os}"
+  # Host should match the target triplet for clang or GCC, otherwise some C extension builds will fail.
+  host         = "#{host_cpu}-#{host_vendor}-#{host_os}"
   cppflags     = ''
   libs         = ''
 
@@ -63,7 +70,8 @@ module RbConfig
       'host_alias'        => '',
       'host_os'           => host_os,
       'host_cpu'          => host_cpu,
-      'LIBEXT'            => 'c',
+      'host'              => host,
+      'LIBEXT'            => 'a',
       'OBJEXT'            => 'bc',
       'exeext'            => '',
       'EXEEXT'            => '',
@@ -147,7 +155,7 @@ module RbConfig
 
   CLANG          = 'clang'
   OPT            = 'opt'
-  
+
   opt_passes     = ['-always-inline', '-mem2reg', '-constprop'].join(' ')
   cc             = CLANG
   cpp            = cc
@@ -179,8 +187,8 @@ module RbConfig
   mkconfig['COMPILE_C'] = "ruby #{libdir}/cext/preprocess.rb $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{OPT} #{opt_passes} $@ -o $@",
   expanded['LINK_SO'] = "#{ruby_launcher} -Xgraal.warn_unless=false -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) #{libs}"
   mkconfig['LINK_SO'] = "#{ruby_launcher} -Xgraal.warn_unless=false -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) $(LIBS)"
-  expanded['TRY_LINK'] = "#{CLANG} -o conftest #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} #{libs}"
-  mkconfig['TRY_LINK'] = "#{CLANG} -o conftest #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} $(LIBS)"
+  expanded['TRY_LINK'] = "#{CLANG} -o conftest ${CPPFLAGS} #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} #{libs}"
+  mkconfig['TRY_LINK'] = "#{CLANG} -o conftest ${CPPFLAGS} #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} $(LIBS)"
 
   def self.ruby
     Truffle::Boot.ruby_launcher or

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -36,11 +36,15 @@ module RbConfig
 
   host_os  = Truffle::System.host_os
   host_cpu = Truffle::System.host_cpu
-
-  # host_os for linux systems is reported as linux-gnu rather than simply linux.
-  host_os = 'linux-gnu' if host_os == 'linux'
-
   host_vendor = 'unknown'
+  # Some config entries report linux-gnu rather than simply linux.
+  if host_os == 'linux'
+    host_os_full = 'linux-gnu'
+  else
+    host_os_full = host_os
+  end
+  # Host should match the target triplet for clang or GCC, otherwise some C extension builds will fail.
+  host         = "#{host_cpu}-#{host_vendor}-#{host_os_full}"
 
   ruby_install_name = 'truffleruby'
 
@@ -52,13 +56,13 @@ module RbConfig
   ruby_version   = ruby_api_version
 
   arch         = "#{host_cpu}-#{host_os}"
-  # Host should match the target triplet for clang or GCC, otherwise some C extension builds will fail.
-  host         = "#{host_cpu}-#{host_vendor}-#{host_os}"
   cppflags     = ''
   libs         = ''
 
   CONFIG = {
       'arch'              => arch,
+      'build'             => host,
+      'build_os'          => host_os_full,
       'configure_args'    => ' ',
       'ARCH_FLAG'         => '',
       'CPPFLAGS'          => cppflags,
@@ -68,7 +72,7 @@ module RbConfig
       'DLEXT'             => 'su',
       'NATIVE_DLEXT'      => RUBY_PLATFORM.include?('darwin') ? 'dylib' : 'so',
       'host_alias'        => '',
-      'host_os'           => host_os,
+      'host_os'           => host_os_full,
       'host_cpu'          => host_cpu,
       'host'              => host,
       'LIBEXT'            => 'a',
@@ -95,6 +99,7 @@ module RbConfig
       'ruby_version'      => ruby_api_version,
       'RUBY_BASE_NAME'    => ruby_base_name,
       'target_cpu'        => host_cpu,
+      'target_os'         => host_os,
   }
 
   MAKEFILE_CONFIG = CONFIG.dup
@@ -187,8 +192,8 @@ module RbConfig
   mkconfig['COMPILE_C'] = "ruby #{libdir}/cext/preprocess.rb $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{OPT} #{opt_passes} $@ -o $@",
   expanded['LINK_SO'] = "#{ruby_launcher} -Xgraal.warn_unless=false -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) #{libs}"
   mkconfig['LINK_SO'] = "#{ruby_launcher} -Xgraal.warn_unless=false -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) $(LIBS)"
-  expanded['TRY_LINK'] = "#{CLANG} -o conftest ${CPPFLAGS} #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} #{libs}"
-  mkconfig['TRY_LINK'] = "#{CLANG} -o conftest ${CPPFLAGS} #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} $(LIBS)"
+  expanded['TRY_LINK'] = "#{CLANG} -o conftest $(CPPFLAGS) #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} #{libs}"
+  mkconfig['TRY_LINK'] = "#{CLANG} -o conftest $(CPPFLAGS) #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} $(LIBS)"
 
   def self.ruby
     Truffle::Boot.ruby_launcher or

--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -289,7 +289,11 @@ module Truffle::CExt
     when Data
       T_DATA
     when Object
-      T_OBJECT
+      if hidden_variable_get(value, :data_holder)
+        T_DATA
+      else
+        T_OBJECT
+      end
     else
       raise "unknown type #{value.class}"
     end

--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -50,7 +50,9 @@ module Truffle::CExt
           end
         end
       end
+      libraries = libraries.uniq
       libraries = resolve_libraries(libraries, search_paths)
+      files = files.uniq
       Truffle::CExt.linker(output, libraries, files)
     end
 


### PR DESCRIPTION
Fixes to truffleruby to allow Nokogiri to compile and run. This will only work with a patched version of Nokogiri installed with the `--disable-static` option.