### PR TITLE
Fix compilation of libtruffleposix for Darwin before Sierra

### DIFF
--- a/src/main/c/truffleposix/Makefile
+++ b/src/main/c/truffleposix/Makefile
@@ -14,6 +14,14 @@ endif
 CFLAGS := -Wall -Werror -fPIC -std=c99
 LDFLAGS := -m64
 
+ifeq ($(OS),Darwin)
+DARWIN_VERSION := $(shell uname -r | sed 's/\..*//')
+MACOS_SIERRA := $(shell test $(DARWIN_VERSION) -gt 15 || echo no)
+ifeq ($(MACOS_SIERRA),no)
+CFLAGS := $(CFLAGS) -DNO_CLOCK_GETTIME
+endif
+endif
+
 ifeq ($(OS),Linux)
 LDFLAGS += -lrt
 endif

--- a/src/main/c/truffleposix/truffleposix.c
+++ b/src/main/c/truffleposix/truffleposix.c
@@ -203,6 +203,7 @@ static void copy_stat(struct stat *native_stat, struct truffleposix_stat* buffer
   buffer->uid     = native_stat->st_uid;
 }
 
+#ifndef NO_CLOCK_GETTIME
 int64_t truffleposix_clock_gettime(int clock) {
   struct timespec timespec;
   int ret = clock_gettime((clockid_t) clock, &timespec);
@@ -211,6 +212,7 @@ int64_t truffleposix_clock_gettime(int clock) {
   }
   return ((int64_t) timespec.tv_sec * 1000000000) + (int64_t) timespec.tv_nsec;
 }
+#endif
 
 #define CHECK(call, label) if ((error = call) != 0) { perror(#call); goto label; }
 


### PR DESCRIPTION
* clock_gettime() is only available on macOS Sierra or newer.