### PR TITLE
Implement initializeThread/disposeThread and allow to create foreign threads

### DIFF
--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -230,12 +230,8 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
             return;
         }
 
-        if (Thread.currentThread() != thread) {
-            throw new IllegalStateException("TruffleRuby currently requires initializeThread() to be executed by the Thread being initialized");
-        }
-
         final DynamicObject foreignThread = context.getThreadManager().createForeignThread();
-        context.getThreadManager().start(foreignThread);
+        context.getThreadManager().start(foreignThread, thread);
     }
 
     @Override
@@ -250,11 +246,8 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
             return;
         }
 
-        // Can only clean ThreadLocal etc if we are the current thread
-        if (Thread.currentThread() == thread) {
-            final DynamicObject rubyThread = context.getThreadManager().getCurrentThread();
-            context.getThreadManager().cleanup(rubyThread);
-        }
+        final DynamicObject rubyThread = context.getThreadManager().getForeignRubyThread(thread);
+        context.getThreadManager().cleanup(rubyThread, thread);
     }
 
 }

--- a/src/main/java/org/truffleruby/core/fiber/FiberLayout.java
+++ b/src/main/java/org/truffleruby/core/fiber/FiberLayout.java
@@ -35,8 +35,7 @@ public interface FiberLayout extends BasicObjectLayout {
                               @Volatile @Nullable DynamicObject lastResumedByFiber,
                               @Volatile boolean alive,
                               @Volatile @Nullable Thread thread,
-                              @Volatile boolean transferred,
-                              long pThreadID);
+                              @Volatile boolean transferred);
 
     boolean isFiber(DynamicObject object);
 
@@ -63,8 +62,5 @@ public interface FiberLayout extends BasicObjectLayout {
 
     boolean getTransferred(DynamicObject object);
     void setTransferred(DynamicObject object, boolean value);
-
-    long getPThreadID(DynamicObject object);
-    void setPThreadID(DynamicObject object, long value);
 
 }

--- a/src/main/java/org/truffleruby/core/regexp/ClassicRegexp.java
+++ b/src/main/java/org/truffleruby/core/regexp/ClassicRegexp.java
@@ -39,7 +39,6 @@ import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
-import org.joni.Matcher;
 import org.joni.NameEntry;
 import org.joni.Option;
 import org.joni.Regex;
