### PR TITLE
Number conversions

### DIFF
--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -702,7 +702,7 @@ rb_num2ll_inline(VALUE x)
 }
 # define RB_NUM2LL(x) rb_num2ll_inline(x)
 # define RB_NUM2ULL(x) rb_num2ull(x)
-#define NUM2LL(x) rb_num2ll(x)
+# define NUM2LL(x) RB_NUM2LL(x)
 # define NUM2ULL(x) RB_NUM2ULL(x)
 #endif
 

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -1518,7 +1518,7 @@ rb_num2char_inline(VALUE x)
     else
 	return (char)(NUM2INT(x) & 0xff);
 }
-char RB_NUM2CHR(VALUE x);
+#define RB_NUM2CHR(x) rb_num2char_inline(x)
 
 #define RB_CHR2FIX(x) INT2FIX((long)((x)&0xff))
 

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -627,7 +627,7 @@ rb_num2long_inline(VALUE x)
 	return rb_num2long(x);
 }
 #define RB_NUM2LONG(x) rb_num2long_inline(x)
-long NUM2LONG(VALUE value);
+#define NUM2LONG(x) RB_NUM2LONG(x)
 static inline unsigned long
 rb_num2ulong_inline(VALUE x)
 {
@@ -637,7 +637,7 @@ rb_num2ulong_inline(VALUE x)
 	return rb_num2ulong(x);
 }
 #define RB_NUM2ULONG(x) rb_num2ulong_inline(x)
-unsigned long NUM2ULONG(VALUE value);
+#define NUM2ULONG(x) RB_NUM2ULONG(x)
 #if SIZEOF_INT < SIZEOF_LONG
 long rb_num2int(VALUE);
 long rb_fix2int(VALUE);

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -361,7 +361,7 @@ int RB_FIXNUM_P(VALUE value);
 #define RB_NEGFIXABLE(f) ((f) >= RUBY_FIXNUM_MIN)
 #define RB_FIXABLE(f) (RB_POSFIXABLE(f) && RB_NEGFIXABLE(f))
 #define FIX2LONG(x) RB_FIX2LONG(x)
-unsigned long FIX2ULONG(VALUE value);
+#define FIX2ULONG(x) RB_FIX2ULONG(x)
 #define FIXNUM_P(f) RB_FIXNUM_P(f)
 #define POSFIXABLE(f) RB_POSFIXABLE(f)
 #define NEGFIXABLE(f) RB_NEGFIXABLE(f)

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -1522,7 +1522,7 @@ rb_num2char_inline(VALUE x)
 
 #define RB_CHR2FIX(x) INT2FIX((long)((x)&0xff))
 
-VALUE LONG2NUM(long value);
+#define LONG2NUM(x) RB_LONG2NUM(x)
 #define ULONG2NUM(x) RB_ULONG2NUM(x)
 #define NUM2CHR(x) RB_NUM2CHR(x)
 #define CHR2FIX(x) RB_CHR2FIX(x)

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -666,6 +666,7 @@ unsigned long rb_fix2uint(VALUE);
 int NUM2INT(VALUE value);
 unsigned int NUM2UINT(VALUE value);
 #define FIX2INT(x)  RB_FIX2INT(x)
+#define FIX2UINT(x) RB_FIX2UINT(x)
 
 
 short rb_num2short(VALUE);

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -663,7 +663,7 @@ unsigned long rb_fix2uint(VALUE);
 #define RB_FIX2INT(x) ((int)RB_FIX2LONG(x))
 #define RB_FIX2UINT(x) ((unsigned int)RB_FIX2ULONG(x))
 #endif /* SIZEOF_INT < SIZEOF_LONG */
-int NUM2INT(VALUE value);
+#define NUM2INT(x)  RB_NUM2INT(x)
 unsigned int NUM2UINT(VALUE value);
 #define FIX2INT(x)  RB_FIX2INT(x)
 #define FIX2UINT(x) RB_FIX2UINT(x)

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -1487,8 +1487,8 @@ rb_uint2num_inline(unsigned int v)
 }
 #define RB_UINT2NUM(x) rb_uint2num_inline(x)
 #endif
-VALUE INT2NUM(long value);
-VALUE UINT2NUM(unsigned int value);
+#define INT2NUM(x) RB_INT2NUM(x)
+#define UINT2NUM(x) RB_UINT2NUM(x)
 
 static inline VALUE
 rb_long2num_inline(long v)

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -360,7 +360,7 @@ int RB_FIXNUM_P(VALUE value);
 #define RB_POSFIXABLE(f) ((f) < RUBY_FIXNUM_MAX+1)
 #define RB_NEGFIXABLE(f) ((f) >= RUBY_FIXNUM_MIN)
 #define RB_FIXABLE(f) (RB_POSFIXABLE(f) && RB_NEGFIXABLE(f))
