### PR TITLE
Revert "Fix mkmf's have_type"

### DIFF
--- a/lib/mri/mkmf.rb
+++ b/lib/mri/mkmf.rb
@@ -577,8 +577,7 @@ MSG
   # [+opt+] a String which contains compiler options
   def try_compile(src, opt="", *opts, &b)
     with_werror(opt, *opts) {|_opt, *| try_do(src, cc_command(_opt), *opts, &b)} and
-      # Truffle: replace $OBJEXT with .o since that's what clang use when no -o is given
-      File.file?("#{CONFTEST}.o")
+      File.file?("#{CONFTEST}.#{$OBJEXT}")
   ensure
     MakeMakefile.rm_f "#{CONFTEST}*"
   end

--- a/lib/mri/mkmf.rb
+++ b/lib/mri/mkmf.rb
@@ -496,7 +496,8 @@ MSG
     conf = RbConfig::CONFIG.merge('hdrdir' => $hdrdir.quote, 'srcdir' => $srcdir.quote,
                                   'arch_hdrdir' => $arch_hdrdir.quote,
                                   'top_srcdir' => $top_srcdir.quote)
-    RbConfig::expand("$(CC) #$INCFLAGS #$CPPFLAGS #$CFLAGS #$ARCH_FLAG #{opt} -c #{CONFTEST_C}",
+    # Truffle: specify output file (-o) explictly. Clang 3.8 produces conftest.o and 3.9 conftest.bc.
+    RbConfig::expand("$(CC) #$INCFLAGS #$CPPFLAGS #$CFLAGS #$ARCH_FLAG #{opt} -o #{CONFTEST}.#{$OBJEXT} -c #{CONFTEST_C}",
                      conf)
   end
 


### PR DESCRIPTION
This reverts commit 28f68dfd3221586119738734e6303b4e57d70bf0.

This fixes `have_type` as used by zlib's extconf.rb for me locally, but I need to check on other platforms.