### PR TITLE
Test running with Graal on Java 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ Announcements about GraalVM, including TruffleRuby, are made on the
 
 ## System Compatibility
 
-TruffleRuby is only compatible with Java 8, unless you are following specific
-instructions for Java 9.
-
 TruffleRuby is actively tested on these systems:
 
 * Ubuntu 16.04 LTS

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -522,7 +522,7 @@
     # {name: "ruby-test-compiler-graal-vm-snapshot"} + linux_gate + $.graal_vm_snapshot + {run: jt(["test", "compiler"])},
 
     {name: "ruby-test-compiler-graal-core-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: jt(["test", "compiler"])},
-    {name: "ruby-test-compiler-standalone-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: jt(["bin/truffleruby", "-J-XX:+UnlockExperimentalVMOptions", "-J-XX:+EnableJVMCI", "-J--module-path=../graal/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:../graal/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar:../graal/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar", "-J-Dgraal.TraceTruffleCompilation=true", "-e", "raise 'no graal' unless Truffle.graal?"])},
+    {name: "ruby-test-compiler-standalone-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: ["bin/truffleruby", "-J-XX:+UnlockExperimentalVMOptions", "-J-XX:+EnableJVMCI", "-J--module-path=../graal/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:../graal/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar:../graal/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar", "-J-Dgraal.TraceTruffleCompilation=true", "-e", "raise 'no graal' unless Truffle.graal?"]},
   ],
 
   local other_rubies = [

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -497,6 +497,18 @@
     { name: "truffle", args: [":truffle"] },
   ],
 
+  local compiler_standalone_java9 = labsjdk9 + {
+    run: [
+      [
+        "bin/truffleruby",
+        "-J-XX:+UnlockExperimentalVMOptions", "-J-XX:+EnableJVMCI",
+        "-J--module-path=../graal/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:../graal/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar",
+        "-J--upgrade-module-path=../graal/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar",
+        "-e", "raise 'no graal' unless Truffle.graal?"
+      ]
+    ]
+  },
+
   tests_jobs: [
     {name: "ruby-deploy-and-test-fast-linux"} + linux_gate + $.deploy_and_test_fast,
     {name: "ruby-deploy-and-test-fast-darwin"} + $.common_darwin + $.gate_caps_darwin + $.deploy_and_test_fast_darwin,
@@ -522,7 +534,7 @@
     # {name: "ruby-test-compiler-graal-vm-snapshot"} + linux_gate + $.graal_vm_snapshot + {run: jt(["test", "compiler"])},
 
     {name: "ruby-test-compiler-graal-core-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: jt(["test", "compiler"])},
-    {name: "ruby-test-compiler-standalone-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: ["bin/truffleruby", "-J-XX:+UnlockExperimentalVMOptions", "-J-XX:+EnableJVMCI", "-J--module-path=../graal/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:../graal/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar:../graal/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar", "-J-Dgraal.TraceTruffleCompilation=true", "-e", "raise 'no graal' unless Truffle.graal?"]},
+    {name: "ruby-test-compiler-standalone-java9"} + linux_gate + $.graal_core + compiler_standalone_java9,
   ],
 
   local other_rubies = [

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -521,6 +521,7 @@
     # {name: "ruby-test-compiler-graal-enterprise"} + linux_gate + $.graal_enterprise + {run: jt(["test", "compiler"])},
     # {name: "ruby-test-compiler-graal-vm-snapshot"} + linux_gate + $.graal_vm_snapshot + {run: jt(["test", "compiler"])},
 
+    {name: "ruby-test-compiler-graal-core-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: jt(["test", "compiler"])},
     {name: "ruby-test-compiler-standalone-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: jt(["bin/truffleruby", "-J-XX:+UnlockExperimentalVMOptions", "-J-XX:+EnableJVMCI", "-J--module-path=../graal/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:../graal/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar:../graal/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar", "-J-Dgraal.TraceTruffleCompilation=true", "-e", "raise 'no graal' unless Truffle.graal?"])},
   ],
 

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -520,6 +520,8 @@
     {name: "ruby-test-compiler-graal-core"} + linux_gate + $.graal_core + {run: jt(["test", "compiler"])},
     # {name: "ruby-test-compiler-graal-enterprise"} + linux_gate + $.graal_enterprise + {run: jt(["test", "compiler"])},
     # {name: "ruby-test-compiler-graal-vm-snapshot"} + linux_gate + $.graal_vm_snapshot + {run: jt(["test", "compiler"])},
+
+    {name: "ruby-test-compiler-standalone-java9"} + linux_gate + $.graal_core + labsjdk9 + {run: jt(["bin/truffleruby", "-J-XX:+UnlockExperimentalVMOptions", "-J-XX:+EnableJVMCI", "-J--module-path=../graal/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:../graal/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar:../graal/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar", "-J-Dgraal.TraceTruffleCompilation=true", "-e", "raise 'no graal' unless Truffle.graal?"])},
   ],
 
   local other_rubies = [

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -4,7 +4,7 @@
 
 You will need:
 
-* Java JDK 8
+* Java JDK 8 or 9
 * Ruby 2
 * [LLVM](../user/installing-llvm.md)
 * [`libssl`](../user/installing-libssl.md)

--- a/doc/user/using-java9.md
+++ b/doc/user/using-java9.md
@@ -18,7 +18,8 @@ $ export JAVACMD=...java 9...
 $ bin/truffleruby \
     -J-XX:+UnlockExperimentalVMOptions \
     -J-XX:+EnableJVMCI \
-    -J--module-path=$GRAAL_REPO/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:$GRAAL_REPO/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar:$GRAAL_REPO/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar \
+    -J--module-path=$GRAAL_REPO/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:$GRAAL_REPO/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar \
+    -J--upgrade-module-path=$GRAAL_REPO/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar \
     -e 'p Truffle.graal?'
 ```
 
@@ -30,8 +31,8 @@ As another check you can run a loop and see that it is compiled.
 $ bin/truffleruby \
     -J-XX:+UnlockExperimentalVMOptions \
     -J-XX:+EnableJVMCI \
-    -J--module-path=$GRAAL_REPO/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:$GRAAL_REPO/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar:$GRAAL_REPO/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar \
-    -J-Dgraal.TraceTruffleCompilation=true \
+    -J--module-path=$GRAAL_REPO/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:$GRAAL_REPO/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar \
+    -J--upgrade-module-path=$GRAAL_REPO/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar \
     -e 'loop { 14 + 2}'
 [truffle] opt done ......
 ```

--- a/doc/user/using-java9.md
+++ b/doc/user/using-java9.md
@@ -10,7 +10,7 @@ moment we only document it for interest.
 To run on Java 9, Graal needs to be built with Java 9 and there is no binary
 distribution of GraalVM based on Java 9 so you will need to
 [build Graal yourself](../contributor/building-graal.md), using Java 9 as the
-JDK. TruffleRuby itself needs to be built with Java 8 as normal.
+JDK. You should also build TruffleRuby with the same JDK.
 
 ```
 $ GRAAL_REPO=...path to graal repository built with JDK 9...
@@ -35,4 +35,15 @@ $ bin/truffleruby \
     -J--upgrade-module-path=$GRAAL_REPO/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar \
     -e 'loop { 14 + 2}'
 [truffle] opt done ......
+```
+
+You may see this warning caused by `jnr-posix`, but it can be safely ignored
+for now.
+
+```
+WARNING: An illegal reflective access operation has occurred
+WARNING: Illegal reflective access by jnr.posix.JavaLibCHelper (file:.../truffleruby.jar) to method sun.nio.ch.SelChImpl.getFD()
+WARNING: Please consider reporting this to the maintainers of jnr.posix.JavaLibCHelper
+WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+WARNING: All illegal access operations will be denied in a future release
 ```


### PR DESCRIPTION
Tests both in `jt` and as if you were running on a standalone JRE 9.