### PR TITLE
Add missing include for minor()/major()

### DIFF
--- a/src/main/c/truffleposix/truffleposix.c
+++ b/src/main/c/truffleposix/truffleposix.c
@@ -68,7 +68,7 @@ SUCH DAMAGE.
 #endif
 
 /* For minor()/major() on Solaris */
-#if defined __sun
+#ifdef __sun
 #include <sys/mkdev.h>
 #endif
 
@@ -256,7 +256,7 @@ pid_t truffleposix_waitpid(pid_t pid, int options, int result[3]) {
 }
 
 /* flock() is not available on Solaris */
-#if defined __sun
+#ifdef __sun
 #define LOCK_SH 1
 #define LOCK_EX 2
 #define LOCK_NB 4

--- a/src/main/c/truffleposix/truffleposix.c
+++ b/src/main/c/truffleposix/truffleposix.c
@@ -62,6 +62,11 @@ SUCH DAMAGE.
 #include <sys/types.h>
 #include <sys/wait.h>
 
+/* For minor()/major() on Linux */
+#ifdef __linux__
+#include <sys/sysmacros.h>
+#endif
+
 /* For minor()/major() on Solaris */
 #if defined __sun
 #include <sys/mkdev.h>


### PR DESCRIPTION
* Otherwise the compiler complains on recent glibc:
 error: In the GNU C Library, "minor" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "minor", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "minor", you should undefine it after including <sys/types.h>.