### PR TITLE
Encoding fixes

### DIFF
--- a/spec/ruby/language/fixtures/binary_symbol.rb
+++ b/spec/ruby/language/fixtures/binary_symbol.rb
@@ -1,0 +1,4 @@
+# encoding: binary
+
+p :il_était.to_s.bytes
+puts :il_était.encoding.name

--- a/spec/ruby/language/symbol_spec.rb
+++ b/spec/ruby/language/symbol_spec.rb
@@ -36,6 +36,11 @@ describe "A Symbol literal" do
     }
   end
 
+  it 'inherits the encoding of the magic comment and can have a binary encoding' do
+    ruby_exe(fixture(__FILE__, "binary_symbol.rb"))
+      .should == "[105, 108, 95, 195, 169, 116, 97, 105, 116]\nASCII-8BIT\n"
+  end
+
   it "may contain '::' in the string" do
     :'Some::Class'.should be_kind_of(Symbol)
   end

--- a/spec/tags/language/symbol_tags.txt
+++ b/spec/tags/language/symbol_tags.txt
@@ -1,0 +1,2 @@
+slow:A Symbol literal inherits the encoding of the magic comment and can have a binary encoding
+fails:A Symbol literal inherits the encoding of the magic comment and can have a binary encoding

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -2559,7 +2559,7 @@ VALUE rb_reg_match_pre(VALUE match) {
 }
 
 VALUE rb_reg_new(const char *s, long len, int options) {
-  return (VALUE) truffle_invoke(RUBY_CEXT, "rb_reg_new", truffle_read_n_string(s, len), options);
+  return (VALUE) truffle_invoke(RUBY_CEXT, "rb_reg_new", rb_str_new(s, len), options);
 }
 
 VALUE rb_reg_new_str(VALUE s, int options) {

--- a/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -159,7 +159,7 @@ public abstract class RegexpNodes {
     public static Rope shimModifiers(Rope bytes) {
         // Joni doesn't support (?u) etc but we can shim some common cases
 
-        String bytesString = bytes.toString();
+        String bytesString = RopeOperations.decodeRope(bytes);
 
         if (bytesString.startsWith("(?u)") || bytesString.startsWith("(?d)") || bytesString.startsWith("(?a)")) {
             final char modifier = (char) bytes.get(2);
@@ -182,7 +182,7 @@ public abstract class RegexpNodes {
                     throw new UnsupportedOperationException();
             }
 
-            bytes = StringOperations.encodeRope(bytesString, ASCIIEncoding.INSTANCE);
+            bytes = StringOperations.encodeRope(bytesString, bytes.getEncoding());
         }
 
         return bytes;

--- a/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
+++ b/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
@@ -365,7 +365,8 @@ public abstract class OutgoingForeignCallNode extends RubyNode {
 
     protected class RespondToOutgoingNode extends OutgoingNode {
 
-        @Child private SnippetNode snippetNode = new SnippetNode();
+        @Child private ForeignToRubyNode toRubyStringNode = ForeignToRubyNode.create();
+        @Child private CallDispatchHeadNode callRespondTo = CallDispatchHeadNode.create();
 
         @Override
         public Object executeCall(VirtualFrame frame, TruffleObject receiver, Object[] args) {
@@ -375,10 +376,8 @@ public abstract class OutgoingForeignCallNode extends RubyNode {
             }
 
             // We have already converted Ruby strings to Java strings at this point, so we need to convert back!
-
-            return snippetNode.execute(frame, "Truffle::Interop.respond_to?(object, String.new(name))",
-                    "object", receiver,
-                    "name", args[0]);
+            final Object name = toRubyStringNode.executeConvert(frame, args[0]);
+            return callRespondTo.call(frame, coreLibrary().getTruffleInteropModule(), "respond_to?", receiver, name);
         }
 
     }

--- a/src/main/ruby/core/string.rb
+++ b/src/main/ruby/core/string.rb
@@ -1373,7 +1373,7 @@ class String
   def initialize(other = undefined, encoding: nil)
     unless undefined.equal?(other)
       Truffle.check_frozen
-      Truffle.invoke_primitive(:string_initialize, self, other)
+      Truffle.invoke_primitive(:string_initialize, self, other, encoding)
       taint if other.tainted?
     end
     self.force_encoding(encoding) if encoding

--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -898,8 +898,8 @@ module Truffle::CExt
     Range.new(beg, last, exclude_end != 0)
   end
 
-  def rb_reg_new(java_string, options)
-    Regexp.new(String.new(java_string), options)
+  def rb_reg_new(pattern, options)
+    Regexp.new(pattern, options)
   end
 
   def rb_reg_new_str(str, options)
@@ -1044,7 +1044,7 @@ module Truffle::CExt
   end
 
   def rb_str_new_cstr(java_string)
-    String.new(java_string)
+    String.new(java_string, encoding: Encoding::BINARY)
   end
 
   def rb_enc_str_coderange(str)


### PR DESCRIPTION
I think `encodeRope` should never be passed a binary encoding, otherwise it encodes the j.l.String in  ISO-8859-1 bytes, which is incorrect if any of them is higher than 128.
The problem is if we have just a j.l.String, we no longer have the raw bytes, and we need to know where does the String comes from to reverse the process bytes->j.l.String.

I was thinking to add an assertion in encodeRope that a binary encoding is not passed, as it re-encodes chars to ISO-8859-1 which seems to make no sense as it's very unlikely to be the original encoding.
But there is one usage in SymbolParseNode and I am not sure whether it's fine to use ASCIIEncoding there.
In any case, I wrote a spec showing it is not working as expected in SymbolParseNode (somehow it believes the Symbol is US-ASCII and 7-bit).