### PR TITLE
Cleanup Errno since only NFI's errno is used

### DIFF
--- a/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
+++ b/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
@@ -84,15 +84,4 @@ public abstract class TrufflePosixNodes {
 
     }
 
-    @CoreMethod(names = "jnr_errno", isModuleFunction = true)
-    public abstract static class ErrnoNode extends CoreMethodArrayArgumentsNode {
-
-        @TruffleBoundary
-        @Specialization
-        public int errno() {
-            return posix().errno();
-        }
-
-    }
-
 }

--- a/src/main/ruby/core/dir.rb
+++ b/src/main/ruby/core/dir.rb
@@ -244,30 +244,30 @@ class Dir
       if block_given?
         original_path = self.getwd
         ret = Truffle::POSIX.chdir path
-        Errno.handle_nfi(path) if ret != 0
+        Errno.handle(path) if ret != 0
 
         begin
           yield path
         ensure
           ret = Truffle::POSIX.chdir original_path
-          Errno.handle_nfi(original_path) if ret != 0
+          Errno.handle(original_path) if ret != 0
         end
       else
         ret = Truffle::POSIX.chdir path
-        Errno.handle_nfi path if ret != 0
+        Errno.handle path if ret != 0
         ret
       end
     end
 
     def mkdir(path, mode = 0777)
       ret = Truffle::POSIX.mkdir(Rubinius::Type.coerce_to_path(path), mode)
-      Errno.handle_nfi path if ret != 0
+      Errno.handle path if ret != 0
       ret
     end
 
     def rmdir(path)
       ret = Truffle::POSIX.rmdir(Rubinius::Type.coerce_to_path(path))
-      Errno.handle_nfi path if ret != 0
+      Errno.handle path if ret != 0
       ret
     end
     alias_method :delete, :rmdir
@@ -276,7 +276,7 @@ class Dir
     def getwd
       Rubinius::FFI::MemoryPointer.new(Rubinius::PATH_MAX) do |ptr|
         wd = Truffle::POSIX.getcwd(ptr, Rubinius::PATH_MAX)
-        Errno.handle_nfi unless wd
+        Errno.handle unless wd
 
         Rubinius::Type.external_string wd
       end

--- a/src/main/ruby/core/env.rb
+++ b/src/main/ruby/core/env.rb
@@ -67,7 +67,7 @@ module Rubinius
         @variables.delete(key)
       else
         if Truffle::POSIX.setenv(key, StringValue(value), 1) != 0
-          Errno.handle_nfi('setenv')
+          Errno.handle('setenv')
         end
         unless @variables.include?(key)
           @variables << set_encoding(key.dup)

--- a/src/main/ruby/core/errno.rb
+++ b/src/main/ruby/core/errno.rb
@@ -45,17 +45,17 @@ module Errno
   # Unlike rb_sys_fail(), handle does not raise an exception if errno is 0.
 
   def self.handle(additional = nil)
-    err = nfi_errno
+    err = errno
     return if err == 0
 
     raise SystemCallError.new(additional, err)
   end
 
-  def self.nfi_errno
+  def self.errno
     Truffle::POSIX.errno_address.read_int
   end
 
-  def self.set_nfi_errno(value)
+  def self.errno=(value)
     Truffle::POSIX.errno_address.write_int value
   end
 

--- a/src/main/ruby/core/errno.rb
+++ b/src/main/ruby/core/errno.rb
@@ -44,13 +44,6 @@ module Errno
   #
   # Unlike rb_sys_fail(), handle does not raise an exception if errno is 0.
 
-  def self.handle_jnr(additional = nil)
-    err = Truffle::POSIX.jnr_errno
-    return if err == 0
-
-    raise SystemCallError.new(additional, err)
-  end
-
   def self.handle_nfi(additional = nil)
     err = nfi_errno
     return if err == 0

--- a/src/main/ruby/core/errno.rb
+++ b/src/main/ruby/core/errno.rb
@@ -44,14 +44,11 @@ module Errno
   #
   # Unlike rb_sys_fail(), handle does not raise an exception if errno is 0.
 
-  def self.handle_nfi(additional = nil)
+  def self.handle(additional = nil)
     err = nfi_errno
     return if err == 0
 
     raise SystemCallError.new(additional, err)
