### PR TITLE
Fix global constant assignment name

### DIFF
--- a/spec/tags/language/constants_tags.txt
+++ b/spec/tags/language/constants_tags.txt
@@ -1,1 +1,0 @@
-fails:Constant resolution within methods with ||= assigns a global constant if previously undefined

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -2263,7 +2263,7 @@ states[227] = new ParserState() {
 states[228] = new ParserState() {
   @Override public Object execute(ParserSupport support, RubyLexer lexer, Object yyVal, Object[] yyVals, int yyTop) {
                     SourceIndexLength pos = lexer.getPosition();
-                    yyVal = support.newOpConstAsgn(pos, new Colon3ParseNode(pos, ((String)yyVals[-3+yyTop])), ((String)yyVals[-1+yyTop]), ((ParseNode)yyVals[0+yyTop]));
+                    yyVal = support.newOpConstAsgn(pos, new Colon3ParseNode(pos, ((String)yyVals[-2+yyTop])), ((String)yyVals[-1+yyTop]), ((ParseNode)yyVals[0+yyTop]));
     return yyVal;
   }
 };

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -1078,7 +1078,7 @@ arg             : lhs '=' arg {
                 }
                 | tCOLON3 tCONSTANT tOP_ASGN arg {
                     SourceIndexLength pos = lexer.getPosition();
-                    $$ = support.newOpConstAsgn(pos, new Colon3ParseNode(pos, $1), $3, $4);
+                    $$ = support.newOpConstAsgn(pos, new Colon3ParseNode(pos, $2), $3, $4);
                 }
                 | backref tOP_ASGN arg {
                     support.backrefAssignError($1);


### PR DESCRIPTION
The current constant name being set to `::` is causing this issue for this example: `::OpAssignGlobalUndefinedExplicitScope ||= 42`.