### PR TITLE
Build svm graal core

### DIFF
--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -330,7 +330,7 @@
   svm_metrics: {
     local run_benchs = benchmark([
       "instructions",
-      ["time", "--", "--aot"],
+      ["time", "--", "--native"],
       "maxrss"]),
 
     run: [
@@ -401,7 +401,7 @@
     run: benchmark([["server", "--", "--no-core-load-path"]])
   },
   svm_server_benchmarks: $.server_benchmarks {
-    run: benchmark([["server", "--", "--aot"]])
+    run: benchmark([["server", "--", "--native"]])
   },
 
   cext_benchmarks: $.sulong + $.graal_core + {

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -63,6 +63,16 @@ $ echo MX_BINARY_SUITES=truffle,sdk > mx.truffleruby/env
 $ jt build
 ```
 
+By default the `jt build` command only builds the JVM-based launcher for TruffleRuby.
+If you'd like to build the native image using the Substrate VM, you can do so by
+providing an extra argument to the build command.
+
+```bash
+$ jt build native
+```
+
+This will create a new file name `native-ruby` in your `bin/` directory.
+
 ## Sulong
 
 TruffleRuby runs C extension using Sulong. You should build Sulong from source.
@@ -99,6 +109,15 @@ $ jt test integration
 Other tests can be hard to set up and can require other repositories, so we
 don't normally run them locally unless we're working on that functionality.
 
+If you'd like to run tests with the native TruffleRuby binary you can do so
+by providing the `--native` argument to the test command. Please note that
+you must follow the steps to build the native image before it can be used 
+for tests.
+
+```bash
+$ jt test --native fast
+```
+
 ## Running
 
 `jt ruby` runs TruffleRuby. You can use it exactly as you'd run the MRI `ruby`
@@ -107,8 +126,18 @@ developing, such as loading the core library from disk rather than the JAR.
 `jt ruby` prints the real command it's running as it starts.
 
 ```bash
-$ ruby ...
+$ bin/ruby ...
 $ jt ruby ...
+```
+
+If you'd like to run tests with the native TruffleRuby binary you can do so
+by providing the `--native` argument to the `ruby` command. Please note that
+you must follow the steps to build the native image before it can be used 
+for tests.
+
+```bash
+$ bin/native-ruby ...
+$ jt ruby --native ...
 ```
 
 ## Options
@@ -132,7 +161,9 @@ set in `RUBYOPT`.
 ## Running with Graal
 
 To run with a GraalVM binary tarball, set the `GRAALVM_BIN` environment variable
-and run with the `--graal` option.
+and run with the `--graal` option. Note that if you're running a native TruffleRuby
+binary, Graal is always built into the binary and enabled; you can safely ignore
+the rest of this section.
 
 ```bash
 $ export GRAALVM_BIN=.../graalvm-0.nn/bin/java

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1733,15 +1733,24 @@ module Commands
     java_home
   end
 
+  def checkout_or_update_graal_repo
+    graal = Utilities.find_or_clone_repo('https://github.com/graalvm/graal.git')
+
+    chdir(graal) do
+      raw_sh "git", "fetch"
+      raw_sh "git", "checkout", Utilities.truffle_version
+    end
+
+    graal
+  end
+
   def install_graal
     build
     java_home = install_jvmci
+    graal = checkout_or_update_graal_repo
 
     puts "Building graal"
-    graal = Utilities.find_or_clone_repo('https://github.com/graalvm/graal.git')
     chdir("#{graal}/compiler") do
-      raw_sh "git", "fetch"
-      raw_sh "git", "checkout", Utilities.truffle_version
       File.write("mx.compiler/env", "JAVA_HOME=#{java_home}\n")
       mx "build"
     end
@@ -1757,12 +1766,10 @@ module Commands
   def build_native_image
     build
     java_home = install_jvmci
+    graal = checkout_or_update_graal_repo
 
     puts 'Building TruffleRuby native binary'
-    graal = Utilities.find_or_clone_repo('https://github.com/graalvm/graal.git')
     chdir("#{graal}/substratevm") do
-      raw_sh 'git', 'fetch'
-      raw_sh 'git', 'checkout', Utilities.truffle_version
       File.write('mx.substratevm/env', "JAVA_HOME=#{java_home}\n")
       mx 'build'
       mx 'image', '-ruby', '-H:Name=native-ruby'

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -497,7 +497,14 @@ module Commands
     super(*args)
   end
 
-  BUILD_OPTIONS = %w[parser options cexts sulong]
+  BUILD_OPTIONS = %w[parser options cexts sulong aot svm]
+
+  def build_truffleruby
+    mx 'sforceimports'
+    mx 'build', '--force-javac', '--warning-as-error',
+       # show more than default 100 errors not to hide actual errors under pile of missing symbols
+       '-A-Xmaxerrs', '-A1000'
+  end
 
   def build(*options)
     project = options.first
@@ -522,11 +529,11 @@ module Commands
       require 'etc'
       cores = Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 4
       raw_sh "make", "-j#{cores}", chdir: "#{TRUFFLERUBY_DIR}/src/main/c"
+    when 'aot', 'svm'
+      build_truffleruby
+      build_aot_image
     when nil
-      mx 'sforceimports'
-      mx 'build', '--force-javac', '--warning-as-error',
-         # show more than default 100 errors not to hide actual errors under pile of missing symbols
-         '-A-Xmaxerrs', '-A1000'
+      build_truffleruby
     else
       raise ArgumentError, project
     end
@@ -1759,6 +1766,22 @@ module Commands
     puts
     puts "To run TruffleRuby with Graal, use:"
     puts "$ #{TRUFFLERUBY_DIR}/tool/jt.rb ruby --graal ..."
+  end
+
+  def build_aot_image
+    build
+    java_home = install_jvmci
+
+    puts 'Building TruffleRuby Substrate VM binary'
+    graal = Utilities.find_or_clone_repo('https://github.com/graalvm/graal.git')
+    chdir("#{graal}/substratevm") do
+      raw_sh 'git', 'fetch'
+      raw_sh 'git', 'checkout', Utilities.truffle_version
+      File.write('mx.substratevm/env', "JAVA_HOME=#{java_home}\n")
+      mx 'build'
+      mx 'image', '-ruby', '-H:Name=native-ruby'
+      FileUtils.mv('svmbuild/native-ruby', '../../truffleruby/bin/')
+    end
   end
 
   def next(*args)

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -159,17 +159,9 @@ module Utilities
 
   def self.find_launcher(use_native)
     if use_native
-      if ENV['AOT_BIN']
-        ENV['AOT_BIN']
-      else
-        "#{TRUFFLERUBY_DIR}/bin/native-ruby"
-      end
+      ENV['AOT_BIN'] || "#{TRUFFLERUBY_DIR}/bin/native-ruby"
     else
-      if ENV['RUBY_BIN']
-        ENV['RUBY_BIN']
-      else
-        "#{TRUFFLERUBY_DIR}/bin/truffleruby"
-      end
+      ENV['RUBY_BIN'] || "#{TRUFFLERUBY_DIR}/bin/truffleruby"
     end
   end
 
@@ -507,13 +499,6 @@ module Commands
 
   BUILD_OPTIONS = %w[parser options cexts sulong native]
 
-  def build_truffleruby
-    mx 'sforceimports'
-    mx 'build', '--force-javac', '--warning-as-error',
-       # show more than default 100 errors not to hide actual errors under pile of missing symbols
-       '-A-Xmaxerrs', '-A1000'
-  end
-
   def build(*options)
     project = options.first
     case project
@@ -538,10 +523,12 @@ module Commands
       cores = Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 4
       raw_sh "make", "-j#{cores}", chdir: "#{TRUFFLERUBY_DIR}/src/main/c"
     when 'native'
-      build_truffleruby
       build_native_image
     when nil
-      build_truffleruby
+      mx 'sforceimports'
+      mx 'build', '--force-javac', '--warning-as-error',
+         # show more than default 100 errors not to hide actual errors under pile of missing symbols
+         '-A-Xmaxerrs', '-A1000'
     else
       raise ArgumentError, project
     end

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -157,11 +157,19 @@ module Utilities
     raise "couldn't find truffle-sl.jar - build Truffle and find it in there"
   end
 
-  def self.find_launcher
-    if ENV['RUBY_BIN']
-      ENV['RUBY_BIN']
+  def self.find_launcher(use_svm)
+    if use_svm
+      if ENV['AOT_BIN']
+        ENV['AOT_BIN']
+      else
+        "#{TRUFFLERUBY_DIR}/bin/native-ruby"
+      end
     else
-      "#{TRUFFLERUBY_DIR}/bin/truffleruby"
+      if ENV['RUBY_BIN']
+        ENV['RUBY_BIN']
+      else
+        "#{TRUFFLERUBY_DIR}/bin/truffleruby"
+      end
     end
   end
 
@@ -686,12 +694,7 @@ module Commands
       options[:use_exec] = true
     end
 
-    ruby_bin = if args.delete('--aot')
-                 verify_aot_bin!
-                 ENV['AOT_BIN']
-               else
-                 Utilities.find_launcher
-               end
+    ruby_bin = Utilities.find_launcher(args.delete('--aot'))
 
     raw_sh env_vars, ruby_bin, *vm_args, *args, options
   end
@@ -1267,7 +1270,7 @@ module Commands
       verify_aot_bin!
 
       options += %w[--excl-tag graalvm --excl-tag aot]
-      options << '-t' << ENV['AOT_BIN']
+      options << '-t' << Utilities.find_launcher(true)
       options << '-T-XX:YoungGenerationSize=2G'
       options << '-T-XX:OldGenerationSize=4G'
       options << "-T-Xhome=#{TRUFFLERUBY_DIR}"
@@ -1367,11 +1370,7 @@ module Commands
   end
 
   def build_stats_aot_binary_size(*args)
-    if File.exist?(ENV['AOT_BIN'].to_s)
-      File.size(ENV['AOT_BIN']) / 1024.0 / 1024.0
-    else
-      -1
-    end
+    File.size(Utilities.find_launcher(true)) / 1024.0 / 1024.0
   end
 
   def build_stats_aot_build_time(*args)
@@ -1505,11 +1504,11 @@ module Commands
       Utilities.log '.', "sampling\n"
 
       max_rss_in_mb = if LINUX
-                        out, err = raw_sh('/usr/bin/time', '-v', '--', ENV['AOT_BIN'], *args, capture: true, no_print_cmd: true)
+                        out, err = raw_sh('/usr/bin/time', '-v', '--', Utilities.find_launcher(true), *args, capture: true, no_print_cmd: true)
                         err =~ /Maximum resident set size \(kbytes\): (?<max_rss_in_kb>\d+)/m
                         Integer($~[:max_rss_in_kb]) / 1024.0
                       elsif MAC
-                        out, err = raw_sh('/usr/bin/time', '-l', '--', ENV['AOT_BIN'], *args, capture: true, no_print_cmd: true)
+                        out, err = raw_sh('/usr/bin/time', '-l', '--', Utilities.find_launcher(true), *args, capture: true, no_print_cmd: true)
                         err =~ /(?<max_rss_in_bytes>\d+)\s+maximum resident set size/m
                         Integer($~[:max_rss_in_bytes]) / 1024.0 / 1024.0
                       else
@@ -1547,7 +1546,7 @@ module Commands
 
     use_json = args.delete '--json'
 
-    out, err = raw_sh('perf', 'stat', '-e', 'instructions', '--', ENV['AOT_BIN'], *args, capture: true, no_print_cmd: true)
+    out, err = raw_sh('perf', 'stat', '-e', 'instructions', '--', Utilities.find_launcher(true), *args, capture: true, no_print_cmd: true)
 
     err =~ /(?<instruction_count>[\d,]+)\s+instructions/m
     instruction_count = $~[:instruction_count].gsub(',', '')
@@ -1654,17 +1653,17 @@ module Commands
 
     run_args = []
 
-    if args.delete('--aot') || (ENV.has_key?('JT_BENCHMARK_RUBY') && (ENV['JT_BENCHMARK_RUBY'] == ENV['AOT_BIN']))
+    if args.delete('--aot') || (ENV.has_key?('JT_BENCHMARK_RUBY') && (ENV['JT_BENCHMARK_RUBY'] == Utilities.find_launcher(true)))
       run_args.push '-XX:YoungGenerationSize=1G'
       run_args.push '-XX:OldGenerationSize=2G'
       run_args.push "-Xhome=#{TRUFFLERUBY_DIR}"
 
       # We already have a mechanism for setting the Ruby to benchmark, but elsewhere we use AOT_BIN with the "--aot" flag.
       # Favor JT_BENCHMARK_RUBY to AOT_BIN, but try both.
-      benchmark_ruby ||= ENV['AOT_BIN']
+      benchmark_ruby ||= Utilities.find_launcher(true)
 
       unless File.exist?(benchmark_ruby.to_s)
-        raise "JT_BENCHMARK_RUBY or AOT_BIN must point at an AOT build of TruffleRuby"
+        raise "Could not find benchmark ruby -- '#{benchmark_ruby}' does not exist"
       end
     end
 
@@ -1848,8 +1847,8 @@ module Commands
   end
 
   def verify_aot_bin!
-    unless File.exist?(ENV['AOT_BIN'].to_s)
-      raise "AOT_BIN must point at an AOT build of TruffleRuby"
+    unless File.exist?(Utilities.find_launcher(true))
+      raise "Could not find AOT image -- either build with 'jt build --aot' or set AOT_BIN to an image location"
     end
   end
 


### PR DESCRIPTION
This introduces `jt build [aot|svm]` as an option for building the TruffleRuby Substrate VM image from our version of Graal. On Linux it will use the open source JVMCI. Mac will still require a JVMCI build from OTN (just like we do for `jt install jvmci`). All of the `jt` commands that take an `--aot` arg, such as `jt test --aot` will use `$AOT_BIN` if it exists, otherwise will look for `bin/native-ruby`. There should be no need to set `-Xhome` unless using a non-standard path with `$AOT_BIN`.

There's more cleanup that can be done. Maybe we should support `--svm` in addition to `--aot`. But this should get people going now and we can gradually improve usability.