### PR TITLE
Refactor backtrace creation to fix disabled backtrace handling.

### DIFF
--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -172,10 +172,8 @@ public class CoreExceptions {
     }
 
     public DynamicObject argumentError(Rope message, Node currentNode, Throwable javaThrowable) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getArgumentErrorClass(),
-                StringOperations.createString(context, message),
-                context.getCallStack().getBacktrace(currentNode, javaThrowable));
+        DynamicObject exceptionClass = context.getCoreLibrary().getArgumentErrorClass();
+        return ExceptionOperations.createRubyException(context, exceptionClass, StringOperations.createString(context, message), currentNode, javaThrowable);
     }
 
     // RuntimeError
@@ -200,30 +198,25 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject runtimeError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getRuntimeErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getRuntimeErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     // SystemStackError
 
     @TruffleBoundary
     public DynamicObject systemStackErrorStackLevelTooDeep(Node currentNode, StackOverflowError javaThrowable) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getSystemStackErrorClass(),
-                coreStrings().STACK_LEVEL_TOO_DEEP.createInstance(),
-                context.getCallStack().getBacktrace(currentNode, javaThrowable));
+        DynamicObject exceptionClass = context.getCoreLibrary().getSystemStackErrorClass();
+        return ExceptionOperations.createRubyException(context, exceptionClass, coreStrings().STACK_LEVEL_TOO_DEEP.createInstance(), currentNode, javaThrowable);
     }
 
     // NoMemoryError
 
     @TruffleBoundary
     public DynamicObject noMemoryError(Node currentNode, OutOfMemoryError javaThrowable) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getNoMemoryErrorClass(),
-                coreStrings().FAILED_TO_ALLOCATE_MEMORY.createInstance(),
-                context.getCallStack().getBacktrace(currentNode, javaThrowable));
+        DynamicObject exceptionClass = context.getCoreLibrary().getNoMemoryErrorClass();
+        return ExceptionOperations.createRubyException(context, exceptionClass, coreStrings().FAILED_TO_ALLOCATE_MEMORY.createInstance(), currentNode, javaThrowable);
     }
 
     // Errno
@@ -270,10 +263,10 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject mathDomainError(String method, Node currentNode) {
-        return ExceptionOperations.createSystemCallError(
-                context.getCoreLibrary().getErrnoClass(Errno.EDOM),
-                StringOperations.createString(context, StringOperations.encodeRope(StringUtils.format("Numerical argument is out of domain - \"%s\"", method), UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode), Errno.EDOM.intValue());
+        DynamicObject exceptionClass = context.getCoreLibrary().getErrnoClass(Errno.EDOM);
+        Rope rope = StringOperations.encodeRope(StringUtils.format("Numerical argument is out of domain - \"%s\"", method), UTF8Encoding.INSTANCE);
+        DynamicObject errorMessage = StringOperations.createString(context, rope);
+        return ExceptionOperations.createSystemCallError(context, exceptionClass, errorMessage, currentNode, Errno.EDOM.intValue());
     }
 
     @TruffleBoundary
@@ -292,10 +285,7 @@ public class CoreExceptions {
         String fullMessage = StringUtils.format("%s%s", errnoObj.description(), extraMessage);
         DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(fullMessage, UTF8Encoding.INSTANCE));
 
-        return ExceptionOperations.createSystemCallError(
-            errnoClass,
-            errorMessage,
-            context.getCallStack().getBacktrace(currentNode), errno);
+        return ExceptionOperations.createSystemCallError(context, errnoClass, errorMessage, currentNode, errno);
     }
 
     // IndexError
@@ -307,10 +297,9 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject indexError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getIndexErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getIndexErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     @TruffleBoundary
@@ -332,10 +321,9 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject localJumpError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getLocalJumpErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getLocalJumpErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     public DynamicObject noBlockGiven(Node currentNode) {
@@ -480,10 +468,9 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject typeError(String message, Node currentNode, Throwable javaThrowable) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getTypeErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode, javaThrowable));
+        DynamicObject exceptionClass = context.getCoreLibrary().getTypeErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, javaThrowable);
     }
 
     // NameError
