### PR TITLE
Use Java's Timsort implementation for primitive arrays when the represented Ruby class hasn't been modified.

### DIFF
--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -9,7 +9,6 @@
  */
 package org.truffleruby.core.array;
 
-import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -1880,9 +1879,6 @@ public abstract class ArrayNodes {
 
         private final BranchProfile errorProfile = BranchProfile.create();
 
-        protected final Assumption fixnumCmpAssumption = getContext().getCoreMethods().fixnumCmpAssumption;
-        protected final Assumption floatCmpAssumption = getContext().getCoreMethods().floatCmpAssumption;
-
         @Specialization(guards = "isEmptyArray(array)")
         public DynamicObject sortEmpty(DynamicObject array, Object unusedBlock) {
             return createArray(null, 0);
@@ -1925,7 +1921,7 @@ public abstract class ArrayNodes {
         }
 
         @Specialization(guards = { "!isEmptyArray(array)", "!isSmall(array)", "isIntArray(array)" },
-                        assumptions = "fixnumCmpAssumption")
+                        assumptions = "getContext().getCoreMethods().fixnumCmpAssumption")
         public Object sortIntArray(DynamicObject array, NotProvided block) {
             final int size = getSize(array);
             int[] copy = ((int[]) getStore(array)).clone();
@@ -1934,7 +1930,7 @@ public abstract class ArrayNodes {
         }
 
         @Specialization(guards = { "!isEmptyArray(array)", "!isSmall(array)", "isLongArray(array)" },
-                        assumptions = "fixnumCmpAssumption")
+                        assumptions = "getContext().getCoreMethods().fixnumCmpAssumption")
         public Object sortLongArray(DynamicObject array, NotProvided block) {
             final int size = getSize(array);
             long[] copy = ((long[]) getStore(array)).clone();
@@ -1943,7 +1939,7 @@ public abstract class ArrayNodes {
         }
 
         @Specialization(guards = { "!isEmptyArray(array)", "!isSmall(array)", "isDoubleArray(array)" },
-                        assumptions = "floatCmpAssumption")
+                        assumptions = "getContext().getCoreMethods().floatCmpAssumption")
         public Object sortDoubleArray(DynamicObject array, NotProvided block) {
             final int size = getSize(array);
             double[] copy = ((double[]) getStore(array)).clone();

--- a/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
+++ b/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
@@ -51,6 +51,7 @@ public class CoreMethods {
     final Assumption fixnumMulAssumption, floatMulAssumption;
     final Assumption fixnumDivAssumption, floatDivAssumption;
     final Assumption fixnumModAssumption, floatModAssumption;
+    public final Assumption fixnumCmpAssumption, floatCmpAssumption;
 
     final Assumption fixnumLeftShiftAssumption;
     final Assumption fixnumRightShiftAssumption;
@@ -89,6 +90,9 @@ public class CoreMethods {
 
         fixnumModAssumption = registerAssumption(fixnumClass, "%");
         floatModAssumption = registerAssumption(floatClass, "%");
+
+        fixnumCmpAssumption = registerAssumption(fixnumClass, "<=>");
+        floatCmpAssumption = registerAssumption(floatClass, "<=>");
 
         fixnumLeftShiftAssumption = registerAssumption(fixnumClass, "<<");
         fixnumRightShiftAssumption = registerAssumption(fixnumClass, ">>");


### PR DESCRIPTION
Java's Timsort implementation is substantially faster for primitive arrays than our sorting implementation written in Ruby. On randomly ordered arrays of 1,000,000 elements, it's around 6x as fast as the Ruby implementation. And if the data is already sorted, I measured 104x as fast for `Float` and 298x as fast for `Fixnum`. In the case of `Object[]`, where we must call the underlying `<=>` I measured no real difference between Java and Ruby, so I moved it all to Ruby. Due to the boundaries involved, it's possible we could be faster in Ruby, but Timsort is not trivial to implement so I didn't do that here.

@eregon I'm fairly certain you're not going to be happy with the way I registered the assumptions. Please suggest improvements. You wrote that code with inlining in mind, but I think it's generally useful in cases like this as well. I did originally store the assumptions in the `CoreMethods` class and reference them, but that resulted in an NPE in the native image. I'm not sure why, but it appears to be an initialization issue. So, I opted to create the assumptions in the `SortNode` class itself, but that required breaking the requirement that method changed assumptions are only registered during initialization.