### PR TITLE
Avoid struct definitions from config in core

### DIFF
--- a/spec/ruby/core/file/utime_spec.rb
+++ b/spec/ruby/core/file/utime_spec.rb
@@ -33,4 +33,11 @@ describe "File.utime" do
   it "accepts an object that has a #to_path method" do
     File.utime(@atime, @mtime, mock_to_path(@file1), mock_to_path(@file2))
   end
+
+  it "allows Time instances in the far future to set mtime and atime" do
+    time = Time.at(1<<44)
+    File.utime(time, time, @file1)
+    File.atime(@file1).year.should == 559444
+    File.mtime(@file1).year.should == 559444
+  end
 end

--- a/src/main/c/truffleposix/truffleposix.c
+++ b/src/main/c/truffleposix/truffleposix.c
@@ -49,6 +49,7 @@ SUCH DAMAGE.
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <utime.h>
 
 #include <sys/file.h>
 #include <sys/resource.h>
@@ -120,6 +121,15 @@ int truffleposix_select(int nread, int *readfds, int nwrite, int *writefds,
     mark_ready_from_set(&exceptset, nexcept, exceptfds);
   }
   return ret;
+}
+
+int truffleposix_utimes(const char *filename, long atime_us, long mtime_us) {
+  struct timeval timevals[2];
+  timevals[0].tv_sec = (atime_us / 1000000);
+  timevals[0].tv_usec = (atime_us % 1000000);
+  timevals[1].tv_sec = (mtime_us / 1000000);
+  timevals[1].tv_usec = (mtime_us % 1000000);
+  return utimes(filename, timevals);
 }
 
 #define timeval2double(timeval) \

--- a/src/main/c/truffleposix/truffleposix.c
+++ b/src/main/c/truffleposix/truffleposix.c
@@ -123,12 +123,13 @@ int truffleposix_select(int nread, int *readfds, int nwrite, int *writefds,
   return ret;
 }
 
-int truffleposix_utimes(const char *filename, long atime_us, long mtime_us) {
+int truffleposix_utimes(const char *filename, long atime_sec, int atime_us,
+                        long mtime_sec, int mtime_us) {
   struct timeval timevals[2];
-  timevals[0].tv_sec = (atime_us / 1000000);
-  timevals[0].tv_usec = (atime_us % 1000000);
-  timevals[1].tv_sec = (mtime_us / 1000000);
-  timevals[1].tv_usec = (mtime_us % 1000000);
+  timevals[0].tv_sec = atime_sec;
+  timevals[0].tv_usec = atime_us;
+  timevals[1].tv_sec = mtime_sec;
+  timevals[1].tv_usec = mtime_us;
   return utimes(filename, timevals);
 }
 

--- a/src/main/ruby/core/file.rb
+++ b/src/main/ruby/core/file.rb
@@ -1126,11 +1126,10 @@ class File < IO
       atime ||= now
       mtime ||= now
     end
-    atime_us = (atime.to_f * 1_000_000).to_i
-    mtime_us = (mtime.to_f * 1_000_000).to_i
     paths.each do |path|
       path = Rubinius::Type.coerce_to_path(path)
-      n = POSIX.truffleposix_utimes(path, atime_us, mtime_us)
+      n = POSIX.truffleposix_utimes(path, atime.to_i, atime.usec,
+                                          mtime.to_i, mtime.usec)
       Errno.handle unless n == 0
     end
   end

--- a/src/main/ruby/core/file.rb
+++ b/src/main/ruby/core/file.rb
@@ -1121,8 +1121,11 @@ class File < IO
   # of file names in the argument list.
   #  #=> Integer
   def self.utime(atime, mtime, *paths)
-    atime ||= Time.now
-    mtime ||= Time.now
+    if !atime || !mtime
+      now = Time.now
+      atime ||= now
+      mtime ||= now
+    end
     atime_us = (atime.to_f * 1_000_000).to_i
     mtime_us = (mtime.to_f * 1_000_000).to_i
     paths.each do |path|

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -162,7 +162,7 @@ module Truffle::POSIX
   attach_function :truncate, [:string, :off_t], :int
   attach_function :umask, [:mode_t], :mode_t
   attach_function :unlink, [:string], :int
-  attach_function :truffleposix_utimes, [:string, :long, :long], :int, library: LIBTRUFFLEPOSIX
+  attach_function :truffleposix_utimes, [:string, :long, :int, :long, :int], :int, library: LIBTRUFFLEPOSIX
   attach_function :write, [:int, :pointer, :size_t], :ssize_t, blocking: true
 
   # Process-related

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -162,7 +162,7 @@ module Truffle::POSIX
   attach_function :truncate, [:string, :off_t], :int
   attach_function :umask, [:mode_t], :mode_t
   attach_function :unlink, [:string], :int
-  attach_function :utimes, [:string, :pointer], :int
+  attach_function :truffleposix_utimes, [:string, :long, :long], :int, library: LIBTRUFFLEPOSIX
   attach_function :write, [:int, :pointer, :size_t], :ssize_t, blocking: true
 
   # Process-related


### PR DESCRIPTION
Less code to run during startup, and we might be able to not load the FFI struct-related code in core at all.