### PR TITLE
Optimize uncached dispatch

### DIFF
--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -172,6 +172,7 @@ public class CoreLibrary {
     private final DynamicObject truffleModule;
     private final DynamicObject truffleBootModule;
     private final DynamicObject truffleInteropModule;
+    private final DynamicObject truffleInteropForeignClass;
     private final DynamicObject truffleInteropJavaModule;
     private final DynamicObject truffleKernelOperationsModule;
     private final DynamicObject bigDecimalClass;
@@ -209,7 +210,6 @@ public class CoreLibrary {
 
     @CompilationFinal private DynamicObject eagainWaitReadable;
     @CompilationFinal private DynamicObject eagainWaitWritable;
-    @CompilationFinal private DynamicObject interopForeignClass;
 
     private final Map<Errno, DynamicObject> errnoClasses = new HashMap<>();
 
@@ -512,6 +512,7 @@ public class CoreLibrary {
 
         truffleModule = defineModule("Truffle");
         truffleInteropModule = defineModule(truffleModule, "Interop");
+        truffleInteropForeignClass = defineClass(truffleInteropModule, objectClass, "Foreign");
         truffleInteropJavaModule = defineModule(truffleInteropModule, "Java");
         defineModule(truffleModule, "CExt");
         defineModule(truffleModule, "Debug");
@@ -849,9 +850,6 @@ public class CoreLibrary {
 
         eagainWaitWritable = (DynamicObject) Layouts.MODULE.getFields(ioClass).getConstant("EAGAINWaitWritable").getValue();
         assert Layouts.CLASS.isClass(eagainWaitWritable);
-
-        interopForeignClass = (DynamicObject) Layouts.MODULE.getFields((DynamicObject) Layouts.MODULE.getFields(truffleModule).getConstant("Interop").getValue()).getConstant("Foreign").getValue();
-        assert Layouts.CLASS.isClass(interopForeignClass);
     }
 
     public void initializePostBoot() {
@@ -975,7 +973,7 @@ public class CoreLibrary {
         } else if (object instanceof Double) {
             return floatClass;
         } else {
-            return interopForeignClass;
+            return truffleInteropForeignClass;
         }
     }
 
@@ -1432,15 +1430,19 @@ public class CoreLibrary {
         return truffleBootModule;
     }
 
-    public Object getTruffleInteropModule() {
+    public DynamicObject getTruffleInteropModule() {
         return truffleInteropModule;
     }
 
-    public Object getTruffleInteropJavaModule() {
+    public DynamicObject getTruffleInteropForeignClass() {
+        return truffleInteropForeignClass;
+    }
+
+    public DynamicObject getTruffleInteropJavaModule() {
         return truffleInteropJavaModule;
     }
 
-    public Object getTruffleKernelOperationsModule() {
+    public DynamicObject getTruffleKernelOperationsModule() {
         return truffleKernelOperationsModule;
     }
 

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -70,7 +70,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
 
     private final SourceSection sourceSection;
 
-    public final ModuleChain start;
+    public final PrependMarker start;
     @CompilationFinal public ModuleChain parentModule;
 
     public final DynamicObject lexicalParent;
@@ -149,6 +149,10 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
 
     private boolean hasPrependedModules() {
         return start.getParentModule() != this;
+    }
+
+    public ModuleChain getFirstModuleChain() {
+        return start.getParentModule();
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -316,21 +316,12 @@ public abstract class ModuleOperations {
 
     @TruffleBoundary
     public static InternalMethod lookupMethodUncached(DynamicObject module, String name) {
-        // Lookup in the top module as we are likely to find the method there
-        final ModuleChain top = Layouts.MODULE.getFields(module).getFirstModuleChain();
-        final ModuleFields topModule = Layouts.MODULE.getFields(top.getActualModule());
-        final InternalMethod topMethod = topModule.getMethod(name);
-
-        if (topMethod != null) {
-            return topMethod;
-        } else {
-            // Look in ancestors
-            for (DynamicObject ancestor : Layouts.MODULE.getFields(module).ancestors()) {
-                final ModuleFields fields = Layouts.MODULE.getFields(ancestor);
-                final InternalMethod method = fields.getMethod(name);
-                if (method != null) {
-                    return method;
-                }
+        // Look in ancestors
+        for (DynamicObject ancestor : Layouts.MODULE.getFields(module).ancestors()) {
+            final ModuleFields fields = Layouts.MODULE.getFields(ancestor);
+            final InternalMethod method = fields.getMethod(name);
+            if (method != null) {
+                return method;
             }
         }
 

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -258,13 +258,7 @@ public class InternalMethod implements ObjectGraphNode {
                 return true;
 
             case PROTECTED:
-                for (DynamicObject ancestor : Layouts.MODULE.getFields(callerClass).ancestors()) {
-                    if (ancestor == declaringModule || Layouts.BASIC_OBJECT.getMetaClass(ancestor) == declaringModule) {
-                        return true;
-                    }
-                }
-
-                return false;
+                return isProtectedMethodVisibleTo(callerClass);
 
             case PRIVATE:
                 // A private method may only be called with an implicit receiver,
@@ -274,6 +268,19 @@ public class InternalMethod implements ObjectGraphNode {
             default:
                 throw new UnsupportedOperationException(visibility.name());
         }
+    }
+
+    @TruffleBoundary
+    public boolean isProtectedMethodVisibleTo(DynamicObject callerClass) {
+        assert visibility == Visibility.PROTECTED;
+
+        for (DynamicObject ancestor : Layouts.MODULE.getFields(callerClass).ancestors()) {
+            if (ancestor == declaringModule || Layouts.BASIC_OBJECT.getMetaClass(ancestor) == declaringModule) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -10,6 +10,7 @@
 package org.truffleruby.language.methods;
 
 import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
@@ -248,6 +249,7 @@ public class InternalMethod implements ObjectGraphNode {
                 capturedDefaultDefinee);
     }
 
+    @TruffleBoundary
     public boolean isVisibleTo(DynamicObject callerClass) {
         assert RubyGuards.isRubyClass(callerClass);
 

--- a/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
@@ -114,11 +114,11 @@ public abstract class LookupMethodNode extends RubyNode {
 
         // Check visibility
 
-        if (publicProfile.profile(method.getVisibility() == Visibility.PUBLIC)) {
-            return method;
-        }
-
         if (!ignoreVisibility) {
+            if (publicProfile.profile(method.getVisibility() == Visibility.PUBLIC)) {
+                return method;
+            }
+
             if (onlyLookupPublic) {
                 return null;
             }


### PR DESCRIPTION
* Only the ConcurrentHashMap lookup is a boundary in common cases
  where the method can be found on the receiver's class.
* Notably useful for the megamorphic call in OptCarrot.