-long FIX2LONG(VALUE value);
+#define FIX2LONG(x) RB_FIX2LONG(x)
 unsigned long FIX2ULONG(VALUE value);
 #define FIXNUM_P(f) RB_FIXNUM_P(f)
 #define POSFIXABLE(f) RB_POSFIXABLE(f)

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -344,7 +344,7 @@ int rb_long2int(long value);
 #define MODET2NUM(v) INT2NUM(v)
 #endif
 
-#define RB_FIX2LONG(x) ((long)RSHIFT((SIGNED_VALUE)(x),1))
+#define RB_FIX2LONG(x) ((long)(x))
 static inline long
 rb_fix2long(VALUE x)
 {
@@ -665,7 +665,7 @@ unsigned long rb_fix2uint(VALUE);
 #endif /* SIZEOF_INT < SIZEOF_LONG */
 int NUM2INT(VALUE value);
 unsigned int NUM2UINT(VALUE value);
-int FIX2INT(VALUE value);
+#define FIX2INT(x)  RB_FIX2INT(x)
 
 
 short rb_num2short(VALUE);

--- a/lib/cext/ruby/ruby.h
+++ b/lib/cext/ruby/ruby.h
@@ -664,7 +664,7 @@ unsigned long rb_fix2uint(VALUE);
 #define RB_FIX2UINT(x) ((unsigned int)RB_FIX2ULONG(x))
 #endif /* SIZEOF_INT < SIZEOF_LONG */
 #define NUM2INT(x)  RB_NUM2INT(x)
-unsigned int NUM2UINT(VALUE value);
+#define NUM2UINT(x) RB_NUM2UINT(x)
 #define FIX2INT(x)  RB_FIX2INT(x)
 #define FIX2UINT(x) RB_FIX2UINT(x)
 

--- a/lib/cext/truffle/ruby.h
+++ b/lib/cext/truffle/ruby.h
@@ -103,7 +103,6 @@ MUST_INLINE int rb_tr_scan_args(int argc, VALUE *argv, const char *format, VALUE
 #define rb_funcall(object, ...) truffle_invoke(RUBY_CEXT, "rb_funcall", (void *) object, __VA_ARGS__)
 
 // Additional non-standard
-unsigned int FIX2UINT(VALUE value);
 int RB_NIL_P(VALUE value);
 VALUE rb_java_class_of(VALUE val);
 VALUE rb_java_to_string(VALUE val);

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -451,10 +451,6 @@ VALUE rb_tr_get_default_rs(void) {
 
 // Conversions
 
-int NUM2INT(VALUE value) {
-  return truffle_invoke_i(RUBY_CEXT, "NUM2INT", value);
-}
-
 unsigned int NUM2UINT(VALUE value) {
   return (unsigned int) NUM2LONG(value);
 }

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -515,10 +515,6 @@ unsigned long NUM2ULONG(VALUE value) {
   return truffle_invoke_l(RUBY_CEXT, "rb_num2ulong", value);
 }
 
-long FIX2LONG(VALUE value) {
-  return truffle_invoke_l(RUBY_CEXT, "FIX2LONG", value);
-}
-
 unsigned long FIX2ULONG(VALUE value) {
   return truffle_invoke_l(RUBY_CEXT, "FIX2ULONG", value);
 }

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -515,10 +515,6 @@ unsigned long NUM2ULONG(VALUE value) {
   return truffle_invoke_l(RUBY_CEXT, "rb_num2ulong", value);
 }
 
-unsigned long FIX2ULONG(VALUE value) {
-  return truffle_invoke_l(RUBY_CEXT, "FIX2ULONG", value);
-}
-
 short rb_num2short(VALUE value) {
   rb_tr_error("rb_num2ushort not implemented");
 }

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -451,10 +451,6 @@ VALUE rb_tr_get_default_rs(void) {
 
 // Conversions
 
-long NUM2LONG(VALUE value) {
-  return truffle_invoke_l(RUBY_CEXT, "rb_num2long", value);
-}
-
 unsigned long rb_num2ulong(VALUE val) {
   return (unsigned long)truffle_invoke_l(RUBY_CEXT, "rb_num2ulong", val);
 }
@@ -509,10 +505,6 @@ LONG_LONG rb_num2ll(VALUE val) {
 
     val = rb_to_int(val);
     return NUM2LL(val);
-}
-
-unsigned long NUM2ULONG(VALUE value) {
-  return truffle_invoke_l(RUBY_CEXT, "rb_num2ulong", value);
 }
 
 short rb_num2short(VALUE value) {

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -519,16 +519,8 @@ short rb_fix2short(VALUE value) {
   rb_tr_error("rb_num2ushort not implemented");
 }
 
-VALUE INT2NUM(long value) {
-  return (VALUE) truffle_invoke(RUBY_CEXT, "INT2NUM", value);
-}
-
 VALUE INT2FIX(long value) {
   return (VALUE) truffle_invoke(RUBY_CEXT, "INT2FIX", value);
-}
-
-VALUE UINT2NUM(unsigned int value) {
-  return (VALUE) truffle_invoke(RUBY_CEXT, "UINT2NUM", value);
 }
 
 VALUE LONG2NUM(long value) {

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -451,10 +451,6 @@ VALUE rb_tr_get_default_rs(void) {
 
 // Conversions
 
-unsigned int NUM2UINT(VALUE value) {
-  return (unsigned int) NUM2LONG(value);
-}
-
 long NUM2LONG(VALUE value) {
   return truffle_invoke_l(RUBY_CEXT, "rb_num2long", value);
 }

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -523,10 +523,6 @@ VALUE INT2FIX(long value) {
   return (VALUE) truffle_invoke(RUBY_CEXT, "INT2FIX", value);
 }
 
-VALUE LONG2NUM(long value) {
-  return (VALUE) truffle_invoke(RUBY_CEXT, "LONG2NUM", value);
-}
-
 VALUE LONG2FIX(long value) {
   return (VALUE) truffle_invoke(RUBY_CEXT, "LONG2FIX", value);
 }
@@ -556,7 +552,7 @@ int rb_cmpint(VALUE val, VALUE a, VALUE b) {
 }
 
 VALUE rb_int2inum(SIGNED_VALUE n) {
-  return (VALUE) truffle_invoke(RUBY_CEXT, "LONG2NUM", n);
+  return (VALUE)LONG2NUM(n);
 }
 
 VALUE rb_uint2inum(VALUE n) {
@@ -567,7 +563,7 @@ VALUE rb_uint2inum(VALUE n) {
 
 VALUE rb_ll2inum(LONG_LONG n) {
   /* Long and long long are both 64-bits with clang x86-64. */
-  return (VALUE) truffle_invoke(RUBY_CEXT, "LONG2NUM", n);
+  return (VALUE)LONG2NUM(n);
 }
 
 VALUE rb_ull2inum(unsigned LONG_LONG val) {
@@ -4640,7 +4636,8 @@ VALUE rb_uint2big(VALUE n) {
 }
 
 VALUE rb_int2big(SIGNED_VALUE n) {
-  rb_tr_error("rb_int2big not implemented");
+  // it cannot overflow Fixnum
+  return LONG2FIX(n);
 }
 
 VALUE rb_newobj(void) {

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -523,10 +523,6 @@ unsigned long NUM2ULONG(VALUE value) {
   return truffle_invoke_l(RUBY_CEXT, "rb_num2ulong", value);
 }
 
-int FIX2INT(VALUE value) {
-  return truffle_invoke_i(RUBY_CEXT, "FIX2INT", value);
-}
-
 unsigned int FIX2UINT(VALUE value) {
   return (unsigned int) truffle_invoke_i(RUBY_CEXT, "FIX2UINT", value);
 }

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -523,10 +523,6 @@ unsigned long NUM2ULONG(VALUE value) {
   return truffle_invoke_l(RUBY_CEXT, "rb_num2ulong", value);
 }
 
-unsigned int FIX2UINT(VALUE value) {
-  return (unsigned int) truffle_invoke_i(RUBY_CEXT, "FIX2UINT", value);
-}
-
 long FIX2LONG(VALUE value) {
   return truffle_invoke_l(RUBY_CEXT, "FIX2LONG", value);
 }

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -551,15 +551,6 @@ VALUE ID2SYM(ID value) {
   return (VALUE) value;
 }
 
-char RB_NUM2CHR(VALUE x) {
-  if (RB_TYPE_P(x, RUBY_T_STRING) && RSTRING_LEN(x)>=1) {
-    return RSTRING_PTR(x)[0];
-  } else {
-    int a = truffle_invoke_i(RUBY_CEXT, "rb_num2int", x);
-    return (char)(a & 0xff);
-  }
-}
-
 int rb_cmpint(VALUE val, VALUE a, VALUE b) {
   return truffle_invoke_i(RUBY_CEXT, "rb_cmpint", val, a, b);
 }

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -130,21 +130,6 @@ public class CExtNodes {
 
     }
 
-    @CoreMethod(names = "FIX2LONG", onSingleton = true, required = 1, lowerFixnum = 1)
-    public abstract static class FIX2LONGNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public long fix2long(int num) {
-            return num;
-        }
-
-        @Specialization
-        public long fix2long(long num) {
-            return num;
-        }
-
-    }
-
     @CoreMethod(names = "INT2NUM", onSingleton = true, required = 1)
     public abstract static class INT2NUMNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -102,21 +102,6 @@ public class CExtNodes {
 
     // TODO CS 19-Mar-17 many of these builtins could just be identify functions with a cast in C
 
-    @CoreMethod(names = "NUM2INT", onSingleton = true, required = 1)
-    public abstract static class NUM2INTNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public int num2int(int num) {
-            return num;
-        }
-
-        @Specialization
-        public int num2int(long num) {
-            return (int) num;
-        }
-
-    }
-
     @CoreMethod(names = "NUM2UINT", onSingleton = true, required = 1, lowerFixnum = 1)
     public abstract static class NUM2UINTNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -130,21 +130,6 @@ public class CExtNodes {
 
     }
 
-    @CoreMethod(names = "INT2NUM", onSingleton = true, required = 1)
-    public abstract static class INT2NUMNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public int int2num(int num) {
-            return num;
-        }
-
-        @Specialization
-        public long int2num(long num) {
-            return num;
-        }
-
-    }
-
     @CoreMethod(names = "INT2FIX", onSingleton = true, required = 1)
     public abstract static class INT2FIXNode extends CoreMethodArrayArgumentsNode {
 
@@ -156,21 +141,6 @@ public class CExtNodes {
         @Specialization
         public long int2fix(long num) {
             return num;
-        }
-
-    }
-
-    @CoreMethod(names = "UINT2NUM", onSingleton = true, required = 1, lowerFixnum = 1)
-    public abstract static class UINT2NUMNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public Object uint2num(int num,
-                @Cached("createBinaryProfile()") ConditionProfile positiveProfile) {
-            if (positiveProfile.profile(num >= 0)) {
-                return num;
-            } else {
-                return Integer.toUnsignedLong(num);
-            }
         }
 
     }

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -127,30 +127,6 @@ public class CExtNodes {
         }
 
     }
-    
-    @CoreMethod(names = "FIX2INT", onSingleton = true, required = 1, lowerFixnum = 1)
-    public abstract static class FIX2INTNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public int fix2int(int num) {
-            return num;
-        }
-
-        @Specialization(guards = "fitsIntoInteger(num)")
-        public int fix2intInRange(long num) {
-            return (int) num;
-        }
-
-        @Specialization(guards = "!fitsIntoInteger(num)")
-        public int fix2intOutOfRange(long num) {
-            throw new RaiseException(coreExceptions().rangeErrorConvertToInt(num, this));
-        }
-
-        protected boolean fitsIntoInteger(long num) {
-            return CoreLibrary.fitsIntoInteger(num);
-        }
-
-    }
 
     @CoreMethod(names = "FIX2UINT", onSingleton = true, required = 1)
     public abstract static class FIX2UINTNode extends CoreMethodArrayArgumentsNode {

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -100,36 +100,7 @@ import static org.truffleruby.core.string.StringOperations.rope;
 @CoreClass("Truffle::CExt")
 public class CExtNodes {
 
-    // TODO CS 19-Mar-17 many of these builtins could just be identify functions with a cast in C
-
-    @CoreMethod(names = "NUM2UINT", onSingleton = true, required = 1, lowerFixnum = 1)
-    public abstract static class NUM2UINTNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public int num2uint(int num) {
-            // TODO CS 2-May-16 what to do about the fact it's unsigned?
-            return num;
-        }
-
-    }
-
-    @CoreMethod(names = "FIX2UINT", onSingleton = true, required = 1)
-    public abstract static class FIX2UINTNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public int fix2uint(int num) {
-            // TODO CS 2-May-16 what to do about the fact it's unsigned?
-            return num;
-        }
-
-        @Specialization
-        public long fix2uint(long num) {
-            // TODO CS 2-May-16 what to do about the fact it's unsigned?
-            return num;
-        }
-
-    }
-
+    // TODO (pitr-ch 14-Dec-2017): remove from java
     @CoreMethod(names = "INT2FIX", onSingleton = true, required = 1)
     public abstract static class INT2FIXNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -145,26 +145,6 @@ public class CExtNodes {
 
     }
 
-    @CoreMethod(names = "LONG2NUM", onSingleton = true, required = 1)
-    public abstract static class LONG2NUMNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public long long2num(long num) {
-            return num;
-        }
-
-    }
-
-    @CoreMethod(names = "LL2NUM", onSingleton = true, required = 1)
-    public abstract static class LL2NUMNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public long longlong2num(long num) {
-            return num;
-        }
-
-    }
-
     @CoreMethod(names = "rb_ulong2num", onSingleton = true, required = 1)
     public abstract static class ULong2NumNode extends CoreMethodArrayArgumentsNode {
 


### PR DESCRIPTION
Based on the bug I needed to fix for zlib in one of the number conversions I did a pass and fixed the most standing out problems: Our direct macro implementations were incomplete, untested and bypassing conversion logic present in theirs method versions; We are now reusing MRI's implementation which become possible thanks to merge of full headers.