### PR TITLE
Remove the license header in mx.truffleruby/suite.py

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -1,11 +1,3 @@
-# Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved. This
-# code is released under a tri EPL/GPL/LGPL license. You can use it,
-# redistribute it and/or modify it under the terms of the:
-#
-# Eclipse Public License version 1.0
-# GNU General Public License version 2
-# GNU Lesser General Public License version 2.1
-
 suite = {
     "mxversion": "5.128.1",
     "name": "truffleruby",


### PR DESCRIPTION
* It creates warnings on the latest mx.
* There is no longer any code in this file.