### PR TITLE
Fix Time#round

### DIFF
--- a/spec/ruby/core/time/round_spec.rb
+++ b/spec/ruby/core/time/round_spec.rb
@@ -3,7 +3,6 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe "Time#round" do
   before do
     @time = Time.utc(2010, 3, 30, 5, 43, "25.123456789".to_r)
-    @subclass = Class.new(Time).now
   end
 
   it "defaults to rounding to 0 places" do
@@ -19,7 +18,10 @@ describe "Time#round" do
   end
 
   it "returns an instance of Time, even if #round is called on a subclass" do
-    @subclass.round.should be_an_instance_of(Time)
+    subclass = Class.new(Time)
+    instance = subclass.at(0)
+    instance.class.should equal subclass
+    instance.round.should be_an_instance_of(Time)
   end
 
   it "copies own timezone to the returning value" do

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -751,7 +751,7 @@ public abstract class KernelNodes {
         @Child private LogicalClassNode classNode = LogicalClassNodeGen.create(null);
 
         @Specialization(guards = "isRubyModule(rubyClass)")
-        public boolean instanceOf(VirtualFrame frame, Object self, DynamicObject rubyClass) {
+        public boolean instanceOf(Object self, DynamicObject rubyClass) {
             return classNode.executeLogicalClass(self) == rubyClass;
         }
 

--- a/src/main/ruby/core/time.rb
+++ b/src/main/ruby/core/time.rb
@@ -198,8 +198,6 @@ class Time
   end
 
   def round(places = 0)
-    return dup if nsec == 0
-
     roundable_time = (to_i + subsec.to_r).round(places)
 
     sec = roundable_time.floor

--- a/src/main/ruby/core/time.rb
+++ b/src/main/ruby/core/time.rb
@@ -198,14 +198,12 @@ class Time
   end
 
   def round(places = 0)
-    roundable_time = (to_i + subsec.to_r).round(places)
-
-    sec = roundable_time.floor
-    nano = ((roundable_time - sec) * 1_000_000_000).floor
+    original = to_i + subsec.to_r
+    rounded = original.round(places)
 
     time = Time.allocate
     time.send(:initialize_copy, self)
-    Truffle.invoke_primitive(:time_add, time, sec - tv_sec, nano - tv_nsec)
+    time + (rounded - original)
   end
 
   def self._load(data)


### PR DESCRIPTION
I have been seeing a Time#round spec fail spuriously for ages, but never found the problem.
It's just hidden in plain sight!
A bad shortcut from Rubinius code, that only happens if you are at millisecond=0.