### PR TITLE
Define RARRAY_LEN as macro

### DIFF
--- a/lib/cext/ruby.h
+++ b/lib/cext/ruby.h
@@ -877,7 +877,8 @@ int rb_is_instance_id(ID id);
 
 // Array
 
-int RARRAY_LEN(VALUE array);
+#define RARRAY_LEN(array) rb_array_len(array)
+long rb_array_len(VALUE array);
 int RARRAY_LENINT(VALUE array);
 #define RARRAY_PTR(array) ((VALUE *)array)
 VALUE RARRAY_AREF(VALUE array, long index);

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -1565,7 +1565,7 @@ int rb_is_instance_id(ID id) {
 
 // Array
 
-int RARRAY_LEN(VALUE array) {
+long rb_array_len(VALUE array) {
   return truffle_get_size(array);
 }
 


### PR DESCRIPTION
This update is compatible with an extension that is expecting this to be a macro with `#ifndef RARRAY_LEN`.