### PR TITLE
Configure GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Rules for GitHub's Linguist language-classification system. We're abusing the
+# 'vendored' attribute to exclude files as a lot of this isn't really vendored,
+# and a whole lot of actually vendored code isn't listed! What we want to do is
+# make the stats accurate for what is actually runtime code.
+
+# Ignore everything that isn't actually runtime code
+
+bench/* linguist-vendored
+bin/* linguist-vendored
+logo/* linguist-vendored
+mx.truffleruby/* linguist-vendored
+spec/* linguist-vendored
+test/* linguist-vendored
+tool/* linguist-vendored
+lib/json/data/* linguist-vendored
+lib/json/java/* linguist-vendored
+lib/json/ext/* linguist-vendored
+lib/json/tests/* linguist-vendored
+lib/json/tools/* linguist-vendored
+src/main/c/Makefile linguist-vendored
+src/main/c/truffleposix/Makefile linguist-vendored
+
+# Some things that I just want to ignore as it skews things
+
+lib/ruby/gems/2.3.0/gems/net-telnet-0.1.1/bin/setup linguist-vendored
+
+# Ignore generated code
+
+src/main/java/org/truffleruby/parser/parser/RubyParser.java linguist-generated
+src/main/java/org/truffleruby/core/time/StrftimeLexer.java linguist-generated
+
+# Ignore templates
+
+lib/mri/rdoc/generator/template/* linguist-vendored
+
+# Ignore extra documentation
+
+lib/ruby/gems/2.3.0/gems/rake-10.4.2/doc/rake.1 linguist-documentation
+
+# All our headers are C - don't magically work out they're ObjectiveC or C++
+
+*.h linguist-language=C


### PR DESCRIPTION
Before:

```json
{
  "Ruby": 23741769,
  "CSS": 177333,
  "Gherkin": 7499,
  "Roff": 12625,
  "Shell": 30241,
  "HTML": 411318,
  "C": 1671670,
  "C++": 8920,
  "Objective-C": 1238,
  "Ragel": 60990,
  "Java": 5773914,
  "JavaScript": 17926,
  "Python": 38238,
  "Batchfile": 120,
  "Makefile": 4278,
  "Lex": 2408,
  "Yacc": 104968,
  "XSLT": 13913,
  "Scilab": 745,
  "PHP": 412
}
```

After:

```json
{
  "C": 1213039,
  "Ruby": 7730610,
  "Java": 5374557,
  "Lex": 2408,
  "Yacc": 104968
}
```