### PR TITLE
Allow TruffleRuby to work with the :ruby platform value in Bundler.

### DIFF
--- a/lib/patches/bundler/bundler/current_ruby.rb
+++ b/lib/patches/bundler/bundler/current_ruby.rb
@@ -6,5 +6,9 @@ module Bundler
     def truffleruby?
       defined?(RUBY_ENGINE) && RUBY_ENGINE == "truffleruby"
     end
+
+    def ruby?
+      truffleruby?
+    end
   end
 end


### PR DESCRIPTION
TruffleRuby aims to be compatible with MRI, so we should be treated the same as MRI for Gemfiles that split dependencies by platform.