-  end
-  class << self
-    alias :handle :handle_nfi
   end
 
   def self.nfi_errno

--- a/src/main/ruby/core/file.rb
+++ b/src/main/ruby/core/file.rb
@@ -238,7 +238,7 @@ class File < IO
 
     paths.each do |path|
       n = POSIX.chmod Rubinius::Type.coerce_to_path(path), mode
-      Errno.handle_nfi if n == -1
+      Errno.handle if n == -1
     end
     paths.size
   end
@@ -254,7 +254,7 @@ class File < IO
 
     paths.each do |path|
       n = POSIX.lchmod Rubinius::Type.coerce_to_path(path), mode
-      Errno.handle_nfi if n == -1
+      Errno.handle if n == -1
     end
 
     paths.size
@@ -286,7 +286,7 @@ class File < IO
 
     paths.each do |path|
       n = POSIX.chown Rubinius::Type.coerce_to_path(path), owner, group
-      Errno.handle_nfi if n == -1
+      Errno.handle if n == -1
     end
 
     paths.size
@@ -295,7 +295,7 @@ class File < IO
   def chmod(mode)
     mode = Rubinius::Type.coerce_to(mode, Integer, :to_int)
     n = POSIX.fchmod @descriptor, clamp_short(mode)
-    Errno.handle_nfi if n == -1
+    Errno.handle if n == -1
     n
   end
 
@@ -313,7 +313,7 @@ class File < IO
     end
 
     n = POSIX.fchown @descriptor, owner, group
-    Errno.handle_nfi if n == -1
+    Errno.handle if n == -1
     n
   end
 
@@ -350,7 +350,7 @@ class File < IO
     mode = Rubinius::Type.coerce_to mode, Integer, :to_int
     path = Rubinius::Type.coerce_to_path(path)
     status = Truffle::POSIX.mkfifo(path, mode)
-    Errno.handle_nfi path if status != 0
+    Errno.handle path if status != 0
     status
   end
 
@@ -850,7 +850,7 @@ class File < IO
   #  IO.readlines(".testfile")[0]         #=> "This is line one\n"
   def self.link(from, to)
     n = POSIX.link Rubinius::Type.coerce_to_path(from), Rubinius::Type.coerce_to_path(to)
-    Errno.handle_nfi if n == -1
+    Errno.handle if n == -1
     n
   end
 
@@ -912,7 +912,7 @@ class File < IO
   def self.readlink(path)
     FFI::MemoryPointer.new(Rubinius::PATH_MAX) do |ptr|
       n = POSIX.readlink Rubinius::Type.coerce_to_path(path), ptr, Rubinius::PATH_MAX
-      Errno.handle_nfi if n == -1
+      Errno.handle if n == -1
 
       return ptr.read_string(n).force_encoding(Encoding.find('filesystem'))
     end
@@ -979,7 +979,7 @@ class File < IO
   #  File.rename("afile", "afile.bak")   #=> 0
   def self.rename(from, to)
     n = POSIX.rename Rubinius::Type.coerce_to_path(from), Rubinius::Type.coerce_to_path(to)
-    Errno.handle_nfi if n == -1
+    Errno.handle if n == -1
     n
   end
 
@@ -1046,7 +1046,7 @@ class File < IO
   #  File.symlink("testfile", "link2test")   #=> 0
   def self.symlink(from, to)
     n = POSIX.symlink Rubinius::Type.coerce_to_path(from), Rubinius::Type.coerce_to_path(to)
-    Errno.handle_nfi if n == -1
+    Errno.handle if n == -1
     n
   end
 
@@ -1111,7 +1111,7 @@ class File < IO
   def self.unlink(*paths)
     paths.each do |path|
       n = POSIX.unlink Rubinius::Type.coerce_to_path(path)
-      Errno.handle_nfi if n == -1
+      Errno.handle if n == -1
     end
 
     paths.size
@@ -1136,7 +1136,7 @@ class File < IO
 
       paths.each do |path|
         n = POSIX.utimes(Rubinius::Type.coerce_to_path(path), ptr)
