### PR TITLE
Use the fact that FFI::MemoryPointer.new(&block) returns the value of the block

### DIFF
--- a/src/main/ruby/core/file.rb
+++ b/src/main/ruby/core/file.rb
@@ -910,7 +910,7 @@ class File < IO
       n = POSIX.readlink Rubinius::Type.coerce_to_path(path), ptr, Rubinius::PATH_MAX
       Errno.handle if n == -1
 
-      return ptr.read_string(n).force_encoding(Encoding.find('filesystem'))
+      ptr.read_string(n).force_encoding(Encoding.find('filesystem'))
     end
   end
 

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -825,11 +825,10 @@ class IO
   end
 
   def self.pipe(external=nil, internal=nil, options=nil)
-    fds = nil
-    FFI::MemoryPointer.new(:int, 2) do |ptr|
+    fds = FFI::MemoryPointer.new(:int, 2) do |ptr|
       r = Truffle::POSIX.pipe(ptr)
       Errno.handle if r == -1
-      fds = ptr.read_array_of_int(2)
+      ptr.read_array_of_int(2)
     end
 
     lhs = self.new(fds[0], RDONLY)
@@ -1073,7 +1072,6 @@ class IO
       }
     }
 
-    value = nil
     Truffle::POSIX.with_array_of_ints(to_fds.call(readables)) do |readables_ptr|
       Truffle::POSIX.with_array_of_ints(to_fds.call(writables)) do |writables_ptr|
         Truffle::POSIX.with_array_of_ints(to_fds.call(errorables)) do |errorables_ptr|
@@ -1081,7 +1079,7 @@ class IO
             start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
           end
 
-          value = Truffle.invoke_primitive :thread_run_blocking_nfi_system_call, -> do
+          Truffle.invoke_primitive :thread_run_blocking_nfi_system_call, -> do
             ret = Truffle::POSIX.truffleposix_select(
               readables.size, readables_ptr,
               writables.size, writables_ptr,
@@ -1117,7 +1115,6 @@ class IO
         end
       end
     end
-    value
   end
 
   ##

--- a/src/main/ruby/core/process_mirror.rb
+++ b/src/main/ruby/core/process_mirror.rb
@@ -461,7 +461,7 @@ module Rubinius
           Truffle::POSIX.with_array_of_ints(redirects) do |redirects_ptr|
             Truffle::POSIX.with_array_of_strings_pointer(args) do |argv|
               Truffle::POSIX.with_array_of_strings_pointer(env_array) do |env|
-                return Truffle::POSIX.truffleposix_posix_spawnp(command, argv, env, redirects.size, redirects_ptr, pgroup)
+                Truffle::POSIX.truffleposix_posix_spawnp(command, argv, env, redirects.size, redirects_ptr, pgroup)
               end
             end
           end

--- a/src/main/ruby/core/truffle/ffi/pointer.rb
+++ b/src/main/ruby/core/truffle/ffi/pointer.rb
@@ -1175,12 +1175,10 @@ module Rubinius::FFI
 
       if block_given?
         begin
-          value = yield ptr
+          yield ptr
         ensure
           ptr.free
         end
-
-        return value
       else
         ptr.autorelease = true
         ptr


### PR DESCRIPTION
* The FFI gem does not do it but our implementation does.
* There is already code relying on it.
* Simplifies passing the return value of native calls.

@bjfish I changed my mind, it's too nice to not be used :)
Many core Ruby APIs have `.open` for a block and `.new` without but it doesn't fit so nicely for a pointer class.