### PR TITLE
Make the RubyContext a PE constant when creating a Fiber

### DIFF
--- a/src/main/java/org/truffleruby/core/fiber/FiberManager.java
+++ b/src/main/java/org/truffleruby/core/fiber/FiberManager.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.core.fiber;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.ControlFlowException;
 import com.oracle.truffle.api.nodes.Node;
@@ -52,7 +53,7 @@ public class FiberManager {
 
     public FiberManager(RubyContext context, DynamicObject rubyThread) {
         this.context = context;
-        this.rootFiber = createRootFiber(rubyThread);
+        this.rootFiber = createRootFiber(context, rubyThread);
         this.currentFiber = rootFiber;
     }
 
@@ -83,12 +84,13 @@ public class FiberManager {
         currentFiber = fiber;
     }
 
-    private DynamicObject createRootFiber(DynamicObject thread) {
-        return createFiber(thread, context.getCoreLibrary().getFiberFactory(), "root Fiber for Thread");
+    private DynamicObject createRootFiber(RubyContext context, DynamicObject thread) {
+        return createFiber(context, thread, context.getCoreLibrary().getFiberFactory(), "root Fiber for Thread");
     }
 
-    public DynamicObject createFiber(DynamicObject thread, DynamicObjectFactory factory, String name) {
+    public DynamicObject createFiber(RubyContext context, DynamicObject thread, DynamicObjectFactory factory, String name) {
         assert RubyGuards.isRubyThread(thread);
+        CompilerAsserts.partialEvaluationConstant(context);
         final DynamicObject fiberLocals = Layouts.BASIC_OBJECT.createBasicObject(context.getCoreLibrary().getObjectFactory());
         final DynamicObject catchTags = ArrayHelpers.createArray(context, null, 0);
 

--- a/src/main/java/org/truffleruby/core/fiber/FiberNodes.java
+++ b/src/main/java/org/truffleruby/core/fiber/FiberNodes.java
@@ -80,7 +80,7 @@ public abstract class FiberNodes {
         public DynamicObject allocate(DynamicObject rubyClass) {
             final DynamicObject thread = getContext().getThreadManager().getCurrentThread();
             final DynamicObjectFactory factory = Layouts.CLASS.getInstanceFactory(rubyClass);
-            return Layouts.THREAD.getFiberManager(thread).createFiber(thread, factory, null);
+            return Layouts.THREAD.getFiberManager(thread).createFiber(getContext(), thread, factory, null);
         }
 
     }


### PR DESCRIPTION
* Reading it from the FiberManager field is not constant at PE time
  since the FiberManager itself escapes and is not a constant.