### PR TITLE
Use NFI for basic POSIX

### DIFF
--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -1506,6 +1506,7 @@ public class CoreLibrary {
             "/core/integer.rb",
             "/core/fixnum.rb",
             "/core/bignum.rb",
+            "/core/posix.rb",
             "/core/regexp.rb",
             "/core/encoding.rb",
             "/core/env.rb",

--- a/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
+++ b/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
@@ -46,17 +46,6 @@ public abstract class TrufflePosixNodes {
         }
     }
 
-    @CoreMethod(names = "chown", isModuleFunction = true, required = 3, lowerFixnum = { 2, 3 })
-    public abstract static class ChownNode extends CoreMethodArrayArgumentsNode {
-
-        @TruffleBoundary
-        @Specialization(guards = "isRubyString(path)")
-        public int chown(DynamicObject path, int owner, int group) {
-            return posix().chown(decodeUTF8(path), owner, group);
-        }
-
-    }
-
     @CoreMethod(names = "dup", isModuleFunction = true, required = 1, lowerFixnum = 1)
     public abstract static class DupNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
+++ b/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
@@ -46,17 +46,6 @@ public abstract class TrufflePosixNodes {
         }
     }
 
-    @CoreMethod(names = "chmod", isModuleFunction = true, required = 2, lowerFixnum = 2)
-    public abstract static class ChmodNode extends CoreMethodArrayArgumentsNode {
-
-        @TruffleBoundary
-        @Specialization(guards = "isRubyString(path)")
-        public int chmod(DynamicObject path, int mode) {
-            return posix().chmod(decodeUTF8(path), mode);
-        }
-
-    }
-
     @CoreMethod(names = "chown", isModuleFunction = true, required = 3, lowerFixnum = { 2, 3 })
     public abstract static class ChownNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
+++ b/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
@@ -46,18 +46,6 @@ public abstract class TrufflePosixNodes {
         }
     }
 
-    @CoreMethod(names = "access", isModuleFunction = true, required = 2, lowerFixnum = 2)
-    public abstract static class AccessNode extends CoreMethodArrayArgumentsNode {
-
-        @TruffleBoundary
-        @Specialization(guards = "isRubyString(path)")
-        public int access(DynamicObject path, int mode) {
-            final String pathString = decodeUTF8(path);
-            return posix().access(pathString, mode);
-        }
-
-    }
-
     @CoreMethod(names = "chmod", isModuleFunction = true, required = 2, lowerFixnum = 2)
     public abstract static class ChmodNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/platform/posix/JNRTrufflePosix.java
