### PR TITLE
Deprecate jt run and prefer jt ruby

### DIFF
--- a/doc/contributor/raw-commands.md
+++ b/doc/contributor/raw-commands.md
@@ -14,7 +14,7 @@ commands are then printed with `$`.
 For an example command such as:
 
 ```
->>> jt run -e 'puts "hello"'
+>>> jt ruby -e 'puts "hello"'
 ```
 
 `jt` will automatically print the command that it runs, but this is just a
@@ -22,7 +22,7 @@ launcher shell script which itself runs `java`. To get that command you need
 to use the `-J-cmd` option.
 
 ```
->>> jt run -J-cmd -e 'puts "hello"'
+>>> jt ruby -J-cmd -e 'puts "hello"'
 $ /Users/chrisseaton/Documents/ruby/truffleruby/bin/truffleruby -Xcore.load_path=/Users/chrisseaton/Documents/ruby/truffleruby/src/main/ruby -Xgraal.warn_unless=false -J-cmd -e 'puts "hello"'
 $ /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home/bin/java -Dfile.encoding=UTF-8 -Xbootclasspath/a:/Users/chrisseaton/Documents/ruby/truffleruby/lib/truffleruby.jar org.truffleruby.Main -Xhome=/Users/chrisseaton/Documents/ruby/truffleruby -Xlauncher=/Users/chrisseaton/Documents/ruby/truffleruby/bin/truffleruby -Xcore.load_path=/Users/chrisseaton/Documents/ruby/truffleruby/src/main/ruby -Xgraal.warn_unless=false -e puts "hello"
 hello

--- a/doc/contributor/using-graal.md
+++ b/doc/contributor/using-graal.md
@@ -14,5 +14,5 @@ Then set the environment variable `GRAALVM_BIN` to the `bin/java` executable in
 GraalVM and use `jt` to run TruffleRuby.
 
 ```
-$ GRAALVM_BIN=..../bin/java jt run --graal ...
+$ GRAALVM_BIN=..../bin/java jt ruby --graal ...
 ```

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -134,7 +134,7 @@ module Process
 
   # Very hacky implementation to pass the specs, since the JVM doesn't give us argv[0]
   # Overwrite *argv inplace because finding the argv pointer itself is harder.
-  # Truncates title if title would cover our org.jruby (main class) marker.
+  # Truncates title if title is longer than the orginal command line.
   def self.setproctitle_linux_from_proc_maps(title)
     @_argv0_address ||= begin
       command = File.binread('/proc/self/cmdline')

--- a/test/truffle/compiler/pe/pe.rb
+++ b/test/truffle/compiler/pe/pe.rb
@@ -24,7 +24,7 @@
 #
 # Run with:
 #
-#   jt run --graal -J-Dgraal.TraceTruffleCompilation=true -J-Dgraal.TruffleCompilationExceptionsAreFatal=true -J-Dgraal.TruffleIterativePartialEscape=true test.rb
+#   jt ruby --graal -J-Dgraal.TraceTruffleCompilation=true -J-Dgraal.TruffleCompilationExceptionsAreFatal=true -J-Dgraal.TruffleIterativePartialEscape=true test.rb
 
 unless Truffle.graal?
   puts 'not running Graal'

--- a/tool/cext-compile-explore.rb
+++ b/tool/cext-compile-explore.rb
@@ -7,7 +7,7 @@
 # GNU Lesser General Public License version 2.1
 
 # For example:
-# $ jt run tool/cext-compile-explore.rb spec/ruby/optional/capi/ext/util_spec.c -Ispec/ruby/optional/capi/ext
+# $ jt ruby tool/cext-compile-explore.rb spec/ruby/optional/capi/ext/util_spec.c -Ispec/ruby/optional/capi/ext
 
 raise 'you need to run this with TruffleRuby' unless RUBY_ENGINE == 'truffleruby'
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -397,7 +397,7 @@ module Commands
       jt env                                         prints the current environment
       jt rebuild                                     clean, sforceimports, and build
       jt dis <file>                                  finds the bc file in the project, disassembles, and returns new filename
-      jt run [options] args...                       run TruffleRuby with args
+      jt ruby [options] args...                      run TruffleRuby with args
           --graal         use Graal (set either GRAALVM_BIN, JVMCI_BIN or GRAAL_HOME, or have graal built as a sibling)
               --stress    stress the compiler (compile immediately, foreground compilation, compilation exceptions are fatal)
           --js            add Graal.js to the classpath (set GRAAL_JS_JAR)
@@ -675,7 +675,7 @@ module Commands
   end
 
   def e(*args)
-    run '-e', args.join(' ')
+    ruby '-e', args.join(' ')
   end
 
   def command_puts(*args)


### PR DESCRIPTION
* jt run leaves the jt process alive and adds another process in between,  which is not needed if running TruffleRuby from the command line.
* jt run is only useful internally when TruffleRuby must be invoked  multiple times.
* Also remove references to JRuby in jt.rb.