### PR TITLE
Write Integer#times in Ruby

### DIFF
--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -588,7 +588,7 @@ public class CExtNodes {
 
         @Specialization
         public Object iterBreakValue(Object value) {
-            throw new BreakException(BreakID.ANY, value);
+            throw new BreakException(BreakID.ANY_BLOCK, value);
         }
 
     }

--- a/src/main/java/org/truffleruby/language/control/BreakID.java
+++ b/src/main/java/org/truffleruby/language/control/BreakID.java
@@ -11,6 +11,6 @@ package org.truffleruby.language.control;
 
 public class BreakID {
 
-    public static final BreakID ANY = new BreakID();
+    public static final BreakID ANY_BLOCK = new BreakID();
 
 }

--- a/src/main/java/org/truffleruby/language/methods/CatchBreakNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CatchBreakNode.java
@@ -23,12 +23,13 @@ public class CatchBreakNode extends RubyNode {
     @Child private RubyNode body;
 
     private final ConditionProfile matchingBreakProfile = ConditionProfile.createCountingProfile();
-    private final ConditionProfile anyBlockProfile = ConditionProfile.createBinaryProfile();
+    private final ConditionProfile anyBlockProfile;
 
     public CatchBreakNode(BreakID breakID, RubyNode body, boolean isWhile) {
         this.isWhile = isWhile;
         this.breakID = breakID;
         this.body = body;
+        this.anyBlockProfile = isWhile ? null : ConditionProfile.createBinaryProfile();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -733,7 +733,7 @@ public class BodyTranslator extends Translator {
         if (argumentsAndBlock.getBlock() instanceof BlockDefinitionNode) { // if we have a literal block, break breaks out of this call site
             callNode = new FrameOnStackNode(callNode, argumentsAndBlock.getFrameOnStackMarkerSlot());
             final BlockDefinitionNode blockDef = (BlockDefinitionNode) argumentsAndBlock.getBlock();
-            return new CatchBreakNode(blockDef.getBreakID(), callNode);
+            return new CatchBreakNode(blockDef.getBreakID(), callNode, false);
         } else {
             return callNode;
         }
@@ -3164,7 +3164,7 @@ public class BodyTranslator extends Translator {
             loop = new WhileNode(new WhileNode.DoWhileRepeatingNode(context, condition, body));
         }
 
-        final RubyNode ret = new CatchBreakNode(whileBreakID, loop);
+        final RubyNode ret = new CatchBreakNode(whileBreakID, loop, true);
         ret.unsafeSetSourceSection(sourceSection);
         return addNewlineIfNeeded(node, ret);
     }

--- a/src/main/ruby/core/integer.rb
+++ b/src/main/ruby/core/integer.rb
@@ -29,6 +29,17 @@ class Integer < Numeric
   alias_method :ceil, :to_i
   alias_method :floor, :to_i
 
+  def times
+    return to_enum(:times) { self } unless block_given?
+
+    i = 0
+    while i < self
+      yield i
+      i += 1
+    end
+    self
+  end
+
   def chr(enc=undefined)
     if self < 0 || (self & 0xffff_ffff) != self
       raise RangeError, "#{self} is outside of the valid character range"


### PR DESCRIPTION
* Enables On-Stack-Replacement (OSR), see https://github.com/eregon/adventofcode/commit/51378b1805fef399d8efcacb19208375ea77194d for example.
* Handles the enumerator correctly.
* Faster in case of a Bignum slightly larger than a Fixnum
  as we start by using Fixnum#+.
* Optimizes just as good.
* Much less code and boilerplate.

Micro-benchmark:
```ruby
benchmark do
  sum = 0
  512.times { |i| sum -= i }
  sum
end
```
Same peak performance before and after (4350k i/s), same IGV graphs.
A bit slower in interpreter (7k vs 10k i/s), but `times` is unlikely the bottleneck when Graal is not available.