+++ b/src/main/java/org/truffleruby/platform/posix/JNRTrufflePosix.java
@@ -60,12 +60,6 @@ public class JNRTrufflePosix implements TrufflePosix {
 
     @TruffleBoundary
     @Override
-    public int chmod(String filename, int mode) {
-        return posix.chmod(filename, mode);
-    }
-
-    @TruffleBoundary
-    @Override
     public int fchmod(int fd, int mode) {
         return posix.fchmod(fd, mode);
     }

--- a/src/main/java/org/truffleruby/platform/posix/JNRTrufflePosix.java
+++ b/src/main/java/org/truffleruby/platform/posix/JNRTrufflePosix.java
@@ -66,12 +66,6 @@ public class JNRTrufflePosix implements TrufflePosix {
 
     @TruffleBoundary
     @Override
-    public int chown(String filename, int user, int group) {
-        return posix.chown(filename, user, group);
-    }
-
-    @TruffleBoundary
-    @Override
     public int fchown(int fd, int user, int group) {
         return posix.fchown(fd, user, group);
     }

--- a/src/main/java/org/truffleruby/platform/posix/JNRTrufflePosix.java
+++ b/src/main/java/org/truffleruby/platform/posix/JNRTrufflePosix.java
@@ -385,12 +385,6 @@ public class JNRTrufflePosix implements TrufflePosix {
 
     @TruffleBoundary
     @Override
-    public int access(CharSequence path, int amode) {
-        return posix.access(path, amode);
-    }
-
-    @TruffleBoundary
-    @Override
     public int close(int fd) {
         return posix.close(fd);
     }

--- a/src/main/java/org/truffleruby/platform/posix/TrufflePosix.java
+++ b/src/main/java/org/truffleruby/platform/posix/TrufflePosix.java
@@ -28,7 +28,6 @@ public interface TrufflePosix {
     byte[] crypt(byte[] key, byte[] salt);
     FileStat allocateStat();
     int fchmod(int fd, int mode);
-    int chown(String filename, int user, int group);
     int fchown(int fd, int user, int group);
     int execve(String path, String[] argv, String[] envp);
     int fstat(int fd, FileStat stat);

--- a/src/main/java/org/truffleruby/platform/posix/TrufflePosix.java
+++ b/src/main/java/org/truffleruby/platform/posix/TrufflePosix.java
@@ -80,7 +80,6 @@ public interface TrufflePosix {
     int dup2(int oldFd, int newFd);
     int fcntlInt(int fd, Fcntl fcntlConst, int arg);
     int fcntl(int fd, Fcntl fcntlConst);
-    int access(CharSequence path, int amode);
     int close(int fd);
     int unlink(CharSequence path);
     int open(CharSequence path, int flags, int perm);

--- a/src/main/java/org/truffleruby/platform/posix/TrufflePosix.java
+++ b/src/main/java/org/truffleruby/platform/posix/TrufflePosix.java
@@ -27,7 +27,6 @@ public interface TrufflePosix {
 
     byte[] crypt(byte[] key, byte[] salt);
     FileStat allocateStat();
-    int chmod(String filename, int mode);
     int fchmod(int fd, int mode);
     int chown(String filename, int user, int group);
     int fchown(int fd, int user, int group);

--- a/src/main/ruby/core/kernel.rb
+++ b/src/main/ruby/core/kernel.rb
@@ -394,14 +394,7 @@ module Kernel
   end
   module_function :open
 
-  def p(*a)
-    return nil if a.empty?
-    a.each { |obj| $stdout.puts obj.inspect }
-    $stdout.flush
-
-    a.size == 1 ? a.first : a
-  end
-  module_function :p
+  # Kernel#p is in post.rb
 
   def print(*args)
     args.each do |obj|

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -17,7 +17,13 @@ module Truffle::POSIX
   }
 
   def self.to_nfi_type(type)
-    TYPES.fetch(type, type)
+    if found = TYPES[type]
+      found
+    elsif typedef = Rubinius::Config["rbx.platform.typedef.#{type}"]
+      TYPES[type] = to_nfi_type(typedef.to_sym)
+    else
+      TYPES[type] = type
+    end
   end
 
   def self.attach_function(name, argument_types, return_type)
@@ -31,12 +37,6 @@ module Truffle::POSIX
     }
   end
 
-  def self.resolve_type(type)
-    Rubinius::Config["rbx.platform.typedef.#{type}"].to_sym
-  end
-
-  mode_t = resolve_type('mode_t')
-
   attach_function :access, [:string, :int], :int
-  attach_function :chmod, [:string, mode_t], :int
+  attach_function :chmod, [:string, :mode_t], :int
 end

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -16,14 +16,14 @@ module Truffle::POSIX
     :uint => :uint32,
   }
 
-  def self.resolve_type(type)
+  def self.to_nfi_type(type)
     TYPES.fetch(type, type)
   end
 
   def self.attach_function(name, argument_types, return_type)
     func = LIBC[name]
-    return_type = resolve_type(return_type)
-    argument_types = argument_types.map { |type| resolve_type(type) }
+    return_type = to_nfi_type(return_type)
+    argument_types = argument_types.map { |type| to_nfi_type(type) }
     bound_func = func.bind("(#{argument_types.join(',')}):#{return_type}")
 
     define_singleton_method(name) { |*args|
@@ -31,7 +31,11 @@ module Truffle::POSIX
     }
   end
 
-  mode_t = Rubinius::Config['rbx.platform.typedef.mode_t'].to_sym
+  def self.resolve_type(type)
+    Rubinius::Config["rbx.platform.typedef.#{type}"].to_sym
+  end
+
+  mode_t = resolve_type('mode_t')
 
   attach_function :access, [:string, :int], :int
   attach_function :chmod, [:string, mode_t], :int

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -1,0 +1,34 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+module Truffle::POSIX
+  LIBC = Truffle::Interop.eval('application/x-native', 'default')
+
+  def self.resolve_type(type)
+    case type
+    when :int
+      :sint32
+    else
+      type
+    end
+  end
+
+  def self.attach_function(name, argument_types, return_type)
+    func = LIBC[name]
+    return_type = resolve_type(return_type)
+    argument_types = argument_types.map { |type| resolve_type(type) }
+    bound_func = func.bind("(#{argument_types.join(',')}):#{return_type}")
+
+    define_singleton_method(name) { |*args|
+      bound_func.call(*args)
+    }
+  end
+
+
+  attach_function :access, [:string, :int], :int
+end

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -39,4 +39,5 @@ module Truffle::POSIX
 
   attach_function :access, [:string, :int], :int
   attach_function :chmod, [:string, :mode_t], :int
+  attach_function :chown, [:string, :uid_t, :gid_t], :int
 end

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -9,13 +9,15 @@
 module Truffle::POSIX
   LIBC = Truffle::Interop.eval('application/x-native', 'default')
 
+  TYPES = {
+    :short => :int16,
+    :ushort => :uint16,
+    :int => :sint32,
+    :uint => :uint32,
+  }
+
   def self.resolve_type(type)
-    case type
-    when :int
-      :sint32
-    else
-      type
-    end
+    TYPES.fetch(type, type)
   end
 
   def self.attach_function(name, argument_types, return_type)
@@ -29,6 +31,8 @@ module Truffle::POSIX
     }
   end
 
+  mode_t = Rubinius::Config['rbx.platform.typedef.mode_t'].to_sym
 
   attach_function :access, [:string, :int], :int
+  attach_function :chmod, [:string, mode_t], :int
 end

--- a/src/main/ruby/core/post.rb
+++ b/src/main/ruby/core/post.rb
@@ -45,6 +45,19 @@ module Rubinius
   end
 end
 
+# Only define Kernel#p here when everything is set up so the basic version is
+# available while loading core where IO is not fully defined.
+module Kernel
+  def p(*a)
+    return nil if a.empty?
+    a.each { |obj| $stdout.puts obj.inspect }
+    $stdout.flush
+
+    a.size == 1 ? a.first : a
+  end
+  module_function :p
+end
+
 ARGV.concat(Truffle::Boot.original_argv)
 
 $LOAD_PATH.concat(Truffle::Boot.original_load_path)


### PR DESCRIPTION
I just migrated a few functions to show how much nicer it is in Ruby for these simple POSIX functions.

The `attach_function` API is compatible with Ruby's FFI, but I use NFI directly here since we don't need much so far beyond resolving types.

Also this seems more correct as it uses type aliases and not `int` for `mode_t` for example (which is unsigned short on darwin).