### PR TITLE
Allow the linker to continue even if we can't find a lib on the search path.

### DIFF
--- a/src/main/ruby/core/truffle/cext.rb
+++ b/src/main/ruby/core/truffle/cext.rb
@@ -99,6 +99,7 @@ module Truffle::CExt
         # have a more comprehensive search path. Additionally, it's possible Sulong never even needs to load the library.
         # Consequently, on search failure, we just return the normalized library name and allow Sulong an attempt at
         # validation.
+        warn "Could not find a search path for #{lib_name} -- passing #{normalized_lib_name} on to Sulong"
         normalized_lib_name
       end
     end


### PR DESCRIPTION
The problematic lib is "libstdc++.so", which comes from linking "-lstdc++" for C++ extensions. We're unable to `dlopen` this with the limited search path provided by the FFI library. However, `@truffle_load_library` handles the path fine without error and the unf extension runs fine. I don't know if Sulong just never loads the library (`@truffle_load_library` is lazy) or if it has a better search path.