### PR TITLE
Hide C exts warnings by default

### DIFF
--- a/src/launcher/java/org/truffleruby/launcher/options/Options.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/Options.java
@@ -123,6 +123,7 @@ public class Options {
     public final boolean SHARED_OBJECTS_FORCE;
     public final boolean SHARED_OBJECTS_SHARE_ALL;
     public final boolean CEXTS_LOG_LOAD;
+    public final boolean CEXTS_LOG_WARNINGS;
     public final String[] CEXTS_LIBRARY_REMAP;
     public final boolean LOG_DYNAMIC_CONSTANT_LOOKUP;
     public final boolean OPTIONS_LOG;
@@ -238,6 +239,7 @@ public class Options {
         SHARED_OBJECTS_FORCE = builder.getOrDefault(OptionsCatalog.SHARED_OBJECTS_FORCE);
         SHARED_OBJECTS_SHARE_ALL = builder.getOrDefault(OptionsCatalog.SHARED_OBJECTS_SHARE_ALL);
         CEXTS_LOG_LOAD = builder.getOrDefault(OptionsCatalog.CEXTS_LOG_LOAD);
+        CEXTS_LOG_WARNINGS = builder.getOrDefault(OptionsCatalog.CEXTS_LOG_WARNINGS);
         CEXTS_LIBRARY_REMAP = builder.getOrDefault(OptionsCatalog.CEXTS_LIBRARY_REMAP);
         LOG_DYNAMIC_CONSTANT_LOOKUP = builder.getOrDefault(OptionsCatalog.LOG_DYNAMIC_CONSTANT_LOOKUP);
         OPTIONS_LOG = builder.getOrDefault(OptionsCatalog.OPTIONS_LOG);
@@ -462,6 +464,8 @@ public class Options {
                 return SHARED_OBJECTS_SHARE_ALL;
             case "ruby.cexts.log.load":
                 return CEXTS_LOG_LOAD;
+            case "ruby.cexts.log.warnings":
+                return CEXTS_LOG_WARNINGS;
             case "ruby.cexts.remap":
                 return CEXTS_LIBRARY_REMAP;
             case "ruby.constant.dynamic_lookup.log":

--- a/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
@@ -444,6 +444,10 @@ public class OptionsCatalog {
             "ruby.cexts.log.load",
             "Log loading of cexts",
             false);
+    public static final BooleanOptionDescription CEXTS_LOG_WARNINGS = new BooleanOptionDescription(
+            "ruby.cexts.log.warnings",
+            "Log cexts warnings",
+            false);
     public static final StringArrayOptionDescription CEXTS_LIBRARY_REMAP = new StringArrayOptionDescription(
             "ruby.cexts.remap",
             "Remap the name of native libraries, written in the form libexample.so=path/to/actual/libexample.so",
@@ -685,6 +689,8 @@ public class OptionsCatalog {
                 return SHARED_OBJECTS_SHARE_ALL;
             case "ruby.cexts.log.load":
                 return CEXTS_LOG_LOAD;
+            case "ruby.cexts.log.warnings":
+                return CEXTS_LOG_WARNINGS;
             case "ruby.cexts.remap":
                 return CEXTS_LIBRARY_REMAP;
             case "ruby.constant.dynamic_lookup.log":
@@ -811,6 +817,7 @@ public class OptionsCatalog {
             SHARED_OBJECTS_FORCE,
             SHARED_OBJECTS_SHARE_ALL,
             CEXTS_LOG_LOAD,
+            CEXTS_LOG_WARNINGS,
             CEXTS_LIBRARY_REMAP,
             LOG_DYNAMIC_CONSTANT_LOOKUP,
             OPTIONS_LOG,

--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -1870,8 +1870,10 @@ module Truffle::CExt
     rb_define_hooked_variable_inner id, getter_proc, setter_proc
   end
 
+  LOG_WARNING = Truffle::Boot.get_option 'cexts.log.warnings'
+
   def rb_tr_log_warning(message)
-    Truffle::Debug.log_warning message
+    Truffle::Debug.log_warning message if LOG_WARNING
   end
 
   def RDATA(object)

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -123,6 +123,7 @@ SHARED_OBJECTS_FORCE: [shared.objects.force, boolean, false, Force sharing of ob
 SHARED_OBJECTS_SHARE_ALL: [shared.objects.share_all, boolean, false, Consider all objects as shared]
 
 CEXTS_LOG_LOAD: [cexts.log.load, boolean, false, Log loading of cexts]
+CEXTS_LOG_WARNINGS: [cexts.log.warnings, boolean, false, Log cexts warnings]
 CEXTS_LIBRARY_REMAP: [cexts.remap, string-array, [], Remap the name of native libraries, written in the form libexample.so=path/to/actual/libexample.so]
 
 LOG_DYNAMIC_CONSTANT_LOOKUP: [constant.dynamic_lookup.log, boolean, false, Log source code positions where dynamic constant lookup is performed]


### PR DESCRIPTION
* They are meant for TruffleRuby developers, not users.
* Fixes #493.