### PR TITLE
Prepare for name-based LLVM interop.

### DIFF
--- a/lib/cext/ruby/io.h
+++ b/lib/cext/ruby/io.h
@@ -85,7 +85,7 @@ typedef struct rb_io_t {
 /* #define FMODE_INET                  0x00400000 */
 /* #define FMODE_INET6                 0x00800000 */
 
-#define GetOpenFile(file, pointer) ( (pointer) = truffle_managed_malloc(sizeof(rb_io_t)), (pointer)->mode = FIX2INT(rb_iv_get(file, "@mode")), (pointer)->fd = FIX2INT(rb_iv_get(file, "@descriptor")), rb_io_check_closed(pointer) )
+#define GetOpenFile(file, pointer) rb_io_check_closed((pointer) = truffle_invoke(RUBY_CEXT, "GetOpenFile", file))
 
 
 #define RB_IO_BUFFER_INIT(buf) do {\

--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -111,6 +111,14 @@ module Truffle::CExt
       data_holder.data = value
     end
 
+    def data
+      data_holder.data
+    end
+
+    def data=(value)
+      data_holder.data = value
+    end
+
     def data_holder
       Truffle::CExt.hidden_variable_get(@object, :data_holder)
     end
@@ -127,6 +135,10 @@ module Truffle::CExt
 
     def [](index)
       raise unless index == NAME_FIELD_INDEX
+      @encoding.name
+    end
+
+    def name
       @encoding.name
     end
   end

--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -143,6 +143,32 @@ module Truffle::CExt
     end
   end
 
+  class RbIO
+    MODE_FIELD_INDEX = 0
+    FD_FIELD_INDEX = 1
+
+    def initialize(io)
+      @io = io
+    end
+
+    def [](index)
+      if index == MODE_FIELD_INDEX
+        mode
+      else
+        raise unless index == FD_FIELD_INDEX
+        fd
+      end
+    end
+
+    def mode
+      @io.instance_variable_get(:@mode)
+    end
+
+    def fd
+      @io.instance_variable_get(:@descriptor)
+    end
+  end
+
   class RStringPtr
     attr_reader :string
 
@@ -1904,6 +1930,10 @@ module Truffle::CExt
   def rb_to_encoding(encoding)
     encoding = Encoding.find(encoding.to_str) unless encoding.is_a?(Encoding)
     RbEncoding.new(encoding)
+  end
+
+  def GetOpenFile(io)
+    RbIO.new(io)
   end
 
   def rb_enc_from_encoding(rb_encoding)


### PR DESCRIPTION
In an upcoming Sulong change, interop to foreign structs (e.g. Ruby objects) will work with member names instead of memory indices. This change prepares for that by adding name-based getters and setters to native wrapper objects.

The indexed getters and setters are kept for backwards compatibility with older sulong versions.