### PR TITLE
Increase the default Metaspace size to avoid a Full GC during startup

### DIFF
--- a/bin/truffleruby.sh
+++ b/bin/truffleruby.sh
@@ -82,6 +82,10 @@ fi
 java_args=()
 CP=""
 
+# Increase the Metaspace size to avoid a Full GC during startup,
+# triggerred by the default MetaspaceSize (~20MB).
+java_args+=("-XX:MetaspaceSize=25M")
+
 # Truffle
 binary_truffle="$root/mx.imports/binary/truffle/mxbuild"
 source_truffle="$root_parent/graal/truffle/mxbuild"

--- a/test/truffle/integration/startup.sh
+++ b/test/truffle/integration/startup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source test/truffle/common.sh.inc
+
+jt ruby -J-verbose:gc -e 'p :hi' > temp.txt
+
+if grep 'Full GC' temp.txt
+then
+  echo "Unexpected Full GC during startup"
+  cat temp.txt
+  rm temp.txt
+  exit 1
+fi
+
+if grep 'Metadata' temp.txt
+then
+  echo "Unexpected Metadata GC during startup"
+  cat temp.txt
+  rm temp.txt
+  exit 1
+fi
+
+rm temp.txt


### PR DESCRIPTION
* `jt ruby -J-verbose:gc -e 0`
Before:
```
[GC (Allocation Failure)  64000K->10074K(243712K), 0.0102741 secs]
[GC (Metadata GC Threshold)  49873K->16931K(307712K), 0.0195888 secs]
[Full GC (Metadata GC Threshold)  16931K->16782K(267776K), 0.0676871 secs]
```
After:
```
[GC (Allocation Failure)  64000K->10092K(243712K), 0.0137345 secs]
```
* Around 80ms of startup saved according to `jt metrics time -e 0`.
* The Full GC happened during patching or did-you-mean if patching is disabled.