### PR TITLE
Translate UnknownIdentifierException

### DIFF
--- a/doc/user/interop.md
+++ b/doc/user/interop.md
@@ -310,6 +310,8 @@ an integer, or anything else
 
 `object.to_a` and `object.to_ary` calls `Truffle::Interop.to_array(object)`
 
+`object.equal?(other)` returns whether object is the same as other, like BasicObject#equal?
+
 `object.inspect` produces a simple string of the format
 `#<Truffle::Interop::Foreign:system-identity-hash-code>`
 
@@ -403,5 +405,5 @@ Method calls on foreign objects are usually translated exactly into foreign
 are a kind of special-form - they are implemented as a special case in the
 call-site logic. They are not being provided by `BasicObject` or `Kernel` as you
 may expect. This means that for example `#method` isn't available, and you can't
-use it to get the method for `#to_a` on a foreign object, as it it's a
+use it to get the method for `#to_a` on a foreign object, as it is a
 special-form, not a method.

--- a/doc/user/interop.md
+++ b/doc/user/interop.md
@@ -310,7 +310,7 @@ an integer, or anything else
 
 `object.to_a` and `object.to_ary` calls `Truffle::Interop.to_array(object)`
 
-`object.equal?(other)` returns whether object is the same as other, like BasicObject#equal?
+`object.equal?(other)` returns whether `object` is the same as `other` using reference equality, like `BasicObject#equal?`
 
 `object.inspect` produces a simple string of the format
 `#<Truffle::Interop::Foreign:system-identity-hash-code>`

--- a/spec/truffle/interop/equal_spec.rb
+++ b/spec/truffle/interop/equal_spec.rb
@@ -1,0 +1,24 @@
+# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+require_relative '../../ruby/spec_helper'
+
+describe "Calling #equal? on a foreign object" do
+  it "tests reference equality" do
+    a = Truffle::Debug.foreign_object
+    a.equal?(a).should == true
+    b = Truffle::Debug.foreign_object
+    a.equal?(b).should == false
+  end
+
+  it "returns false for other objects" do
+    foreign = Truffle::Debug.foreign_object
+    foreign.equal?(Object.new).should == false
+    foreign.equal?(42).should == false
+  end
+end

--- a/spec/truffle/interop/invoke_spec.rb
+++ b/spec/truffle/interop/invoke_spec.rb
@@ -29,6 +29,7 @@ describe "Truffle::Interop.invoke" do
   it "raises a NoMethodError when the method is not found on a foreign object" do
     foreign = Truffle::Interop.java_array(1, 2, 3)
     lambda { foreign.foo(42) }.should raise_error(NoMethodError, /Unknown identifier: foo/) { |e|
+      e.receiver.equal?(foreign).should == true
       e.name.should == :foo
       e.args.should == [42]
     }

--- a/spec/truffle/interop/invoke_spec.rb
+++ b/spec/truffle/interop/invoke_spec.rb
@@ -26,4 +26,12 @@ describe "Truffle::Interop.invoke" do
     Truffle::Interop.invoke(InvokeTestClass.new, 'add', 14, 2).should == 16
   end
 
+  it "raises a NoMethodError when the method is not found on a foreign object" do
+    foreign = Truffle::Interop.java_array(1, 2, 3)
+    lambda { foreign.foo(42) }.should raise_error(NoMethodError, /Unknown identifier: foo/) { |e|
+      e.name.should == :foo
+      e.args.should == [42]
+    }
+  end
+
 end

--- a/spec/truffle/interop/read_spec.rb
+++ b/spec/truffle/interop/read_spec.rb
@@ -85,6 +85,7 @@ describe "Truffle::Interop.read" do
   it "raises a NameError when the identifier is not found on a foreign object" do
     foreign = Truffle::Interop.java_array(1, 2, 3)
     lambda { foreign.foo }.should raise_error(NameError, /Unknown identifier: foo/) { |e|
+      e.receiver.equal?(foreign).should == true
       e.name.should == :foo
     }
   end

--- a/spec/truffle/interop/write_spec.rb
+++ b/spec/truffle/interop/write_spec.rb
@@ -101,6 +101,7 @@ describe "Truffle::Interop.write" do
   it "raises a NameError when the identifier is not found on a foreign object" do
     foreign = Truffle::Interop.java_array(1, 2, 3)
     lambda { foreign.foo = 42 }.should raise_error(NameError, /Unknown identifier: foo/) { |e|
+      e.receiver.equal?(foreign).should == true
       e.name.should == :foo
     }
   end

