### PR TITLE
Add PATH_SEPARATOR to RbConfig

### DIFF
--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -79,6 +79,7 @@ module RbConfig
       'LIBRUBYARG'        => '',
       'NULLCMD'           => ':',
       'optflags'          => '',
+      'PATH_SEPARATOR'    => File::PATH_SEPARATOR,
       'RM'                => 'rm -f',
       'prefix'            => '',
       'ruby_install_name' => ruby_install_name,


### PR DESCRIPTION
This is used in `mkmf` to separate the path in the `VPATH` var. It was causing issues for me while using `rake compile` in `mysql2` which uses a `Makefile` in a separate directory than the sources.