### PR TITLE
Inline nil? calls in the AST

### DIFF
--- a/src/main/java/org/truffleruby/builtins/BuiltinsClasses.java
+++ b/src/main/java/org/truffleruby/builtins/BuiltinsClasses.java
@@ -40,6 +40,8 @@ import org.truffleruby.core.binding.TruffleBindingNodesBuiltins;
 import org.truffleruby.core.binding.TruffleBindingNodesFactory;
 import org.truffleruby.core.bool.FalseClassNodesBuiltins;
 import org.truffleruby.core.bool.FalseClassNodesFactory;
+import org.truffleruby.core.bool.NilClassNodesBuiltins;
+import org.truffleruby.core.bool.NilClassNodesFactory;
 import org.truffleruby.core.bool.TrueClassNodesBuiltins;
 import org.truffleruby.core.bool.TrueClassNodesFactory;
 import org.truffleruby.core.encoding.EncodingConverterNodesBuiltins;
@@ -208,6 +210,7 @@ public abstract class BuiltinsClasses {
         ModuleNodesBuiltins.setup(coreManager, primitiveManager);
         MutexNodesBuiltins.setup(coreManager, primitiveManager);
         NameErrorNodesBuiltins.setup(coreManager, primitiveManager);
+        NilClassNodesBuiltins.setup(coreManager, primitiveManager);
         NoMethodErrorNodesBuiltins.setup(coreManager, primitiveManager);
         ObjectSpaceNodesBuiltins.setup(coreManager, primitiveManager);
         ObjSpaceNodesBuiltins.setup(coreManager, primitiveManager);
@@ -289,6 +292,7 @@ public abstract class BuiltinsClasses {
             ModuleNodesFactory.getFactories(),
             MutexNodesFactory.getFactories(),
             NameErrorNodesFactory.getFactories(),
+            NilClassNodesFactory.getFactories(),
             NoMethodErrorNodesFactory.getFactories(),
             ObjectSpaceNodesFactory.getFactories(),
             ObjSpaceNodesFactory.getFactories(),

--- a/src/main/java/org/truffleruby/core/bool/NilClassNodes.java
+++ b/src/main/java/org/truffleruby/core/bool/NilClassNodes.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby.core.bool;
+
+import org.truffleruby.builtins.CoreClass;
+import org.truffleruby.builtins.CoreMethod;
+import org.truffleruby.builtins.CoreMethodNode;
+import org.truffleruby.core.inlined.InlinedIsNilNode;
+
+import com.oracle.truffle.api.dsl.Specialization;
+
+@CoreClass("NilClass")
+public abstract class NilClassNodes {
+
+    /** Needs to be in Java for {@link InlinedIsNilNode} */
+    @CoreMethod(names = "nil?", needsSelf = false)
+    public abstract static class AndNode extends CoreMethodNode {
+
+        @Specialization
+        public boolean isNil() {
+            return true;
+        }
+    }
+
+}

--- a/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
+++ b/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
@@ -38,8 +38,11 @@ public class CoreMethods {
     final Assumption fixnumLessThanAssumption, fixnumLessOrEqualAssumption;
     final Assumption fixnumGreaterThanAssumption, fixnumGreaterOrEqualAssumption;
 
+    final Assumption nilClassIsNilAssumption;
+
     public final InternalMethod BLOCK_GIVEN;
     public final InternalMethod NOT;
+    public final InternalMethod KERNEL_IS_NIL;
 
     public CoreMethods(RubyContext context) {
         this.context = context;
@@ -47,6 +50,7 @@ public class CoreMethods {
         final DynamicObject kernelModule = context.getCoreLibrary().getKernelModule();
         final DynamicObject fixnumClass = context.getCoreLibrary().getFixnumClass();
         final DynamicObject floatClass = context.getCoreLibrary().getFloatClass();
+        final DynamicObject nilClass = context.getCoreLibrary().getNilClass();
 
         fixnumAddAssumption = registerAssumption(fixnumClass, "+");
         floatAddAssumption = registerAssumption(floatClass, "+");
@@ -74,8 +78,11 @@ public class CoreMethods {
         fixnumGreaterThanAssumption = registerAssumption(fixnumClass, ">");
         fixnumGreaterOrEqualAssumption = registerAssumption(fixnumClass, ">=");
 
+        nilClassIsNilAssumption = registerAssumption(nilClass, "nil?");
+
         BLOCK_GIVEN = getMethod(kernelModule, "block_given?");
         NOT = getMethod(basicObjectClass, "!");
+        KERNEL_IS_NIL = getMethod(kernelModule, "nil?");
     }
 
     private Assumption registerAssumption(DynamicObject klass, String methodName) {
@@ -109,6 +116,8 @@ public class CoreMethods {
                         return InlinedBlockGivenNodeGen.create(context, callParameters, self);
                     }
                     break;
+                case "nil?":
+                    return InlinedIsNilNodeGen.create(context, callParameters, self);
                 default:
             }
         } else if (n == 2) {

--- a/src/main/java/org/truffleruby/core/inlined/InlinedIsNilNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedIsNilNode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby.core.inlined;
+
+import org.truffleruby.RubyContext;
+import org.truffleruby.language.dispatch.RubyCallNodeParameters;
+import org.truffleruby.language.methods.LookupMethodNode;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+public abstract class InlinedIsNilNode extends UnaryInlinedOperationNode {
+
+    protected static final String METHOD = "nil?";
+
+    public InlinedIsNilNode(RubyContext context, RubyCallNodeParameters callNodeParameters) {
+        super(callNodeParameters,
+                context.getCoreMethods().nilClassIsNilAssumption);
+    }
+
+    @Specialization(guards = "isNil(self)", assumptions = "assumptions")
+    boolean nil(Object self) {
+        return true;
+    }
+
+    @Specialization(guards = {
+            "!isForeignObject(self)",
+            "lookupNode.lookup(frame, self, METHOD) == coreMethods().KERNEL_IS_NIL",
+    }, assumptions = "assumptions", limit = "1")
+    boolean notNil(VirtualFrame frame, Object self,
+            @Cached("create()") LookupMethodNode lookupNode) {
+        return false;
+    }
+
+    @Specialization
+    Object fallback(VirtualFrame frame, Object self) {
+        return rewriteAndCall(frame, self);
+    }
+
+}

--- a/src/main/ruby/core/nil.rb
+++ b/src/main/ruby/core/nil.rb
@@ -41,10 +41,6 @@ class NilClass
     'nil'
   end
 
-  def nil?
-    true
-  end
-
   def to_a
     []
   end


### PR DESCRIPTION
* Unfortunately, this requires NilClass#nil? to be defined in Java,
  as otherwise we cannot replace nil? calls in the core library safely.