### PR TITLE
Move TRUFFLERUBY_RESILIENT_GEM_HOME logic to post-boot

### DIFF
--- a/bin/truffleruby.sh
+++ b/bin/truffleruby.sh
@@ -59,10 +59,6 @@ if [ -n "$RUBY_BIN" ]; then
     exec "$RUBY_BIN" "$@"
 fi
 
-if [ -n "$TRUFFLERUBY_RESILIENT_GEM_HOME" ]; then
-    unset GEM_HOME GEM_PATH GEM_ROOT
-fi
-
 if [ -z "$JAVACMD" ]; then
     if [ -z "$JAVA_HOME" ]; then
         JAVACMD='java'

--- a/src/main/ruby/post-boot/post-boot.rb
+++ b/src/main/ruby/post-boot/post-boot.rb
@@ -24,6 +24,12 @@ rescue LoadError => e
 end
 
 if Truffle::Boot.get_option 'rubygems'
+  if !ENV['TRUFFLERUBY_RESILIENT_GEM_HOME'].to_s.empty?
+    ENV.delete 'GEM_HOME'
+    ENV.delete 'GEM_PATH'
+    ENV.delete 'GEM_ROOT'
+  end
+
   begin
     Truffle::Boot.print_time_metric :'before-rubygems'
     begin


### PR DESCRIPTION
* So it applies no matter how TruffleRuby is started,
  no matter which launcher is used.
* This functionality was lost with the new GraalVM launcher.