### PR TITLE
Recompile spec cexts if ruby.su changed

### DIFF
--- a/spec/ruby/optional/capi/spec_helper.rb
+++ b/spec/ruby/optional/capi/spec_helper.rb
@@ -23,11 +23,18 @@ def compile_extension(name)
   ext = "#{name}_spec"
   lib = "#{object_path}/#{ext}.#{RbConfig::CONFIG['DLEXT']}"
   ruby_header = "#{RbConfig::CONFIG['rubyhdrdir']}/ruby.h"
+  libruby_so = RbConfig::CONFIG['LIBRUBY_SO']
+  ruby_library = "#{RbConfig::CONFIG['libdir']}/#{libruby_so}"
+  unless libruby_so and File.exist?(ruby_library)
+    # Statically-compiled lib in the binary
+    ruby_library = RbConfig.ruby
+  end
 
   return lib if File.exist?(lib) and
                 File.mtime(lib) > File.mtime("#{extension_path}/rubyspec.h") and
                 File.mtime(lib) > File.mtime("#{extension_path}/#{ext}.c") and
                 File.mtime(lib) > File.mtime(ruby_header) and
+                File.mtime(lib) > File.mtime(ruby_library) and
                 true            # sentinel
 
   # Copy needed source files to tmpdir

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -88,6 +88,7 @@ module RbConfig
       'libdirname'        => 'libdir',
       'LIBRUBY'           => '',
       'LIBRUBY_A'         => '',
+      'LIBRUBY_SO'        => 'cext/ruby.su',
       'LIBRUBYARG'        => '',
       'NULLCMD'           => ':',
       'optflags'          => '',


### PR DESCRIPTION
cc @rschatz

The value for `LIBRUBY_SO` is a bit hacky as it's not a name but includes a sub-directory as well.
In MRI, when libruby.so exists, it's always directly under libdir (that `PREFIX/lib`).
Maybe we should just have `lib/ruby.su` instead of `lib/cext/ruby.su` ?