### PR TITLE
Fix rb_Hash for spec

### DIFF
--- a/spec/tags/optional/capi/hash_tags.txt
+++ b/spec/tags/optional/capi/hash_tags.txt
@@ -1,5 +1,3 @@
 fails:C-API Hash function rb_hash_foreach iterates over the hash
 fails:C-API Hash function rb_hash_foreach stops via the callback
 fails:C-API Hash function rb_hash_foreach deletes via the callback
-fails:C-API Hash function rb_Hash tries to convert the passed argument to a hash by calling #to_hash
-fails:C-API Hash function rb_Hash raises a TypeError if #to_hash does not return a hash

--- a/src/main/ruby/core/kernel.rb
+++ b/src/main/ruby/core/kernel.rb
@@ -76,7 +76,7 @@ module Kernel
   module_function :Float
 
   def Hash(obj)
-    return {} if obj.nil? || obj == []
+    return {} if obj.equal?(nil) || obj == []
 
     if hash = Rubinius::Type.check_convert_type(obj, Hash, :to_hash)
       return hash


### PR DESCRIPTION
`BasicObject` used in the spec doesn't have the `nil?` method.