-        Errno.handle_nfi unless n == 0
+        Errno.handle unless n == 0
       end
     end
   end
@@ -1294,7 +1294,7 @@ class File < IO
     result = POSIX.truffleposix_flock @descriptor, const
     if result == -1
       begin
-        Errno.handle_nfi
+        Errno.handle
       rescue Errno::EWOULDBLOCK
         return false
       end

--- a/src/main/ruby/core/file.rb
+++ b/src/main/ruby/core/file.rb
@@ -1265,7 +1265,6 @@ class File < IO
       perm = 0666 if undefined.equal? perm
 
       fd = IO.sysopen(path, nmode, perm)
-      Errno.handle_jnr path if fd < 0
 
       @path = path
       super(fd, mode, options)

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -1088,7 +1088,7 @@ class IO
   #
   def self.setup(io, fd, mode=nil, sync=false)
     cur_mode = Truffle::POSIX.fcntl(fd, F_GETFL, 0)
-    Errno.handle_nfi if cur_mode < 0
+    Errno.handle if cur_mode < 0
 
     cur_mode &= ACCMODE
 
@@ -1718,7 +1718,7 @@ class IO
   def fsync
     flush
     err = Truffle::POSIX.fsync @descriptor
-    Errno.handle_nfi 'fsync(2)' if err < 0
+    Errno.handle 'fsync(2)' if err < 0
     err
   end
 
@@ -2595,7 +2595,7 @@ class IO
         Truffle.invoke_primitive :object_ivar_set, self, :@descriptor, -1
         if fd >= 3
           ret = Truffle::POSIX.close(fd)
-          Errno.handle_nfi if ret < 0
+          Errno.handle if ret < 0
         end
       end
     end

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -79,7 +79,7 @@ module Truffle::POSIX
             r = bound_func.call(*args)
             if r == INTERRUPTED
               raise "#{native_name} returned -EINTR = #{INTERRUPTED} but :blocking expected it did not"
-            elsif r == -1 and Errno.nfi_errno == EINTR
+            elsif r == -1 and Errno.errno == EINTR
               INTERRUPTED
             else
               r
@@ -228,6 +228,6 @@ end
 
 # Initialize errno methods so they do not cause classloading when called later on.
 # Classloading may change the value of errno as a side-effect.
-Errno.nfi_errno
-Errno.set_nfi_errno(0)
+Errno.errno
+Errno.errno = 0
 Errno.handle

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -230,4 +230,4 @@ end
 # Classloading may change the value of errno as a side-effect.
 Errno.nfi_errno
 Errno.set_nfi_errno(0)
-Errno.handle_nfi
+Errno.handle

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -129,7 +129,7 @@ module Process
       time = Truffle.invoke_primitive(:process_time_currenttimemillis) * 1_000_000
     else
       time = Truffle::POSIX.truffleposix_clock_gettime(id)
-      Errno.handle_nfi if time == 0
+      Errno.handle if time == 0
     end
     case unit
     when :nanosecond
@@ -242,7 +242,7 @@ module Process
     rlimit[:rlim_max] = undefined.equal?(max_limit) ? cur_limit : max_limit
 
     ret = Truffle::POSIX.setrlimit(resource, rlimit.pointer)
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
     nil
   end
 
@@ -251,14 +251,14 @@ module Process
 
     rlimit = Rlimit.new
     ret = Truffle::POSIX.getrlimit(resource, rlimit.pointer)
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
 
     [rlimit[:rlim_cur], rlimit[:rlim_max]]
   end
 
   def self.setsid
     pgid = Truffle::POSIX.setsid
-    Errno.handle_nfi if pgid == -1
+    Errno.handle if pgid == -1
     pgid
   end
 
@@ -306,7 +306,7 @@ module Process
       else
         pid = -pid if use_process_group
         result = Truffle::POSIX.kill(pid, signal)
-        Errno.handle_nfi if result == -1
+        Errno.handle if result == -1
       end
     end
 
@@ -325,7 +325,7 @@ module Process
     pid = Rubinius::Type.coerce_to pid, Integer, :to_int
 
     ret = Truffle::POSIX.getpgid(pid)
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
     ret
   end
 
