### PR TITLE
Add an option to show all threads and backtraces on Ctrl+C

### DIFF
--- a/src/launcher/java/org/truffleruby/launcher/options/Options.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/Options.java
@@ -117,6 +117,7 @@ public class Options {
     public final boolean BACKTRACES_INTERLEAVE_JAVA;
     public final int BACKTRACES_LIMIT;
     public final boolean BACKTRACES_OMIT_UNUSED;
+    public final boolean BACKTRACE_ON_INTERRUPT;
     public final boolean BASICOPS_INLINE;
     public final boolean GRAAL_WARNING_UNLESS;
     public final boolean SHARED_OBJECTS_ENABLED;
@@ -234,6 +235,7 @@ public class Options {
         BACKTRACES_INTERLEAVE_JAVA = builder.getOrDefault(OptionsCatalog.BACKTRACES_INTERLEAVE_JAVA);
         BACKTRACES_LIMIT = builder.getOrDefault(OptionsCatalog.BACKTRACES_LIMIT);
         BACKTRACES_OMIT_UNUSED = builder.getOrDefault(OptionsCatalog.BACKTRACES_OMIT_UNUSED);
+        BACKTRACE_ON_INTERRUPT = builder.getOrDefault(OptionsCatalog.BACKTRACE_ON_INTERRUPT);
         BASICOPS_INLINE = builder.getOrDefault(OptionsCatalog.BASICOPS_INLINE);
         GRAAL_WARNING_UNLESS = builder.getOrDefault(OptionsCatalog.GRAAL_WARNING_UNLESS);
         SHARED_OBJECTS_ENABLED = builder.getOrDefault(OptionsCatalog.SHARED_OBJECTS_ENABLED);
@@ -454,6 +456,8 @@ public class Options {
                 return BACKTRACES_LIMIT;
             case "ruby.backtraces.omit_unused":
                 return BACKTRACES_OMIT_UNUSED;
+            case "ruby.backtraces.on_interrupt":
+                return BACKTRACE_ON_INTERRUPT;
             case "ruby.basic_ops.inline":
                 return BASICOPS_INLINE;
             case "ruby.graal.warn_unless":

--- a/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
@@ -521,6 +521,11 @@ public class OptionsCatalog {
             "Omit backtraces that should be unused as they have pure rescue expressions",
             null,
             true);
+    public static final BooleanOptionDescription BACKTRACE_ON_INTERRUPT = new BooleanOptionDescription(
+            "ruby.backtraces.on_interrupt",
+            "Show the backtraces of all Threads on Ctrl+C",
+            null,
+            false);
     public static final BooleanOptionDescription BASICOPS_INLINE = new BooleanOptionDescription(
             "ruby.basic_ops.inline",
             "Inline basic operations (like Fixnum operators) in the AST without a call",
@@ -796,6 +801,8 @@ public class OptionsCatalog {
                 return BACKTRACES_LIMIT;
             case "ruby.backtraces.omit_unused":
                 return BACKTRACES_OMIT_UNUSED;
+            case "ruby.backtraces.on_interrupt":
+                return BACKTRACE_ON_INTERRUPT;
             case "ruby.basic_ops.inline":
                 return BASICOPS_INLINE;
             case "ruby.graal.warn_unless":
@@ -932,6 +939,7 @@ public class OptionsCatalog {
             BACKTRACES_INTERLEAVE_JAVA,
             BACKTRACES_LIMIT,
             BACKTRACES_OMIT_UNUSED,
+            BACKTRACE_ON_INTERRUPT,
             BASICOPS_INLINE,
             GRAAL_WARNING_UNLESS,
             SHARED_OBJECTS_ENABLED,

--- a/src/main/ruby/core/main.rb
+++ b/src/main/ruby/core/main.rb
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, 2016 Oracle and/or its affiliates. All rights reserved. This
 # code is released under a tri EPL/GPL/LGPL license. You can use it,
 # redistribute it and/or modify it under the terms of the:
-# 
+#
 # Eclipse Public License version 1.0
 # GNU General Public License version 2
 # GNU Lesser General Public License version 2.1
@@ -56,5 +56,20 @@ class << self
 end
 
 Signal.trap('INT') do
+  if Truffle::Boot.get_option('backtraces.on_interrupt')
+    puts 'Interrupting...'
+    puts 'Threads and backtraces:'
+    Thread.list.each { |thread|
+      p thread
+      if thread == Thread.current
+        # Ignore the signal handler frames
+        puts thread.backtrace[4..-1]
+      else
+        puts thread.backtrace
+      end
+      puts
+    }
+  end
+
   raise Interrupt
 end

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -114,6 +114,7 @@ BACKTRACES_HIDE_CORE_FILES: [backtraces.hide_core_files, boolean, true, 'Hide co
 BACKTRACES_INTERLEAVE_JAVA: [backtraces.interleave_java, boolean, false, Interleave Java stacktraces into the Ruby backtrace]
 BACKTRACES_LIMIT: [backtraces.limit, integer, 9999, Limit the size of Ruby backtraces]
 BACKTRACES_OMIT_UNUSED: [backtraces.omit_unused, boolean, true, Omit backtraces that should be unused as they have pure rescue expressions]
+BACKTRACE_ON_INTERRUPT: [backtraces.on_interrupt, boolean, false, Show the backtraces of all Threads on Ctrl+C]
 BASICOPS_INLINE: [basic_ops.inline, boolean, true, Inline basic operations (like Fixnum operators) in the AST without a call]
 
 GRAAL_WARNING_UNLESS: [graal.warn_unless, boolean, true, Warn unless the JVM has the Graal compiler]


### PR DESCRIPTION
* By default not enabled so the output after `Ctrl+C` is unchanged.

I am thinking to also show all threads and backtraces on another signal by default, so we can have something like `Ctrl+\` for Ruby, not terminating the process but just used for monitoring. `Ctrl+\` is SIGQUIT which is already taken by the JVM though.
Maybe SIGALRM?
SIGUSR2 is another possibility but that's likely used by the application (if used it would just override the handler, removing the backtrace dumping functionality).