### PR TITLE
Simplify the 'string_byte_index' primitive.

### DIFF
--- a/spec/ruby/core/string/include_spec.rb
+++ b/spec/ruby/core/string/include_spec.rb
@@ -25,4 +25,11 @@ describe "String#include? with String" do
     lambda { "hello".include?('h'.ord)  }.should raise_error(TypeError)
     lambda { "hello".include?(mock('x')) }.should raise_error(TypeError)
   end
+
+  it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
+    pat = "ア".encode Encoding::EUC_JP
+    lambda do
+      "あれ".include?(pat)
+    end.should raise_error(Encoding::CompatibilityError)
+  end
 end

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3269,7 +3269,10 @@ public abstract class StringNodes {
 
         @Specialization(guards = { "isRubyString(pattern)", "!isBrokenCodeRange(pattern)", "!isSingleByteSearch(string, pattern)" })
         public Object stringIndexGeneric(VirtualFrame frame, DynamicObject string, DynamicObject pattern, int start,
+                                  @Cached("create()") EncodingNodes.CheckEncodingNode checkEncodingNode,
                                   @Cached("createBinaryProfile()") ConditionProfile badIndexProfile) {
+            checkEncodingNode.executeCheckEncoding(string, pattern);
+
             // Rubinius will pass in a byte index for the `start` value, but StringSupport.index requires a character index.
             final int charIndex = byteIndexToCharIndexNode.executeStringByteCharacterIndex(frame, string, start, 0);
 

--- a/src/main/ruby/core/string.rb
+++ b/src/main/ruby/core/string.rb
@@ -1094,7 +1094,7 @@ class String
         raise IndexError, "index #{index} out of string"
       end
 
-      unless bi = m.byte_index(index)
+      unless bi = m.string_byte_index_from_char_index(index)
         raise IndexError, "unable to find character at: #{index}"
       end
 
@@ -1109,10 +1109,10 @@ class String
         if total >= size
           bs = bytesize - bi
         else
-          bs = m.byte_index(total) - bi
+          bs = m.string_byte_index_from_char_index(total) - bi
         end
       else
-        bs = index == size ? 0 : m.byte_index(index + 1) - bi
+        bs = index == size ? 0 : m.string_byte_index_from_char_index(index + 1) - bi
       end
 
       replacement = StringValue replacement
@@ -1120,7 +1120,7 @@ class String
 
       m.splice bi, bs, replacement, enc
     when String
-      unless start = m.byte_index(index)
+      unless start = find_string(index, 0)
         raise IndexError, 'string not matched'
       end
 
@@ -1137,7 +1137,7 @@ class String
         raise RangeError, "#{index.first} is out of range"
       end
 
-      unless bi = m.byte_index(start)
+      unless bi = m.string_byte_index_from_char_index(start)
         raise IndexError, "unable to find character at: #{start}"
       end
 
@@ -1150,7 +1150,7 @@ class String
       elsif stop >= size
         bs = bytesize - bi
       else
-        bs = m.byte_index(stop + 1) - bi
+        bs = m.string_byte_index_from_char_index(stop + 1) - bi
       end
 
       replacement = StringValue replacement
@@ -1182,8 +1182,8 @@ class String
       replacement = StringValue replacement
       enc = Rubinius::Type.compatible_encoding self, replacement
 
-      bi = m.byte_index match.begin(count)
-      bs = m.byte_index(match.end(count)) - bi
+      bi = m.string_byte_index_from_char_index match.begin(count)
+      bs = m.string_byte_index_from_char_index(match.end(count)) - bi
 
       m.splice bi, bs, replacement, enc
     else
@@ -1223,7 +1223,7 @@ class String
       x = left / ps
       y = left % ps
 
-      lpbi = pm.byte_index(y)
+      lpbi = pm.string_byte_index_from_char_index(y)
       lbytes = x * pbs + lpbi
 
       right = left + (width & 0x1)
@@ -1231,7 +1231,7 @@ class String
       x = right / ps
       y = right % ps
 
-      rpbi = pm.byte_index(y)
+      rpbi = pm.string_byte_index_from_char_index(y)
       rbytes = x * pbs + rpbi
 
       pad = self.class.pattern rbytes, padding
@@ -1272,7 +1272,7 @@ class String
       x = width / ps
       y = width % ps
 
-      pbi = pm.byte_index(y)
+      pbi = pm.string_byte_index_from_char_index(y)
       bytes = x * pbs + pbi
 
       str = self.class.pattern bytes + bs, self
@@ -1321,7 +1321,7 @@ class String
       x = width / ps
       y = width % ps
 
-      bytes = x * pbs + pm.byte_index(y)
+      bytes = x * pbs + pm.string_byte_index_from_char_index(y)
     else
       bytes = width
     end

--- a/src/main/ruby/core/string_mirror.rb
+++ b/src/main/ruby/core/string_mirror.rb
@@ -50,7 +50,13 @@ module Rubinius
       end
 
       def byte_index(value, start=0)
-        Truffle.invoke_primitive :string_byte_index, @object, value, start
+        if value.kind_of?(Integer)
+          Truffle.invoke_primitive :string_byte_index_from_char_index, @object, value
+        elsif value.kind_of? ::String
+          @object.find_string(value, start)
+        else
+          raise ArgumentError, 'argument is not a String or Fixnum'
+        end
       end
 
       def previous_byte_index(index)

--- a/src/main/ruby/core/string_mirror.rb
+++ b/src/main/ruby/core/string_mirror.rb
@@ -49,14 +49,8 @@ module Rubinius
         Truffle.invoke_primitive :string_character_index, @object, str, start
       end
 
-      def byte_index(value, start=0)
-        if value.kind_of?(Integer)
-          Truffle.invoke_primitive :string_byte_index_from_char_index, @object, value
-        elsif value.kind_of? ::String
-          @object.find_string(value, start)
-        else
-          raise ArgumentError, 'argument is not a String or Fixnum'
-        end
+      def string_byte_index_from_char_index(value, start=0)
+        Truffle.invoke_primitive :string_byte_index_from_char_index, @object, value
       end
 
       def previous_byte_index(index)


### PR DESCRIPTION
* The case where the index value is a String was duplicating code
elsewhere in the StringIndexPrimitiveNode.

* By removing handling of String index values, we're left with just
the Integer case, which was already handled by the
StringByteIndexFromCharIndexNode class.

* Promote StringByteIndexFromCharIndexNode and remove the
StringByteIndexNode as the former conveys intent better and
the latter can now be replaced by some Ruby code.