--- a/spec/truffle/interop/write_spec.rb
+++ b/spec/truffle/interop/write_spec.rb
@@ -88,4 +88,25 @@ describe "Truffle::Interop.write" do
     hash[3].should == 14
   end
 
+  it "raises a NameError when the identifier is not found on a Ruby object" do
+    obj = Object.new
+    lambda {
+      Truffle::Interop.write(obj, Truffle::Interop.to_java_string('foo'), 42)
+    }.should raise_error(NameError, /Unknown identifier: foo/) { |e|
+      e.receiver.should equal obj
+      e.name.should == :foo
+    }
+  end
+
+  it "raises a NameError when the identifier is not found on a foreign object" do
+    foreign = Truffle::Interop.java_array(1, 2, 3)
+    lambda { foreign.foo = 42 }.should raise_error(NameError, /Unknown identifier: foo/) { |e|
+      e.name.should == :foo
+    }
+  end
+
+  it "raises a NameError when the name is not a supported type" do
+    lambda { Truffle::Interop.write(Math, Truffle::Debug.foreign_object, 42) }.should raise_error(NameError, /Unknown identifier: /)
+  end
+
 end

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -10,6 +10,8 @@
 package org.truffleruby.core.exception;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import jnr.constants.platform.Errno;
@@ -565,6 +567,11 @@ public class CoreExceptions {
     }
 
     @TruffleBoundary
+    public DynamicObject nameErrorUnknownIdentifier(TruffleObject receiver, Object name, UnknownIdentifierException exception, Node currentNode) {
+        return nameError(exception.getMessage(), receiver, name.toString(), currentNode);
+    }
+
+    @TruffleBoundary
     public DynamicObject nameError(String message, Object receiver, String name, Node currentNode) {
         final DynamicObject messageString = StringOperations.createString(context, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));
         DynamicObject exceptionClass = context.getCoreLibrary().getNameErrorClass();
@@ -628,6 +635,10 @@ public class CoreExceptions {
         final Object stringRepresentation = hasInspect ? context.send(receiver, "inspect", null) : context.getCoreLibrary().getNil();
 
         return noMethodError(StringUtils.format("undefined method `%s' for %s:%s", name, stringRepresentation, moduleName), receiver, name, args, currentNode);
+    }
+
+    public DynamicObject noMethodErrorUnknownIdentifier(TruffleObject receiver, Object name, Object[] args, UnknownIdentifierException exception, Node currentNode) {
+        return noMethodError(exception.getMessage(), receiver, name.toString(), args, currentNode);
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
+++ b/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
@@ -114,6 +114,8 @@ public abstract class OutgoingForeignCallNode extends RubyNode {
             return new SendOutgoingNode();
         } else if (name.equals("nil?") && argsLength == 0) {
             return new IsNilOutgoingNode();
+        } else if (name.equals("equal?") && argsLength == 1) {
+            return new IsReferenceEqualOutgoingNode();
         } else if (name.endsWith("!") && argsLength == 0) {
             return new InvokeOutgoingNode(name.substring(0, name.length() - 1), argsLength);
         } else if (argsLength == 0) {
@@ -457,6 +459,16 @@ public abstract class OutgoingForeignCallNode extends RubyNode {
             assert args.length == 0;
 
             return ForeignAccess.sendIsNull(node, receiver);
+        }
+
+    }
+
+    protected class IsReferenceEqualOutgoingNode extends OutgoingNode {
+
+        @Override
+        public Object executeCall(VirtualFrame frame, TruffleObject receiver, Object[] args) {
+            assert args.length == 1;
+            return receiver == args[0];
         }
 
     }

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -37,8 +37,8 @@ module Truffle::POSIX
   def self.attach_function(method_name, native_name = method_name, argument_types, return_type)
     begin
       func = LIBC[native_name]
-    rescue RubyTruffleError => e
-      raise e unless e.message.include?('Unknown identifier')
+    rescue NameError # Missing function
+      func = nil
     end
 
     if func


### PR DESCRIPTION
* To NameError on READ/WRITE.
* To NoMethodError on INVOKE.
* Use the original Ruby arguments and not the converted to foreign
  as we create a Ruby exception.
* Add the foreign.equal?(other) special form