### PR TITLE
Add a default handler for SIGALRM showing all threads and backtraces

### DIFF
--- a/src/launcher/java/org/truffleruby/launcher/options/Options.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/Options.java
@@ -118,6 +118,7 @@ public class Options {
     public final int BACKTRACES_LIMIT;
     public final boolean BACKTRACES_OMIT_UNUSED;
     public final boolean BACKTRACE_ON_INTERRUPT;
+    public final boolean BACKTRACE_ON_SIGALRM;
     public final boolean BASICOPS_INLINE;
     public final boolean GRAAL_WARNING_UNLESS;
     public final boolean SHARED_OBJECTS_ENABLED;
@@ -236,6 +237,7 @@ public class Options {
         BACKTRACES_LIMIT = builder.getOrDefault(OptionsCatalog.BACKTRACES_LIMIT);
         BACKTRACES_OMIT_UNUSED = builder.getOrDefault(OptionsCatalog.BACKTRACES_OMIT_UNUSED);
         BACKTRACE_ON_INTERRUPT = builder.getOrDefault(OptionsCatalog.BACKTRACE_ON_INTERRUPT);
+        BACKTRACE_ON_SIGALRM = builder.getOrDefault(OptionsCatalog.BACKTRACE_ON_SIGALRM);
         BASICOPS_INLINE = builder.getOrDefault(OptionsCatalog.BASICOPS_INLINE);
         GRAAL_WARNING_UNLESS = builder.getOrDefault(OptionsCatalog.GRAAL_WARNING_UNLESS);
         SHARED_OBJECTS_ENABLED = builder.getOrDefault(OptionsCatalog.SHARED_OBJECTS_ENABLED);
@@ -458,6 +460,8 @@ public class Options {
                 return BACKTRACES_OMIT_UNUSED;
             case "ruby.backtraces.on_interrupt":
                 return BACKTRACE_ON_INTERRUPT;
+            case "ruby.backtraces.sigalrm":
+                return BACKTRACE_ON_SIGALRM;
             case "ruby.basic_ops.inline":
                 return BASICOPS_INLINE;
             case "ruby.graal.warn_unless":

--- a/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
@@ -526,6 +526,11 @@ public class OptionsCatalog {
             "Show the backtraces of all Threads on Ctrl+C",
             null,
             false);
+    public static final BooleanOptionDescription BACKTRACE_ON_SIGALRM = new BooleanOptionDescription(
+            "ruby.backtraces.sigalrm",
+            "Show the backtraces of all Threads on SIGALRM",
+            null,
+            true);
     public static final BooleanOptionDescription BASICOPS_INLINE = new BooleanOptionDescription(
             "ruby.basic_ops.inline",
             "Inline basic operations (like Fixnum operators) in the AST without a call",
@@ -803,6 +808,8 @@ public class OptionsCatalog {
                 return BACKTRACES_OMIT_UNUSED;
             case "ruby.backtraces.on_interrupt":
                 return BACKTRACE_ON_INTERRUPT;
+            case "ruby.backtraces.sigalrm":
+                return BACKTRACE_ON_SIGALRM;
             case "ruby.basic_ops.inline":
                 return BASICOPS_INLINE;
             case "ruby.graal.warn_unless":
@@ -940,6 +947,7 @@ public class OptionsCatalog {
             BACKTRACES_LIMIT,
             BACKTRACES_OMIT_UNUSED,
             BACKTRACE_ON_INTERRUPT,
+            BACKTRACE_ON_SIGALRM,
             BASICOPS_INLINE,
             GRAAL_WARNING_UNLESS,
             SHARED_OBJECTS_ENABLED,

--- a/src/main/ruby/core/main.rb
+++ b/src/main/ruby/core/main.rb
@@ -58,14 +58,14 @@ end
 show_backtraces = -> {
   puts 'Threads and backtraces:'
   Thread.list.each { |thread|
-    p thread
+    $stderr.puts thread
     if thread == Thread.current
       # Ignore the signal handler frames
-      puts thread.backtrace[6..-1]
+      $stderr.puts thread.backtrace[6..-1]
     else
-      puts thread.backtrace
+      $stderr.puts thread.backtrace
     end
-    puts
+    $stderr.puts
   }
 }
 

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -115,6 +115,7 @@ BACKTRACES_INTERLEAVE_JAVA: [backtraces.interleave_java, boolean, false, Interle
 BACKTRACES_LIMIT: [backtraces.limit, integer, 9999, Limit the size of Ruby backtraces]
 BACKTRACES_OMIT_UNUSED: [backtraces.omit_unused, boolean, true, Omit backtraces that should be unused as they have pure rescue expressions]
 BACKTRACE_ON_INTERRUPT: [backtraces.on_interrupt, boolean, false, Show the backtraces of all Threads on Ctrl+C]
+BACKTRACE_ON_SIGALRM: [backtraces.sigalrm, boolean, true, Show the backtraces of all Threads on SIGALRM]
 BASICOPS_INLINE: [basic_ops.inline, boolean, true, Inline basic operations (like Fixnum operators) in the AST without a call]
 
 GRAAL_WARNING_UNLESS: [graal.warn_unless, boolean, true, Warn unless the JVM has the Graal compiler]


### PR DESCRIPTION
* A one-liner to send SIGALRM to the process if there is only one running is:
```
$ kill -ALRM `jps -l | grep org.truffleruby.Main | cut -f 1 -d ' '`
```
* By default SIGALRM would just kill the process so I don't think it has any use if its signal handler is not overridden.