### PR TITLE
Allow to build a Time instance with seconds=60 like MRI

### DIFF
--- a/spec/tags/core/time/utc_tags.txt
+++ b/spec/tags/core/time/utc_tags.txt
@@ -1,3 +1,2 @@
 fails:Time#utc on a frozen time raises a RuntimeError if the time is not UTC
 fails:Time.utc handles real leap seconds
-fails:Time.utc handles bad leap seconds by carrying values forward


### PR DESCRIPTION
* Fixes #824.