@@ -334,7 +334,7 @@ module Process
     int = Rubinius::Type.coerce_to int, Integer, :to_int
 
     ret = Truffle::POSIX.setpgid(pid, int)
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
     ret
   end
 
@@ -348,7 +348,7 @@ module Process
   end
   def self.getpgrp
     ret = Truffle::POSIX.getpgrp
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
     ret
   end
 
@@ -383,7 +383,7 @@ module Process
       end
     end
 
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
 
     uid
   end
@@ -416,7 +416,7 @@ module Process
       end
     end
 
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
 
     uid
   end
@@ -459,20 +459,20 @@ module Process
     priority = Rubinius::Type.coerce_to priority, Integer, :to_int
 
     ret = Truffle::POSIX.setpriority(kind, id, priority)
-    Errno.handle_nfi if ret == -1
+    Errno.handle if ret == -1
     ret
   end
 
   def self.groups
     ngroups = Truffle::POSIX.getgroups(0, FFI::Pointer::NULL)
-    Errno.handle_nfi if ngroups == -1
+    Errno.handle if ngroups == -1
 
     gid_t = Rubinius::Config['rbx.platform.typedef.gid_t']
     raise gid_t unless gid_t == 'uint'
 
     FFI::MemoryPointer.new(:gid_t, ngroups) do |ptr|
       ret = Truffle::POSIX.getgroups(ngroups, ptr)
-      Errno.handle_nfi if ret == -1
+      Errno.handle if ret == -1
       return ptr.read_array_of_uint(ngroups)
     end
   end
@@ -538,7 +538,7 @@ module Process
       if pid == 0
         return nil
       elsif pid == -1
-        Errno.handle_nfi "No child process: #{input_pid}"
+        Errno.handle "No child process: #{input_pid}"
       else
         exitcode, termsig, stopsig = ptr.read_array_of_int(3).map { |e| e == -1000 ? nil : e }
 
@@ -755,7 +755,7 @@ module Process
         gid = Rubinius::Type.coerce_to gid, Integer, :to_int
 
         ret = Truffle::POSIX.setgid gid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
 
@@ -763,7 +763,7 @@ module Process
         uid = Rubinius::Type.coerce_to uid, Integer, :to_int
 
         ret = Truffle::POSIX.setuid uid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
 
@@ -771,7 +771,7 @@ module Process
         egid = Rubinius::Type.coerce_to egid, Integer, :to_int
 
         ret = Truffle::POSIX.setegid egid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
 
@@ -779,7 +779,7 @@ module Process
         euid = Rubinius::Type.coerce_to euid, Integer, :to_int
 
         ret = Truffle::POSIX.seteuid euid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
 
@@ -796,7 +796,7 @@ module Process
         eid = Rubinius::Type.coerce_to eid, Integer, :to_int
 
         ret = Truffle::POSIX.setregid rid, eid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
 
@@ -805,7 +805,7 @@ module Process
         eid = Rubinius::Type.coerce_to eid, Integer, :to_int
 
         ret = Truffle::POSIX.setreuid rid, eid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
 
@@ -815,7 +815,7 @@ module Process
         sid = Rubinius::Type.coerce_to sid, Integer, :to_int
 
         ret = Truffle::POSIX.setresgid rid, eid, sid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
 
@@ -825,7 +825,7 @@ module Process
         sid = Rubinius::Type.coerce_to sid, Integer, :to_int
 
         ret = Truffle::POSIX.setresuid rid, eid, sid
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         nil
       end
     end
@@ -837,7 +837,7 @@ module Process
         uid = Rubinius::Type.coerce_to uid, Integer, :to_int
 
         ret = Truffle::POSIX.setreuid(uid, uid)
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         uid
       end
 
@@ -849,7 +849,7 @@ module Process
         uid = Rubinius::Type.coerce_to uid, Integer, :to_int
 
         ret = Truffle::POSIX.seteuid(uid)
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         uid
       end
       alias_method :grant_privilege, :eid=
@@ -858,7 +858,7 @@ module Process
         real = Truffle::POSIX.getuid
         eff = Truffle::POSIX.geteuid
         ret = Truffle::POSIX.setreuid(eff, real)
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         eff
       end
 
