### PR TITLE
Fix magic comment symbol encoding

### DIFF
--- a/spec/tags/language/symbol_tags.txt
+++ b/spec/tags/language/symbol_tags.txt
@@ -1,2 +1,1 @@
 slow:A Symbol literal inherits the encoding of the magic comment and can have a binary encoding
-fails:A Symbol literal inherits the encoding of the magic comment and can have a binary encoding

--- a/src/main/java/org/truffleruby/parser/ast/SymbolParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/SymbolParseNode.java
@@ -55,14 +55,14 @@ public class SymbolParseNode extends ParseNode implements ILiteralNode, INameNod
 
     // Interned ident path (e.g. [':', ident]).
     public SymbolParseNode(SourceIndexLength position, String name, Encoding encoding, CodeRange cr) {
+        // The cr argument is ignored since it is not always correct
         super(position);
         this.name = name;  // Assumed all names are already intern'd by lexer.
-
-        if (encoding == USASCIIEncoding.INSTANCE || cr == CodeRange.CR_7BIT) {
-            encoding = USASCIIEncoding.INSTANCE;
+        if (encoding.isAsciiCompatible() && StringOperations.isASCIIOnly(name)) {
+            this.rope = StringOperations.encodeRope(name, USASCIIEncoding.INSTANCE, CodeRange.CR_7BIT);
+        } else {
+            this.rope = StringOperations.encodeRope(name, encoding, CodeRange.CR_UNKNOWN);
         }
-
-        this.rope = StringOperations.encodeRope(name, encoding, cr == null ? CodeRange.CR_UNKNOWN : cr);
     }
 
     // String path (e.g. [':', str_beg, str_content, str_end])


### PR DESCRIPTION
Related logic in MRI found here:
https://github.com/ruby/ruby/blob/4bd69735af901266ec21486243fc206030caa6b9/symbol.c#L588
https://github.com/ruby/ruby/blob/4bd69735af901266ec21486243fc206030caa6b9/symbol.c#L428