### PR TITLE
Untag optional assignment specs

### DIFF
--- a/spec/tags/language/optional_assignments_tags.txt
+++ b/spec/tags/language/optional_assignments_tags.txt
@@ -1,2 +1,0 @@
-fails:Optional variable assignments using compunded constants with &&= assignments
-fails:Optional variable assignments using compunded constants with operator assignments


### PR DESCRIPTION
These appear to have been resolved by the warning added in #732 