### PR TITLE
Add previous definition warning for already initialized constants

### DIFF
--- a/src/main/java/org/truffleruby/core/constant/WarnAlreadyInitializedNode.java
+++ b/src/main/java/org/truffleruby/core/constant/WarnAlreadyInitializedNode.java
@@ -21,13 +21,17 @@ public class WarnAlreadyInitializedNode extends RubyBaseNode {
     @Child private WarnNode warnNode = new WarnNode();
 
     @TruffleBoundary
-    public void warnAlreadyInitialized(DynamicObject module, String name, SourceSection sourceSection) {
+    public void warnAlreadyInitialized(DynamicObject module, String name, SourceSection sourceSection, SourceSection previousSourceSection) {
         final String moduleName = Layouts.MODULE.getFields(module).getName();
-        if (sourceSection != null) {
-            warnNode.warn(sourceSection.getSource().getName(), ":", Integer.toString(sourceSection.getStartLine()),
-                    ": warning: already initialized constant ", moduleName, "::", name);
+        final String constName;
+        if (module == getContext().getCoreLibrary().getObjectClass()) {
+            constName = name;
         } else {
-            warnNode.warn("warning: already initialized constant ", moduleName, "::", name);
+            constName = moduleName + "::" + name;
+        }
+        warnNode.warningMessage(sourceSection, "already initialized constant " + constName);
+        if (previousSourceSection != null) {
+            warnNode.warningMessage(previousSourceSection, "previous definition of " + name + " was here");
         }
     }
 

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -960,19 +960,19 @@ public abstract class ModuleNodes {
                 throw new RaiseException(coreExceptions().nameError(StringUtils.format("wrong constant name %s", name), module, name, this));
             }
 
-            final boolean redefined = Layouts.MODULE.getFields(module).setConstant(getContext(), this, name, value);
-            if (redefined) {
-                warnAlreadyInitializedConstant(module, name);
+            final RubyConstant previous = Layouts.MODULE.getFields(module).setConstant(getContext(), this, name, value);
+            if (previous != null) {
+                warnAlreadyInitializedConstant(module, name, previous.getSourceSection());
             }
             return value;
         }
 
-        private void warnAlreadyInitializedConstant(DynamicObject module, String name) {
+        private void warnAlreadyInitializedConstant(DynamicObject module, String name, SourceSection previousSourceSection) {
             if (warnAlreadyInitializedNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 warnAlreadyInitializedNode = insert(new WarnAlreadyInitializedNode());
             }
-            warnAlreadyInitializedNode.warnAlreadyInitialized(module, name, getSourceSection());
+            warnAlreadyInitializedNode.warnAlreadyInitialized(module, name, getSourceSection(), previousSourceSection);
         }
 
     }

--- a/src/main/java/org/truffleruby/language/RubyConstant.java
+++ b/src/main/java/org/truffleruby/language/RubyConstant.java
@@ -11,6 +11,7 @@ package org.truffleruby.language;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.source.SourceSection;
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
 
@@ -21,14 +22,17 @@ public class RubyConstant {
     private final boolean isPrivate;
     private final boolean autoload;
     private final boolean isDeprecated;
+    private final SourceSection sourceSection;
 
-    public RubyConstant(DynamicObject declaringModule, Object value, boolean isPrivate, boolean autoload, boolean isDeprecated) {
+    public RubyConstant(DynamicObject declaringModule, Object value, boolean isPrivate, boolean autoload, boolean isDeprecated,
+                        SourceSection sourceSection) {
         assert RubyGuards.isRubyModule(declaringModule);
         this.declaringModule = declaringModule;
         this.value = value;
         this.isPrivate = isPrivate;
         this.autoload = autoload;
         this.isDeprecated = isDeprecated;
+        this.sourceSection = sourceSection;
     }
 
     public DynamicObject getDeclaringModule() {
@@ -47,11 +51,15 @@ public class RubyConstant {
         return isDeprecated;
     }
 
+    public SourceSection getSourceSection() {
+        return sourceSection;
+    }
+
     public RubyConstant withPrivate(boolean isPrivate) {
         if (isPrivate == this.isPrivate) {
             return this;
         } else {
-            return new RubyConstant(declaringModule, value, isPrivate, autoload, isDeprecated);
+            return new RubyConstant(declaringModule, value, isPrivate, autoload, isDeprecated, sourceSection);
         }
     }
 
@@ -59,7 +67,7 @@ public class RubyConstant {
         if (this.isDeprecated()) {
             return this;
         } else {
-            return new RubyConstant(declaringModule, value, isPrivate, autoload, true);
+            return new RubyConstant(declaringModule, value, isPrivate, autoload, true, sourceSection);
         }
     }
 
@@ -68,7 +76,7 @@ public class RubyConstant {
         if (newDeclaringModule == declaringModule) {
             return this;
         } else {
-            return new RubyConstant(newDeclaringModule, value, isPrivate, autoload, isDeprecated);
+            return new RubyConstant(newDeclaringModule, value, isPrivate, autoload, isDeprecated, sourceSection);
         }
     }
 


### PR DESCRIPTION
Also updates constants defined on `Object` to be shown as `ONE` instead of `Object::ONE`.