### PR TITLE
Do not warn about Graal when building C extensions

### DIFF
--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -1,5 +1,5 @@
 ROOT := $(realpath ../../..)
-RUBY := $(ROOT)/bin/truffleruby
+RUBY := $(ROOT)/bin/truffleruby -Xgraal.warn_unless=false
 OS := $(shell uname)
 
 ifeq ($(TRUFFLERUBY_CEXT_ENABLED),false)

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -177,8 +177,8 @@ module RbConfig
 
   expanded['COMPILE_C'] = "ruby #{libdir}/cext/preprocess.rb $< | #{cc} $(INCFLAGS) #{cppflags} #{cflags} $(COUTFLAG) -xc - -o $@ && #{OPT} #{opt_passes} $@ -o $@",
   mkconfig['COMPILE_C'] = "ruby #{libdir}/cext/preprocess.rb $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{OPT} #{opt_passes} $@ -o $@",
-  expanded['LINK_SO'] = "#{ruby_launcher} -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) #{libs}"
-  mkconfig['LINK_SO'] = "#{ruby_launcher} -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) $(LIBS)"
+  expanded['LINK_SO'] = "#{ruby_launcher} -Xgraal.warn_unless=false -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) #{libs}"
+  mkconfig['LINK_SO'] = "#{ruby_launcher} -Xgraal.warn_unless=false -e Truffle::CExt::Linker.main -- -o $@ $(OBJS) $(LIBS)"
   expanded['TRY_LINK'] = "#{CLANG} -o conftest #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} #{libs}"
   mkconfig['TRY_LINK'] = "#{CLANG} -o conftest #{libdir}/cext/ruby.bc #{libdir}/cext/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} $(LIBS)"
 


### PR DESCRIPTION
* It does not matter if Graal is not there for the extconf.rb or the linker.