### PR TITLE
Warnings fixes

### DIFF
--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -330,7 +330,7 @@ public class ModuleFields implements ModuleChain, ObjectGraphNode {
 
             if ((previous == null) ? (constants.putIfAbsent(name, newValue) == null) : constants.replace(name, previous, newValue)) {
                 newConstantsVersion();
-                if (!autoload) {
+                if (!autoload && previous != null && !previous.isAutoload()) {
                     return previous;
                 } else {
                     return null;

--- a/src/main/java/org/truffleruby/parser/RubyWarnings.java
+++ b/src/main/java/org/truffleruby/parser/RubyWarnings.java
@@ -36,18 +36,18 @@ import org.truffleruby.debug.DebugHelpers;
 
 public class RubyWarnings implements WarnCallback {
 
-    private final RubyContext runtime;
+    private final RubyContext context;
 
-    public RubyWarnings(RubyContext runtime) {
-        this.runtime = runtime;
+    public RubyWarnings(RubyContext context) {
+        this.context = context;
     }
 
     public boolean warningsEnabled() {
-        return runtime.getCoreLibrary().warningsEnabled();
+        return context.getCoreLibrary().warningsEnabled();
     }
 
     public boolean isVerbose() {
-        return runtime != null && runtime.getCoreLibrary().isVerbose();
+        return context != null && context.getCoreLibrary().isVerbose();
     }
 
     @Override
@@ -68,7 +68,7 @@ public class RubyWarnings implements WarnCallback {
 
         buffer.append(fileName).append(':').append(lineNumber).append(": ");
         buffer.append("warning: ").append(message).append('\n');
-        DebugHelpers.eval(runtime, "$stderr.write Truffle::Interop.from_java_string(message)", "message", buffer.toString());
+        DebugHelpers.eval(context, "$stderr.write Truffle::Interop.from_java_string(message)", "message", buffer.toString());
     }
     /**
      * Prints a warning, unless $VERBOSE is nil.
@@ -86,7 +86,7 @@ public class RubyWarnings implements WarnCallback {
         }
         buffer.append("warning: ").append(message).append('\n');
         DebugHelpers.eval(
-                runtime,
+                context,
                 "$stderr.write Truffle::Interop.from_java_string(message)",
                 "message",
                 buffer.toString());

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -747,7 +747,7 @@ public class RubyLexer {
     }
 
     private boolean arg_ambiguous() {
-        if (warnings.isVerbose() && !parserSupport.skipTruffleRubiniusWarnings(this)) {
+        if (warnings.isVerbose()) {
             warnings.warning(getFile(), getPosition().toSourceSection(src.getSource()).getStartLine(), "Ambiguous first argument; make sure.");
         }
         return true;
@@ -2048,8 +2048,9 @@ public class RubyLexer {
         default:
             pushback(c);
             if (isSpaceArg(c, spaceSeen)) {
-                if (warnings.isVerbose() && !parserSupport.skipTruffleRubiniusWarnings(this))
+                if (warnings.isVerbose()) {
                     warnings.warning(getFile(), getPosition().toSourceSection(src.getSource()).getStartLine(), "`*' interpreted as argument prefix");
+                }
                 c = Tokens.tSTAR;
             } else if (isBEG()) {
                 c = Tokens.tSTAR;

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -1355,9 +1355,7 @@ public class ParserSupport {
         if (current.isBlockScope()) {
             if (current.exists(name) >= 0) yyerror("duplicated argument name");
 
-            if (warnings.isVerbose() && current.isDefined(name) >= 0 &&
-                    !skipTruffleRubiniusWarnings(lexer)) {
-
+            if (warnings.isVerbose() && current.isDefined(name) >= 0) {
                 warnings.warning(file, lexer.getPosition().toSourceSection(lexer.getSource()).getStartLine(),
                         "shadowing outer local variable - " + name);
             }
@@ -1605,10 +1603,6 @@ public class ParserSupport {
 
     public String internalId() {
         return "";
-    }
-
-    public boolean skipTruffleRubiniusWarnings(RubyLexer lexer) {
-        return lexer.getFile().startsWith(context.getOptions().CORE_LOAD_PATH);
     }
 
     public SourceIndexLength extendedUntil(SourceIndexLength start, SourceIndexLength end) {


### PR DESCRIPTION
Fixes the warning
```
lib/mri/rubygems/requirement.rb:292: warning: already initialized constant Gem::Version::Requirement
```
on
```
jt ruby -Xlazy.default=false -w -d -e 'p 3'
```