### PR TITLE
Restrict the File.utime spec with large times to Linux 64-bit

### DIFF
--- a/spec/ruby/core/file/utime_spec.rb
+++ b/spec/ruby/core/file/utime_spec.rb
@@ -34,10 +34,14 @@ describe "File.utime" do
     File.utime(@atime, @mtime, mock_to_path(@file1), mock_to_path(@file2))
   end
 
-  it "allows Time instances in the far future to set mtime and atime" do
-    time = Time.at(1<<44)
-    File.utime(time, time, @file1)
-    File.atime(@file1).year.should == 559444
-    File.mtime(@file1).year.should == 559444
+  platform_is :linux do
+    platform_is wordsize: 64 do
+      it "allows Time instances in the far future to set mtime and atime" do
+        time = Time.at(1<<44)
+        File.utime(time, time, @file1)
+        File.atime(@file1).year.should == 559444
+        File.mtime(@file1).year.should == 559444
+      end
+    end
   end
 end


### PR DESCRIPTION
* Notably it seems not supported on some macOS setups.