### PR TITLE
lookupSymbol is replaced by findTopScopes

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -15,7 +15,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "9598d144899a797bceff6d0162472c3c66ec9ca0",
+                "version": "d1bb9076f1fa6af71c60be140f980794596a75b4",
                 "urls": [
                     {"url": "https://github.com/graalvm/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -145,11 +145,6 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
             return null;
         }
 
-        return lookupSymbol(context, symbolName);
-    }
-
-    @Override
-    protected Object lookupSymbol(RubyContext context, String symbolName) {
         return context.send(context.getCoreLibrary().getTruffleInteropModule(), "lookup_symbol", null, context.getSymbolTable().getSymbol(symbolName));
     }
 


### PR DESCRIPTION
No need to implement findTopScopes, because the default works with getLanguageGlobal which we already implement.