### PR TITLE
Ignore fewer warnings in C exts

### DIFF
--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -145,7 +145,6 @@ typedef char ruby_check_sizeof_voidp[SIZEOF_VOIDP == sizeof(void*) ? 1 : -1];
 #define PRI_VALUE_PREFIX        "l"
 #define PRI_LONG_PREFIX         "l"
 #define PRI_64_PREFIX           PRI_LONG_PREFIX
-#define RUBY_PRI_VALUE_MARK     ""
 #define PRIdVALUE               PRI_VALUE_PREFIX"d"
 #define PRIoVALUE               PRI_VALUE_PREFIX"o"
 #define PRIuVALUE               PRI_VALUE_PREFIX"u"
@@ -430,10 +429,16 @@ enum ruby_special_consts {
     RUBY_SPECIAL_SHIFT  = 8
 };
 
-#define Qfalse ((VALUE)RUBY_Qfalse)
-#define Qtrue  ((VALUE)RUBY_Qtrue)
-#define Qnil   ((VALUE)RUBY_Qnil)
-#define Qundef ((VALUE)RUBY_Qundef)	/* undefined value for placeholder */
+VALUE rb_tr_get_undef(void);
+VALUE rb_tr_get_true(void);
+VALUE rb_tr_get_false(void);
+VALUE rb_tr_get_nil(void);
+
+#define Qfalse rb_tr_get_false()
+#define Qtrue rb_tr_get_true()
+#define Qnil rb_tr_get_nil()
+#define Qundef rb_tr_get_undef()
+
 #define IMMEDIATE_MASK RUBY_IMMEDIATE_MASK
 #define FIXNUM_FLAG RUBY_FIXNUM_FLAG
 #if USE_FLONUM

--- a/lib/cext/truffle/constants.h
+++ b/lib/cext/truffle/constants.h
@@ -1,9 +1,5 @@
 // From ./tool/generate-cext-constants.rb
 
-VALUE rb_tr_get_undef(void);
-VALUE rb_tr_get_true(void);
-VALUE rb_tr_get_false(void);
-VALUE rb_tr_get_nil(void);
 VALUE rb_tr_get_Array(void);
 VALUE rb_tr_get_Bignum(void);
 VALUE rb_tr_get_Class(void);
@@ -75,10 +71,6 @@ VALUE rb_tr_get_rs(void);
 VALUE rb_tr_get_output_rs(void);
 VALUE rb_tr_get_default_rs(void);
 
-#define Qundef rb_tr_get_undef()
-#define Qtrue rb_tr_get_true()
-#define Qfalse rb_tr_get_false()
-#define Qnil rb_tr_get_nil()
 #define rb_cArray rb_tr_get_Array()
 #define rb_cBignum rb_tr_get_Bignum()
 #define rb_cClass rb_tr_get_Class()

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -12,9 +12,6 @@
  * as described in the file BSDL included with TruffleRuby.
  */
 
-// Needed for vasprintf
-#define _GNU_SOURCE
-
 #include <ruby.h>
 #include <ruby/debug.h>
 #include <ruby/encoding.h>

--- a/src/main/c/openssl/extconf.rb
+++ b/src/main/c/openssl/extconf.rb
@@ -28,6 +28,9 @@ have_flags = %w[
 
 $CFLAGS += " #{have_flags.map { |h| "-DHAVE_#{h}" }.join(' ')}"
 
+# The openssl C extension uses macros expanding to defined
+$CFLAGS += ' -Wno-expansion-to-defined'
+
 MAC = `uname`.chomp == 'Darwin'
 
 if MAC && !ENV['OPENSSL_PREFIX']

--- a/src/main/c/zlib/extconf.rb
+++ b/src/main/c/zlib/extconf.rb
@@ -6,4 +6,7 @@
 #
 
 require 'mkmf'
+
+have_type('z_crc_t', 'zlib.h')
+
 create_makefile('zlib')

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -171,7 +171,6 @@ module RbConfig
                     '-Wno-int-conversion',                    # MRI has VALUE defined as long while we have it as void*
                     '-Wno-int-to-pointer-cast',               # Same as above
                     '-Wno-unused-value',                      # RB_GC_GUARD leaves
-                    '-Wno-incompatible-pointer-types',        # We define VALUE as void* rather than uint32_t
                     '-Wno-expansion-to-defined',              # The openssl C extension uses macros expanding to defined
                     '-ferror-limit=500'].join(' ')
   cflags         =  "#{linkflags} -c -emit-llvm"

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -170,7 +170,6 @@ module RbConfig
                     '-Wno-unknown-warning-option',            # If we're on an earlier version of clang without a warning option, ignore it
                     '-Wno-int-conversion',                    # MRI has VALUE defined as long while we have it as void*
                     '-Wno-int-to-pointer-cast',               # Same as above
-                    '-Wno-macro-redefined',                   # We redefine __DARWIN_ALIAS_C
                     '-Wno-unused-value',                      # RB_GC_GUARD leaves
                     '-Wno-incompatible-pointer-types',        # We define VALUE as void* rather than uint32_t
                     '-Wno-expansion-to-defined',              # The openssl C extension uses macros expanding to defined

--- a/src/main/ruby/core/rbconfig.rb
+++ b/src/main/ruby/core/rbconfig.rb
@@ -171,7 +171,6 @@ module RbConfig
                     '-Wno-int-conversion',                    # MRI has VALUE defined as long while we have it as void*
                     '-Wno-int-to-pointer-cast',               # Same as above
                     '-Wno-unused-value',                      # RB_GC_GUARD leaves
-                    '-Wno-expansion-to-defined',              # The openssl C extension uses macros expanding to defined
                     '-ferror-limit=500'].join(' ')
   cflags         =  "#{linkflags} -c -emit-llvm"
   # We do not have a launcher if we are embedded with the polyglot API

--- a/tool/generate-cext-constants.rb
+++ b/tool/generate-cext-constants.rb
@@ -125,14 +125,14 @@ File.open("lib/cext/truffle/constants.h", "w") do |f|
   f.puts "// From #{__FILE__}"
   f.puts
 
-  constants.each do |_, name, _|
-    f.puts "VALUE rb_tr_get_#{name}(void);"
+  constants.each do |macro_name, name, _|
+    f.puts "VALUE rb_tr_get_#{name}(void);" unless macro_name[0] == 'Q'
   end
 
   f.puts
 
   constants.each do |macro_name, name, _|
-    f.puts "#define #{macro_name} rb_tr_get_#{name}()"
+    f.puts "#define #{macro_name} rb_tr_get_#{name}()" unless macro_name[0] == 'Q'
   end
 end
 


### PR DESCRIPTION
Enable macro redefinition warnings and fix them:
* _GNU_SOURCE is already defined by config.h.
* RUBY_PRI_VALUE_MARK was defined twice.
* Qfalse, Qtrue, Qnil and Qundef should be defined once.