@@ -111,35 +110,6 @@ public class ClassicRegexp implements ReOptions {
         regex.setUserObject(bytes);
         patternCache.put(key, regex);
         return regex;
-    }
-
-    public static int matcherSearch(Matcher matcher, int start, int range, int option) {
-        try {
-            SearchMatchTask task = new SearchMatchTask(start, range, option, false);
-            return task.run(null, matcher);
-        } catch (InterruptedException e) {
-            throw new UnsupportedOperationException();
-        }
-    }
-
-    private static class SearchMatchTask {
-        final int start;
-        final int range;
-        final int option;
-        final boolean match;
-
-        SearchMatchTask(int start, int range, int option, boolean match) {
-            this.start = start;
-            this.range = range;
-            this.option = option;
-            this.match = match;
-        }
-
-        public Integer run(Object context, Matcher matcher) throws InterruptedException {
-            return match ?
-                    matcher.matchInterruptible(start, range, option) :
-                    matcher.searchInterruptible(start, range, option);
-        }
     }
 
     /** default constructor

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -63,7 +63,7 @@ public class ThreadManager {
     private final Set<DynamicObject> runningRubyThreads =
             Collections.newSetFromMap(new ConcurrentHashMap<DynamicObject, Boolean>());
 
-    private final Set<Thread> threadsWeCreated =
+    private final Set<Thread> rubyManagedThreads =
             Collections.newSetFromMap(new ConcurrentHashMap<Thread, Boolean>());
 
     private final Map<Thread, UnblockingAction> unblockingActions = new ConcurrentHashMap<>();
@@ -83,18 +83,18 @@ public class ThreadManager {
             setupSignalHandler(context);
         }
 
-        threadsWeCreated.add(rootJavaThread);
+        rubyManagedThreads.add(rootJavaThread);
         start(rootThread, rootJavaThread);
     }
 
     public Thread createJavaThread(Runnable runnable) {
         final Thread thread = context.getEnv().createThread(runnable);
-        threadsWeCreated.add(thread);
+        rubyManagedThreads.add(thread);
         return thread;
     }
 
     public boolean isRubyManagedThread(Thread thread) {
-        return threadsWeCreated.contains(thread);
+        return rubyManagedThreads.contains(thread);
     }
 
     public DynamicObject createBootThread(String info) {

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -406,7 +406,7 @@ public class ThreadManager {
         return currentThread.get();
     }
 
-    public synchronized void registerThread(DynamicObject thread) {
+    public void registerThread(DynamicObject thread) {
         assert RubyGuards.isRubyThread(thread);
         runningRubyThreads.add(thread);
 
@@ -417,7 +417,7 @@ public class ThreadManager {
         }
     }
 
-    public synchronized void unregisterThread(DynamicObject thread) {
+    public void unregisterThread(DynamicObject thread) {
         assert RubyGuards.isRubyThread(thread);
         runningRubyThreads.remove(thread);
         currentThread.set(null);

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -296,6 +296,26 @@ public class ThreadManager {
         void unblock();
     }
 
+    /** Only use when no context is available. */
+    @TruffleBoundary
+    public static <T> T retryWhileInterrupted(BlockingAction<T> action) {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    return action.block();
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    // retry
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
     @TruffleBoundary
     public <T> T runUntilResultKeepStatus(Node currentNode, BlockingAction<T> action) {
         T result = null;

--- a/src/test/java/org/truffleruby/MiscTest.java
+++ b/src/test/java/org/truffleruby/MiscTest.java
@@ -85,4 +85,18 @@ public class MiscTest {
         }
     }
 
+    @Test
+    public void testFiberFromIntegratorThread() throws InterruptedException {
+        try (Context context = Context.newBuilder().allowCreateThread(true).build()) {
+            context.eval("ruby", ":init");
+
+            Thread thread = new Thread(() -> {
+                int value = context.eval("ruby", "Fiber.new { 6 * 7 }.resume").asInt();
+                assertEquals(42, value);
+            });
+            thread.start();
+            thread.join();
+        }
+    }
+
 }

--- a/src/test/java/org/truffleruby/MiscTest.java
+++ b/src/test/java/org/truffleruby/MiscTest.java
@@ -10,11 +10,17 @@
 package org.truffleruby;
 
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Timer;
+import java.util.TimerTask;
 
 public class MiscTest {
 
@@ -34,6 +40,48 @@ public class MiscTest {
             assertTrue(array.hasArrayElements());
             assertEquals(3, array.getArraySize());
             assertEquals(42, array.getArrayElement(1).asInt());
+        }
+    }
+
+    @Test
+    public void timeoutExecution() {
+        Context context = Context.create();
+
+        Timer timer = new Timer();
+        // schedule a timeout in 1s
+        timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    context.close(true);
+                } catch (PolyglotException e) {
+                    assertTrue(e.isCancelled());
+                }
+            }
+        }, 1000);
+
+        try {
+            String maliciousCode = "while true; end";
+            context.eval("ruby", maliciousCode);
+            Assert.fail();
+        } catch (PolyglotException e) {
+            assertTrue(e.isCancelled());
+        }
+    }
+
+    @Test
+    public void testEvalFromIntegratorThreadSingleThreaded() throws InterruptedException {
+        final String codeDependingOnCurrentThread = "Thread.current.object_id";
+
+        try (Context context = Context.create()) {
+            long thread1 = context.eval("ruby", codeDependingOnCurrentThread).asLong();
+
+            Thread thread = new Thread(() -> {
+                long thread2 = context.eval("ruby", codeDependingOnCurrentThread).asLong();
+                assertNotEquals(thread1, thread2);
+            });
+            thread.start();
+            thread.join();
         }
     }
 


### PR DESCRIPTION
* Foreign threads (threads not created by Ruby) do not register with the
  SafepointManager since we do not know if they execute Truffle code
  within a call to Context.eval() or regular non-Truffle Java code.
  If the latter, we cannot possibly stop them or ask to come to a
  guest-language safepoint.
* Each new foreign thread creates a new Ruby Thread in the root ThreadGroup.
* Add a couple tests using foreign threads.
* Do not depend on the value of the current Thread for initialization and cleanup.