### PR TITLE
Ugly hack for loading libm on Debian-based systems.

### DIFF
--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -81,7 +81,9 @@ module Truffle::CExt
       if lib.start_with?('lib') or lib.start_with?('/')
         lib
       else
-        "lib#{lib}.#{RbConfig::CONFIG['NATIVE_DLEXT']}"
+        res = "lib#{lib}.#{RbConfig::CONFIG['NATIVE_DLEXT']}"
+        res += '.6' if lib == 'm'
+        res
       end
     end
   end


### PR DESCRIPTION
On Debian-based systems, libm.so is a GNU ld script, not a shared library, and thus fails to `dlopen`. We really need to specify the proper SO version to dlopen. Absent a good general purpose solution, this hack fixes the immediate problem with loading libm, which is needed by Nokogiri.

I've added everyone to this to see if someone has a better general purpose solution. The three I've come up with are: we could try parsing the GNU ld scripts ourselves; we could try some name-mangling and get them from `gnu/lib-names.h` in our own utility; we could try parsing the output of `ldconfig`. I'm hoping there's a better tool in the C toolchain that I'm overlooking.