### PR TITLE
Share the same underlying objects when copying a regexp.

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/RegexpGuards.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpGuards.java
@@ -29,4 +29,8 @@ public class RegexpGuards {
         return StringOperations.codeRange(string) != CodeRange.CR_BROKEN;
     }
 
+    public static boolean isSameRegexp(DynamicObject a, DynamicObject b) {
+        return Layouts.REGEXP.getRegex(a) == Layouts.REGEXP.getRegex(b);
+    }
+
 }

--- a/src/main/ruby/core/regexp.rb
+++ b/src/main/ruby/core/regexp.rb
@@ -191,10 +191,6 @@ class Regexp
     compile pattern, opts
   end
 
-  def initialize_copy(other)
-    initialize other.source, other.options
-  end
-
   def match(str, pos=0)
     unless str
       Truffle.invoke_primitive(:regexp_set_last_match, nil)


### PR DESCRIPTION
To preserve high level semantics of union and interpolated regexps we must produce new `Regexp` objects for each call, but they must share internals for encoding caches and other optimisations to be effective.