@@ -894,7 +894,7 @@ module Process
         gid = Rubinius::Type.coerce_to gid, Integer, :to_int
 
         ret = Truffle::POSIX.setregid(gid, gid)
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         gid
       end
 
@@ -906,7 +906,7 @@ module Process
         gid = Rubinius::Type.coerce_to gid, Integer, :to_int
 
         ret = Truffle::POSIX.setegid(gid)
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         gid
       end
       alias_method :grant_privilege, :eid=
@@ -915,7 +915,7 @@ module Process
         real = Truffle::POSIX.getgid
         eff = Truffle::POSIX.getegid
         ret = Truffle::POSIX.setregid(eff, real)
-        Errno.handle_nfi if ret == -1
+        Errno.handle if ret == -1
         eff
       end
 

--- a/src/main/ruby/core/process_mirror.rb
+++ b/src/main/ruby/core/process_mirror.rb
@@ -406,10 +406,10 @@ module Rubinius
           to = (-to + 1) if to < 0
 
           result = Truffle::POSIX.dup2(to, from)
-          Errno.handle_nfi if result < 0
+          Errno.handle if result < 0
 
           flags = Truffle::POSIX.fcntl(from, Fcntl::F_GETFD, 0)
-          Errno.handle_nfi if flags < 0
+          Errno.handle if flags < 0
 
           Truffle::POSIX.fcntl(from, Fcntl::F_SETFD, flags & ~Fcntl::FD_CLOEXEC)
         end
@@ -447,7 +447,7 @@ module Rubinius
           with_array_of_strings_pointer(@argv) do |argv|
             with_array_of_strings_pointer(@env_array) do |env|
               ret = Truffle::POSIX.execve(@command, argv, env)
-              Errno.handle_nfi if ret == -1
+              Errno.handle if ret == -1
             end
           end
 

--- a/src/main/ruby/core/stat.rb
+++ b/src/main/ruby/core/stat.rb
@@ -80,7 +80,7 @@ class File
         path = Rubinius::Type.coerce_to_path(path_or_buffer)
         Buffer.new do |buffer|
           result = Truffle::POSIX.truffleposix_stat(path, buffer)
-          Errno.handle_nfi path unless result == 0
+          Errno.handle path unless result == 0
           @buffer = buffer.to_h
         end
       end
@@ -100,7 +100,7 @@ class File
 
     def self.lstat(path)
       stat = lstat?(path)
-      Errno.handle_nfi path unless stat
+      Errno.handle path unless stat
       stat
     end
 
@@ -120,7 +120,7 @@ class File
       fd = Rubinius::Type.coerce_to fd, Integer, :to_int
       Buffer.new do |buffer|
         result = Truffle::POSIX.truffleposix_fstat(fd, buffer)
-        Errno.handle_nfi "file descriptor #{descriptor}" unless result == 0
+        Errno.handle "file descriptor #{descriptor}" unless result == 0
         return Stat.new buffer
       end
     end

--- a/src/main/ruby/core/string.rb
+++ b/src/main/ruby/core/string.rb
@@ -1559,7 +1559,7 @@ class String
     raise ArgumentError, 'salt too short (need >= 2 bytes)' if salt.bytesize < 2 || salt[0] == "\0" || salt[1] == "\0"
     raise ArgumentError, 'string contains null byte' if include?("\0")
     crypted = Truffle::POSIX.crypt(self, salt)
-    Errno.handle_nfi unless crypted
+    Errno.handle unless crypted
     crypted.taint if tainted? || salt.tainted?
     crypted
   end

--- a/src/main/ruby/core/truffle/ffi/ffi.rb
+++ b/src/main/ruby/core/truffle/ffi/ffi.rb
@@ -109,7 +109,7 @@ module Rubinius::FFI
     end
 
     def errno
-      Errno.nfi_errno
+      Errno.errno
     end
 
   end


### PR DESCRIPTION
https://github.com/graalvm/truffleruby/pull/715/files#diff-dcd0a21283e55a2651817c0b07593287R233
and
https://github.com/graalvm/truffleruby/pull/715/files#diff-dcd0a21283e55a2651817c0b07593287R238
should be updated to use `Errno.errno` and `Errno.handle` if we merge this first.