@@ -580,8 +567,9 @@ public class CoreExceptions {
     @TruffleBoundary
     public DynamicObject nameError(String message, Object receiver, String name, Node currentNode) {
         final DynamicObject messageString = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
-        final Backtrace backtrace = context.getCallStack().getBacktrace(currentNode);
-        showExceptionIfDebug(context.getCoreLibrary().getNameErrorClass(), messageString, backtrace);
+        DynamicObject exceptionClass = context.getCoreLibrary().getNameErrorClass();
+        final Backtrace backtrace = context.getCallStack().getBacktraceForException(currentNode, exceptionClass);
+        showExceptionIfDebug(exceptionClass, messageString, backtrace);
         return Layouts.NAME_ERROR.createNameError(
                 context.getCoreLibrary().getNameErrorFactory(),
                 messageString,
@@ -596,8 +584,9 @@ public class CoreExceptions {
     public DynamicObject noMethodError(String message, Object receiver, String name, Object[] args, Node currentNode) {
         final DynamicObject messageString = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
         final DynamicObject argsArray =  createArray(context, args, args.length);
-        final Backtrace backtrace = context.getCallStack().getBacktrace(currentNode);
-        showExceptionIfDebug(context.getCoreLibrary().getNoMethodErrorClass(), messageString, backtrace);
+        DynamicObject exceptionClass = context.getCoreLibrary().getNoMethodErrorClass();
+        final Backtrace backtrace = context.getCallStack().getBacktraceForException(currentNode, exceptionClass);
+        showExceptionIfDebug(exceptionClass, messageString, backtrace);
         return Layouts.NO_METHOD_ERROR.createNoMethodError(
                 context.getCoreLibrary().getNoMethodErrorFactory(),
                 messageString,
@@ -610,8 +599,9 @@ public class CoreExceptions {
     @TruffleBoundary
     public DynamicObject noSuperMethodOutsideMethodError(Node currentNode) {
         final DynamicObject messageString = StringOperations.createString(context, StringOperations.encodeRope("super called outside of method", UTF8Encoding.INSTANCE));
-        final Backtrace backtrace = context.getCallStack().getBacktrace(currentNode);
-        showExceptionIfDebug(context.getCoreLibrary().getNameErrorClass(), messageString, backtrace);
+        DynamicObject exceptionClass = context.getCoreLibrary().getNameErrorClass();
+        final Backtrace backtrace = context.getCallStack().getBacktraceForException(currentNode, exceptionClass);
+        showExceptionIfDebug(exceptionClass, messageString, backtrace);
         // TODO BJF Jul 21, 2016 Review to add receiver
         DynamicObject noMethodError = Layouts.NAME_ERROR.createNameError(
                 context.getCoreLibrary().getNoMethodErrorFactory(),
@@ -657,7 +647,8 @@ public class CoreExceptions {
     @TruffleBoundary
     public DynamicObject loadError(String message, String path, Node currentNode) {
         DynamicObject messageString = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
-        DynamicObject loadError = ExceptionOperations.createRubyException(context.getCoreLibrary().getLoadErrorClass(), messageString, context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getLoadErrorClass();
+        DynamicObject loadError = ExceptionOperations.createRubyException(context, exceptionClass, messageString, currentNode, null);
         if("openssl.so".equals(path)){
             // This is a workaround for the rubygems/security.rb file expecting the error path to be openssl
             path = "openssl";
@@ -679,20 +670,19 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject zeroDivisionError(Node currentNode, ArithmeticException exception) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getZeroDivisionErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope("divided by 0", UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode, exception));
+        DynamicObject exceptionClass = context.getCoreLibrary().getZeroDivisionErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope("divided by 0", UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, exception);
     }
 
     // NotImplementedError
 
     @TruffleBoundary
     public DynamicObject notImplementedError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getNotImplementedErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(StringUtils.format("Method %s not implemented", message),
-                        UTF8Encoding.INSTANCE)), context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getNotImplementedErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(StringUtils.format("Method %s not implemented", message),
+                UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     // SyntaxError
@@ -704,20 +694,18 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject syntaxError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getSyntaxErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getSyntaxErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     // FloatDomainError
 
     @TruffleBoundary
     public DynamicObject floatDomainError(String value, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getFloatDomainErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(value, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getFloatDomainErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(value, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     public DynamicObject floatDomainErrorResultsToNaN(Node currentNode) {
@@ -740,10 +728,9 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject ioError(String fileName, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getIOErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(StringUtils.format("Error reading file -  %s", fileName), UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getIOErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(StringUtils.format("Error reading file -  %s", fileName), UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     // RangeError
@@ -791,10 +778,9 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject rangeError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getRangeErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getRangeErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     // InternalError
@@ -822,20 +808,18 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject internalErrorFullMessage(String fullMessage, Node currentNode, Throwable javaThrowable) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getRubyTruffleErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(fullMessage, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode, javaThrowable));
+        DynamicObject exceptionClass = context.getCoreLibrary().getRubyTruffleErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(fullMessage, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, javaThrowable);
     }
 
     // RegexpError
 
     @TruffleBoundary
     public DynamicObject regexpError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getRegexpErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getRegexpErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     // Encoding conversion errors.
@@ -852,18 +836,15 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject encodingCompatibilityError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getEncodingCompatibilityErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getEncodingCompatibilityErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     @TruffleBoundary
     public DynamicObject encodingUndefinedConversionError(Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getEncodingUndefinedConversionErrorClass(),
-                coreStrings().REPLACEMENT_CHARACTER_SETUP_FAILED.createInstance(),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getEncodingUndefinedConversionErrorClass();
+        return ExceptionOperations.createRubyException(context, exceptionClass, coreStrings().REPLACEMENT_CHARACTER_SETUP_FAILED.createInstance(), currentNode, null);
     }
 
 
@@ -871,10 +852,9 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject fiberError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getFiberErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getFiberErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     public DynamicObject deadFiberCalledError(Node currentNode) {
@@ -889,10 +869,9 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject threadError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getThreadErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getThreadErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     public DynamicObject threadErrorKilledThread(Node currentNode) {
@@ -915,38 +894,45 @@ public class CoreExceptions {
 
     @TruffleBoundary
     public DynamicObject securityError(String message, Node currentNode) {
-        return ExceptionOperations.createRubyException(
-                context.getCoreLibrary().getSecurityErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getSecurityErrorClass();
+        DynamicObject errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
     }
 
     // SystemCallError
 
     @TruffleBoundary
     public DynamicObject systemCallError(String message, int errno, Node currentNode) {
-        return ExceptionOperations.createSystemCallError(
-                context.getCoreLibrary().getSystemCallErrorClass(),
-                StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE)),
-                context.getCallStack().getBacktrace(currentNode), errno);
+        DynamicObject exceptionClass = context.getCoreLibrary().getSystemCallErrorClass();
+        DynamicObject errorMessage;
+        if (message == null) {
+            errorMessage = context.getCoreLibrary().getNil();
+        } else {
+            errorMessage = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
+        }
+        return ExceptionOperations.createSystemCallError(context, exceptionClass, errorMessage, currentNode, errno);
     }
 
     // IO::EAGAINWaitReadable, IO::EAGAINWaitWritable
 
     @TruffleBoundary
     public DynamicObject eAGAINWaitReadable(Node currentNode) {
+        DynamicObject exceptionClass = context.getCoreLibrary().getEagainWaitReadable();
         return ExceptionOperations.createSystemCallError(
-                context.getCoreLibrary().getEagainWaitReadable(),
+                context,
+                exceptionClass,
                 coreStrings().RESOURCE_TEMP_UNAVAIL_READ.createInstance(),
-                context.getCallStack().getBacktrace(currentNode), Errno.EAGAIN.intValue());
+                currentNode, Errno.EAGAIN.intValue());
     }
 
     @TruffleBoundary
     public DynamicObject eAGAINWaitWritable(Node currentNode) {
+        DynamicObject exceptionClass = context.getCoreLibrary().getEagainWaitWritable();
         return ExceptionOperations.createSystemCallError(
-                context.getCoreLibrary().getEagainWaitWritable(),
+                context,
+                exceptionClass,
                 coreStrings().RESOURCE_TEMP_UNAVAIL_WRITE.createInstance(),
-                context.getCallStack().getBacktrace(currentNode), Errno.EAGAIN.intValue());
+                currentNode, Errno.EAGAIN.intValue());
     }
 
     // SystemExit
@@ -954,7 +940,8 @@ public class CoreExceptions {
     @TruffleBoundary
     public DynamicObject systemExit(int exitStatus, Node currentNode) {
         final DynamicObject message = StringOperations.createString(context, StringOperations.encodeRope("exit", UTF8Encoding.INSTANCE));
-        final DynamicObject systemExit = ExceptionOperations.createRubyException(context.getCoreLibrary().getSystemExitClass(), message, context.getCallStack().getBacktrace(currentNode));
+        DynamicObject exceptionClass = context.getCoreLibrary().getSystemExitClass();
+        final DynamicObject systemExit = ExceptionOperations.createRubyException(context, exceptionClass, message, currentNode, null);
         systemExit.define("@status", exitStatus);
         return systemExit;
     }

--- a/src/main/java/org/truffleruby/core/exception/ExceptionNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/ExceptionNodes.java
@@ -115,10 +115,8 @@ public abstract class ExceptionNodes {
         @TruffleBoundary
         @Specialization
         public DynamicObject captureBacktrace(DynamicObject exception, int offset) {
-            final Backtrace backtrace = getContext().getCallStack().getBacktrace(
-                    this,
-                    offset,
-                    exception);
+            DynamicObject exceptionClass = Layouts.BASIC_OBJECT.getLogicalClass(exception);
+            final Backtrace backtrace = getContext().getCallStack().getBacktraceForException(this, offset, exceptionClass);
             Layouts.EXCEPTION.setBacktrace(exception, backtrace);
             return nil();
         }

--- a/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
+++ b/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
@@ -9,8 +9,9 @@
  */
 package org.truffleruby.core.exception;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.object.DynamicObject;
+import java.util.EnumSet;
+import java.util.List;
+
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
@@ -21,8 +22,9 @@ import org.truffleruby.language.backtrace.Backtrace;
 import org.truffleruby.language.backtrace.BacktraceFormatter;
 import org.truffleruby.language.backtrace.BacktraceFormatter.FormattingFlags;
 
-import java.util.EnumSet;
-import java.util.List;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.object.DynamicObject;
 
 public abstract class ExceptionOperations {
 
@@ -63,18 +65,17 @@ public abstract class ExceptionOperations {
 
     // because the factory is not constant
     @TruffleBoundary
-    public static DynamicObject createRubyException(DynamicObject rubyClass, Object message, Backtrace backtrace) {
-        final RubyContext context = Layouts.MODULE.getFields(rubyClass).getContext();
+    public static DynamicObject createRubyException(RubyContext context, DynamicObject rubyClass, Object message, Node node, Throwable javaException) {
+        Backtrace backtrace = context.getCallStack().getBacktraceForException(node, rubyClass, javaException);
         context.getCoreExceptions().showExceptionIfDebug(rubyClass, message, backtrace);
         return Layouts.EXCEPTION.createException(Layouts.CLASS.getInstanceFactory(rubyClass), message, backtrace);
     }
 
     // because the factory is not constant
     @TruffleBoundary
-    public static DynamicObject createSystemCallError(DynamicObject rubyClass, Object message, Backtrace backtrace, int errno) {
-        final RubyContext context = Layouts.MODULE.getFields(rubyClass).getContext();
+    public static DynamicObject createSystemCallError(RubyContext context, DynamicObject rubyClass, Object message, Node node, int errno) {
+        Backtrace backtrace = context.getCallStack().getBacktraceForException(node, rubyClass);
         context.getCoreExceptions().showExceptionIfDebug(rubyClass, message, backtrace);
         return Layouts.SYSTEM_CALL_ERROR.createSystemCallError(Layouts.CLASS.getInstanceFactory(rubyClass), message, backtrace, errno);
     }
-
 }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -278,7 +278,7 @@ public abstract class KernelNodes {
         }
 
         private DynamicObject innerCallerLocations(int omit, int length) {
-            final Backtrace backtrace = getContext().getCallStack().getBacktrace(this, 1 + omit, true, null);
+            final Backtrace backtrace = getContext().getCallStack().getBacktrace(this, 1 + omit, true);
             // Build the description of Thread::Backtrace::Location eagerly since backtrace
             // formatting relies on accessing activations above to show a user file path for core
             // methods.

--- a/src/main/java/org/truffleruby/core/rubinius/IOBufferNodes.java
+++ b/src/main/java/org/truffleruby/core/rubinius/IOBufferNodes.java
@@ -37,13 +37,6 @@
  */
 package org.truffleruby.core.rubinius;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.object.DynamicObject;
-import com.oracle.truffle.api.profiles.BranchProfile;
-import jnr.constants.platform.Errno;
 import org.truffleruby.Layouts;
 import org.truffleruby.builtins.CoreClass;
 import org.truffleruby.builtins.CoreMethod;
@@ -51,7 +44,6 @@ import org.truffleruby.builtins.Primitive;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.collections.ByteArrayBuilder;
-import org.truffleruby.core.exception.ExceptionOperations;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeBuilder;
 import org.truffleruby.core.rope.RopeNodes;
@@ -59,6 +51,15 @@ import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.objects.AllocateObjectNode;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.profiles.BranchProfile;
+
+import jnr.constants.platform.Errno;
 
 @CoreClass("IO::InternalBuffer")
 public abstract class IOBufferNodes {
@@ -166,7 +167,7 @@ public abstract class IOBufferNodes {
                         getContext().getSafepointManager().pollFromBlockingCall(this);
                         continue;
                     } else {
-                        throw new RaiseException(ExceptionOperations.createSystemCallError(coreLibrary().getErrnoClass(Errno.valueOf(errno)), nil(), null, errno));
+                        throw new RaiseException(getContext().getCoreExceptions().errnoError(errno, this));
                     }
                 } else {
                     break;

--- a/src/main/java/org/truffleruby/core/string/ConvertBytes.java
+++ b/src/main/java/org/truffleruby/core/string/ConvertBytes.java
@@ -510,7 +510,6 @@ public class ConvertBytes {
     /** rb_invalid_str
      *
      */
-    @TruffleBoundary
     private void invalidString(String type) {
         throw new RaiseException(
                 context.getCoreExceptions().argumentErrorInvalidValue(_str, type, node));

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3938,7 +3938,6 @@ public abstract class StringNodes {
     @Primitive(name = "string_to_inum", lowerFixnum = 1)
     public static abstract class StringToInumPrimitiveNode extends PrimitiveArrayArgumentsNode {
 
-        @TruffleBoundary
         @Specialization
         public Object stringToInum(DynamicObject string, int fixBase, boolean strict,
                                    @Cached("create(getSourceIndexLength())") FixnumOrBignumNode fixnumOrBignumNode) {

--- a/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
@@ -573,7 +573,8 @@ public abstract class ThreadNodes {
 
             context.getSafepointManager().pauseRubyThreadAndExecute(rubyThread, currentNode, (currentThread, currentNode1) -> {
                 if (Layouts.EXCEPTION.getBacktrace(exception) == null) {
-                    Backtrace backtrace = context.getCallStack().getBacktrace(currentNode1);
+                    DynamicObject exceptionClass = Layouts.BASIC_OBJECT.getLogicalClass(exception);
+                    Backtrace backtrace = context.getCallStack().getBacktraceForException(currentNode1, exceptionClass);
                     Layouts.EXCEPTION.setBacktrace(exception, backtrace);
                 }
                 throw new RaiseException(exception);

--- a/src/main/java/org/truffleruby/platform/posix/TrufflePosixHandler.java
+++ b/src/main/java/org/truffleruby/platform/posix/TrufflePosixHandler.java
@@ -9,16 +9,15 @@
  */
 package org.truffleruby.platform.posix;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import jnr.constants.platform.Errno;
-import jnr.posix.POSIXHandler;
-import org.truffleruby.RubyContext;
-import org.truffleruby.core.exception.ExceptionOperations;
-import org.truffleruby.language.control.RaiseException;
-
 import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
+
+import org.truffleruby.RubyContext;
+import org.truffleruby.language.control.RaiseException;
+
+import jnr.constants.platform.Errno;
+import jnr.posix.POSIXHandler;
 
 public class TrufflePosixHandler implements POSIXHandler {
 
@@ -28,16 +27,10 @@ public class TrufflePosixHandler implements POSIXHandler {
         this.context = context;
     }
 
-    @TruffleBoundary
     @Override
     public void error(Errno errno, String methodName) {
         // TODO CS 17-Apr-15 - not specialised, no way to build a good stacktrace, missing content for error messages
-
-        throw new RaiseException(ExceptionOperations.createSystemCallError(
-                context.getCoreLibrary().getErrnoClass(errno),
-                context.getCoreLibrary().getNil(),
-                context.getCallStack().getBacktrace(null),
-                errno.intValue()));
+        throw new RaiseException(context.getCoreExceptions().errnoError(errno.intValue(), null));
     }
 
     @Override


### PR DESCRIPTION
Refactors our creation of ruby exceptions in Java to ensure we don't miss any cases where we should omit filling in the backtrace, and to separate out the logic for non-exception filling cases so we don't accidental omit it when we shouldn't.