### PR TITLE
Fix case/when and cleanup the translators

### DIFF
--- a/spec/ruby/language/case_spec.rb
+++ b/spec/ruby/language/case_spec.rb
@@ -91,6 +91,44 @@ describe "The 'case'-construct" do
     end.should == true
   end
 
+  it "tests with matching regexps and sets $~ and captures" do
+    case "foo42"
+    when /oo(\d+)/
+      $~.should be_kind_of(MatchData)
+      $1.should == "42"
+    else
+      flunk
+    end
+    $~.should be_kind_of(MatchData)
+    $1.should == "42"
+  end
+
+  it "tests with a regexp interpolated within another regexp" do
+    digits = '\d+'
+    case "foo44"
+    when /oo(#{digits})/
+      $~.should be_kind_of(MatchData)
+      $1.should == "44"
+    else
+      flunk
+    end
+    $~.should be_kind_of(MatchData)
+    $1.should == "44"
+  end
+
+  it "tests with a string interpolated in a regexp" do
+    digits_regexp = /\d+/
+    case "foo43"
+    when /oo(#{digits_regexp})/
+      $~.should be_kind_of(MatchData)
+      $1.should == "43"
+    else
+      flunk
+    end
+    $~.should be_kind_of(MatchData)
+    $1.should == "43"
+  end
+
   it "does not test with equality when given classes" do
     case :symbol.class
       when Symbol

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -779,25 +779,25 @@ public class BodyTranslator extends Translator {
     protected ArgumentsAndBlockTranslation translateArgumentsAndBlock(SourceIndexLength sourceSection, ParseNode iterNode, ParseNode argsNode, String nameToSetWhenTranslatingBlock) {
         assert !(argsNode instanceof IterParseNode);
 
-        final List<ParseNode> arguments = new ArrayList<>();
-
+        final ParseNode[] arguments;
         boolean isSplatted = false;
 
         if (argsNode == null) {
             // No arguments
+            arguments = new ParseNode[0];
         } else if (argsNode instanceof ArrayParseNode) {
             // Multiple arguments
-            arguments.addAll(argsNode.childNodes());
+            arguments = ((ArrayParseNode) argsNode).children();
         } else if (argsNode instanceof SplatParseNode || argsNode instanceof ArgsCatParseNode || argsNode instanceof ArgsPushParseNode) {
             isSplatted = true;
-            arguments.add(argsNode);
+            arguments = new ParseNode[]{ argsNode };
         } else {
             throw new UnsupportedOperationException("Unknown argument node type: " + argsNode.getClass());
         }
 
-        final RubyNode[] argumentsTranslated = new RubyNode[arguments.size()];
-        for (int i = 0; i < arguments.size(); i++) {
-            argumentsTranslated[i] = arguments.get(i).accept(this);
+        final RubyNode[] argumentsTranslated = new RubyNode[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            argumentsTranslated[i] = arguments[i].accept(this);
         }
 
         // If the last argument is a splat, do not copy the array, to support m(*args, &args.pop)

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -3132,20 +3132,16 @@ public class BodyTranslator extends Translator {
     public RubyNode visitYieldNode(YieldParseNode node) {
         final List<ParseNode> arguments = new ArrayList<>();
 
-        ParseNode argsNode = node.getArgsNode();
-
+        final ParseNode argsNode = node.getArgsNode();
         final boolean unsplat = argsNode instanceof SplatParseNode || argsNode instanceof ArgsCatParseNode;
 
-        if (argsNode instanceof SplatParseNode) {
-            argsNode = ((SplatParseNode) argsNode).getValue();
-        }
-
-        if (argsNode != null) {
-            if (argsNode instanceof ArrayParseNode) {
-                arguments.addAll(node.getArgsNode().childNodes());
-            } else {
-                arguments.add(node.getArgsNode());
-            }
+        if (argsNode == null) {
+            // No arguments
+        } else if (argsNode instanceof ArrayParseNode) {
+            // Multiple arguments
+            arguments.addAll(argsNode.childNodes());
+        } else {
+            arguments.add(node.getArgsNode());
         }
 
         final List<RubyNode> argumentsTranslated = new ArrayList<>();

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -1076,7 +1076,7 @@ public class BodyTranslator extends Translator {
             ret = getLexicalScopeModuleNode("dynamic constant lookup", sourceSection);
             ret.unsafeSetSourceSection(sourceSection);
         } else if (node instanceof Colon2ConstParseNode) { // A::B
-            ret = node.childNodes().get(0).accept(this);
+            ret = ((Colon2ConstParseNode) node).getLeftNode().accept(this);
         } else { // Colon3ParseNode: on top-level (Object)
             ret = new ObjectLiteralNode(context.getCoreLibrary().getObjectClass());
             ret.unsafeSetSourceSection(sourceSection);

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -788,13 +788,7 @@ public class BodyTranslator extends Translator {
         } else if (argsNode instanceof ArrayParseNode) {
             // Multiple arguments
             arguments.addAll(argsNode.childNodes());
-        } else if (argsNode instanceof SplatParseNode) {
-            isSplatted = true;
-            arguments.add(argsNode);
-        } else if (argsNode instanceof ArgsCatParseNode) {
-            isSplatted = true;
-            arguments.add(argsNode);
-        } else if (argsNode instanceof ArgsPushParseNode) {
+        } else if (argsNode instanceof SplatParseNode || argsNode instanceof ArgsCatParseNode || argsNode instanceof ArgsPushParseNode) {
             isSplatted = true;
             arguments.add(argsNode);
         } else {

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -3130,29 +3130,27 @@ public class BodyTranslator extends Translator {
 
     @Override
     public RubyNode visitYieldNode(YieldParseNode node) {
-        final List<ParseNode> arguments = new ArrayList<>();
-
         final ParseNode argsNode = node.getArgsNode();
         final boolean unsplat = argsNode instanceof SplatParseNode || argsNode instanceof ArgsCatParseNode;
 
+        final ParseNode[] arguments;
         if (argsNode == null) {
             // No arguments
+            arguments = new ParseNode[0];
         } else if (argsNode instanceof ArrayParseNode) {
             // Multiple arguments
-            arguments.addAll(argsNode.childNodes());
+            arguments = ((ArrayParseNode) argsNode).children();
         } else {
-            arguments.add(node.getArgsNode());
+            arguments = new ParseNode[]{ node.getArgsNode() };
         }
 
-        final List<RubyNode> argumentsTranslated = new ArrayList<>();
+        final RubyNode[] argumentsTranslated = new RubyNode[arguments.length];
 
-        for (ParseNode argument : arguments) {
-            argumentsTranslated.add(argument.accept(this));
+        for (int i = 0; i < arguments.length; i++) {
+            argumentsTranslated[i] = arguments[i].accept(this);
         }
 
-        final RubyNode[] argumentsTranslatedArray = argumentsTranslated.toArray(new RubyNode[argumentsTranslated.size()]);
-
-        final RubyNode ret = new YieldExpressionNode(unsplat, argumentsTranslatedArray);
+        final RubyNode ret = new YieldExpressionNode(unsplat, argumentsTranslated);
         ret.unsafeSetSourceSection(node.getPosition());
         return addNewlineIfNeeded(node, ret);
     }

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -260,6 +260,7 @@ import org.truffleruby.parser.ast.UndefParseNode;
 import org.truffleruby.parser.ast.UntilParseNode;
 import org.truffleruby.parser.ast.VAliasParseNode;
 import org.truffleruby.parser.ast.VCallParseNode;
+import org.truffleruby.parser.ast.WhenOneArgParseNode;
 import org.truffleruby.parser.ast.WhenParseNode;
 import org.truffleruby.parser.ast.WhileParseNode;
 import org.truffleruby.parser.ast.XStrParseNode;
@@ -886,17 +887,17 @@ public class BodyTranslator extends Translator {
                 final RubyNode rubyExpression = expressionNode.accept(this);
 
                 final RubyNode receiver;
-                final RubyNode[] arguments;
                 final String method;
-                if (expressionNode instanceof SplatParseNode || expressionNode instanceof ArgsCatParseNode || expressionNode instanceof ArgsPushParseNode) {
+                final RubyNode[] arguments;
+                if (when instanceof WhenOneArgParseNode) {
+                    receiver = rubyExpression;
+                    method = "===";
+                    arguments = new RubyNode[]{ NodeUtil.cloneNode(readTemp) };
+                } else {
                     receiver = new ObjectLiteralNode(context.getCoreLibrary().getTruffleModule());
                     receiver.unsafeSetSourceSection(sourceSection);
                     method = "when_splat";
                     arguments = new RubyNode[]{ rubyExpression, NodeUtil.cloneNode(readTemp) };
-                } else {
-                    receiver = rubyExpression;
-                    method = "===";
-                    arguments = new RubyNode[]{ NodeUtil.cloneNode(readTemp) };
                 }
                 final RubyCallNodeParameters callParameters = new RubyCallNodeParameters(receiver, method, null, arguments, false, true);
                 final RubyNode conditionNode = Translator.withSourceSection(sourceSection, new RubyCallNode(callParameters));

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -3141,8 +3141,8 @@ public class BodyTranslator extends Translator {
         }
 
         if (argsNode != null) {
-            if (argsNode instanceof ListParseNode) {
-                arguments.addAll((node.getArgsNode()).childNodes());
+            if (argsNode instanceof ArrayParseNode) {
+                arguments.addAll(node.getArgsNode().childNodes());
             } else {
                 arguments.add(node.getArgsNode());
             }

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -785,7 +785,8 @@ public class BodyTranslator extends Translator {
 
         if (argsNode == null) {
             // No arguments
-        } else if (argsNode instanceof ListParseNode) {
+        } else if (argsNode instanceof ArrayParseNode) {
+            // Multiple arguments
             arguments.addAll(argsNode.childNodes());
         } else if (argsNode instanceof SplatParseNode) {
             isSplatted = true;

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -880,13 +880,9 @@ public class BodyTranslator extends Translator {
 
                 // Make a condition from the one or more expressions combined in an or expression
 
-                final List<ParseNode> expressions;
-
-                if (when.getExpressionNodes() instanceof ListParseNode && !(when.getExpressionNodes() instanceof ArrayParseNode)) {
-                    expressions = when.getExpressionNodes().childNodes();
-                } else {
-                    expressions = Collections.singletonList(when.getExpressionNodes());
-                }
+                // JRuby AST always gives WhenParseNode with only one expression.
+                // "when 1,2; body" gets translated to 2 WhenParseNode.
+                final List<ParseNode> expressions = Collections.singletonList(when.getExpressionNodes());
 
                 final List<RubyNode> comparisons = new ArrayList<>();
 

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -2601,7 +2601,7 @@ public class BodyTranslator extends Translator {
          * visitOpAsgnNode.
          */
 
-        final ParseNode index = node.getArgsNode().childNodes().get(0);
+        final ParseNode index = ((ArrayParseNode) node.getArgsNode()).get(0);
 
         final ParseNode operand = node.getValueNode();
 

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -2683,12 +2683,14 @@ public class BodyTranslator extends Translator {
         // https://github.com/jruby/jruby/issues/4257
         final StaticScope scope = new StaticScope(StaticScope.Type.BLOCK, null);
 
+        final SourceIndexLength position = node.getPosition();
+
         return translateCallNode(
-                new CallParseNode(node.getPosition(),
-                        new TruffleFragmentParseNode(node.getPosition(), new ObjectLiteralNode(context.getCoreLibrary().getTruffleKernelOperationsModule())),
+                new CallParseNode(position,
+                        new TruffleFragmentParseNode(position, new ObjectLiteralNode(context.getCoreLibrary().getTruffleKernelOperationsModule())),
                         "at_exit",
-                        new ListParseNode(node.getPosition(), new TrueParseNode(node.getPosition())),
-                        new IterParseNode(node.getPosition(), node.getArgsNode(), scope, node.getBodyNode())),
+                        new ListParseNode(position, new TrueParseNode(position)),
+                        new IterParseNode(position, node.getArgsNode(), scope, node.getBodyNode())),
                 false, false, false);
     }
 

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -1545,7 +1545,7 @@ public class BodyTranslator extends Translator {
         bodyWithTempAssign.add(node.getBodyNode());
 
         final ArgumentParseNode blockVar = new ArgumentParseNode(node.getPosition(), temp);
-        final ListParseNode blockArgsPre = new ListParseNode(node.getPosition(), blockVar);
+        final ArrayParseNode blockArgsPre = new ArrayParseNode(node.getPosition(), blockVar);
         final ArgsParseNode blockArgs = new ArgsParseNode(node.getPosition(), blockArgsPre, null, null, null, null, null, null);
         final IterParseNode block = new IterParseNode(node.getPosition(), blockArgs, node.getScope(), bodyWithTempAssign);
 
@@ -2689,7 +2689,7 @@ public class BodyTranslator extends Translator {
                 new CallParseNode(position,
                         new TruffleFragmentParseNode(position, new ObjectLiteralNode(context.getCoreLibrary().getTruffleKernelOperationsModule())),
                         "at_exit",
-                        new ListParseNode(position, new TrueParseNode(position)),
+                        new ArrayParseNode(position, new TrueParseNode(position)),
                         new IterParseNode(position, node.getArgsNode(), scope, node.getBodyNode())),
                 false, false, false);
     }

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -2601,13 +2601,7 @@ public class BodyTranslator extends Translator {
          * visitOpAsgnNode.
          */
 
-        ParseNode index;
-
-        if (node.getArgsNode() == null) {
-            index = null;
-        } else {
-            index = node.getArgsNode().childNodes().get(0);
-        }
+        final ParseNode index = node.getArgsNode().childNodes().get(0);
 
         final ParseNode operand = node.getValueNode();
 

--- a/src/main/java/org/truffleruby/parser/Helpers.java
+++ b/src/main/java/org/truffleruby/parser/Helpers.java
@@ -28,6 +28,7 @@ package org.truffleruby.parser;
 
 import org.truffleruby.parser.ast.ArgsParseNode;
 import org.truffleruby.parser.ast.ArgumentParseNode;
+import org.truffleruby.parser.ast.AssignableParseNode;
 import org.truffleruby.parser.ast.DAsgnParseNode;
 import org.truffleruby.parser.ast.LocalAsgnParseNode;
 import org.truffleruby.parser.ast.MultipleAsgnParseNode;
@@ -144,7 +145,8 @@ public class Helpers {
     }
 
     public static boolean isRequiredKeywordArgumentValueNode(ParseNode asgnNode) {
-        return asgnNode.childNodes().get(0) instanceof RequiredKeywordArgumentValueParseNode;
+        return asgnNode instanceof AssignableParseNode &&
+                ((AssignableParseNode) asgnNode).getValueNode() instanceof RequiredKeywordArgumentValueParseNode;
     }
 
 }

--- a/src/main/java/org/truffleruby/parser/Helpers.java
+++ b/src/main/java/org/truffleruby/parser/Helpers.java
@@ -41,11 +41,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Helper methods which are called by the compiler.  Note: These will show no consumers, but
- * generated code does call these so don't remove them thinking they are dead code.
- *
- */
 public class Helpers {
 
     public static final Map<String, String> map(String... keyValues) {

--- a/src/main/java/org/truffleruby/parser/Helpers.java
+++ b/src/main/java/org/truffleruby/parser/Helpers.java
@@ -30,6 +30,7 @@ import org.truffleruby.parser.ast.ArgsParseNode;
 import org.truffleruby.parser.ast.ArgumentParseNode;
 import org.truffleruby.parser.ast.AssignableParseNode;
 import org.truffleruby.parser.ast.DAsgnParseNode;
+import org.truffleruby.parser.ast.KeywordArgParseNode;
 import org.truffleruby.parser.ast.LocalAsgnParseNode;
 import org.truffleruby.parser.ast.MultipleAsgnParseNode;
 import org.truffleruby.parser.ast.OptArgParseNode;
@@ -118,13 +119,12 @@ public class Helpers {
         if (keywordsCount > 0) {
             int keywordsIndex = argsNode.getKeywordsIndex();
             for (int i = 0; i < keywordsCount; i++) {
-                ParseNode keyWordNode = args[keywordsIndex + i];
-                for (ParseNode asgnNode : keyWordNode.childNodes()) {
-                    if (isRequiredKeywordArgumentValueNode(asgnNode)) {
-                        descs.add(new ArgumentDescriptor(ArgumentType.keyreq, ((INameNode) asgnNode).getName()));
-                    } else {
-                        descs.add(new ArgumentDescriptor(ArgumentType.key, ((INameNode) asgnNode).getName()));
-                    }
+                KeywordArgParseNode keyWordNode = (KeywordArgParseNode) args[keywordsIndex + i];
+                ParseNode asgnNode = keyWordNode.getAssignable();
+                if (isRequiredKeywordArgumentValueNode(asgnNode)) {
+                    descs.add(new ArgumentDescriptor(ArgumentType.keyreq, ((INameNode) asgnNode).getName()));
+                } else {
+                    descs.add(new ArgumentDescriptor(ArgumentType.key, ((INameNode) asgnNode).getName()));
                 }
             }
         }

--- a/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
@@ -61,7 +61,6 @@ import org.truffleruby.parser.ast.types.INameNode;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 
@@ -463,14 +462,6 @@ public class LoadArgumentsTranslator extends Translator {
 
         pushArraySlot(arraySlot);
 
-        final List<ParseNode> childNodes;
-
-        if (node.childNodes().get(0) == null) {
-            childNodes = Collections.emptyList();
-        } else {
-            childNodes = node.childNodes().get(0).childNodes();
-        }
-
         // The load to use when the array is not nil and the length is smaller than the number of required arguments
 
         final List<RubyNode> notNilSmallerSequence = new ArrayList<>();
@@ -571,10 +562,10 @@ public class LoadArgumentsTranslator extends Translator {
             nilSequence.add(methodBodyTranslator.getEnvironment().findOrAddLocalVarNodeDangerous(parameterToClear, source, sourceSection).makeWriteNode(nilNode(sourceSection)));
         }
 
-        if (!childNodes.isEmpty()) {
+        if (node.getPre() != null) {
             // We haven't pushed a new array slot, so this will read the value which we couldn't convert to an array into the first destructured argument
             index = arrayIndex;
-            nilSequence.add(childNodes.get(0).accept(this));
+            nilSequence.add(node.getPre().get(0).accept(this));
         }
 
         final RubyNode nil = sequence(sourceSection, nilSequence);

--- a/src/main/java/org/truffleruby/parser/ParameterCollector.java
+++ b/src/main/java/org/truffleruby/parser/ParameterCollector.java
@@ -128,4 +128,12 @@ public class ParameterCollector extends AbstractNodeVisitor<Object> {
         return null;
     }
 
+    private void visitChildren(ParseNode node) {
+        for (ParseNode child : node.childNodes()) {
+            if (child != null) {
+                child.accept(this);
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/truffleruby/parser/ast/ArgsParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ArgsParseNode.java
@@ -269,10 +269,10 @@ public class ArgsParseNode extends ParseNode {
 
         int count = 0;
         for (int i = 0; i < getKeywordCount(); i++) {
-            for (ParseNode asgnNode : args[keywordsIndex + i].childNodes()) {
-                if (Helpers.isRequiredKeywordArgumentValueNode(asgnNode)) {
-                    count++;
-                }
+            KeywordArgParseNode keyWordNode = (KeywordArgParseNode) args[keywordsIndex + i];
+            ParseNode asgnNode = keyWordNode.getAssignable();
+            if (Helpers.isRequiredKeywordArgumentValueNode(asgnNode)) {
+                count++;
             }
         }
         return count;

--- a/src/main/java/org/truffleruby/parser/ast/ArgsParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ArgsParseNode.java
@@ -162,7 +162,7 @@ public class ArgsParseNode extends ParseNode {
      * Gets the required arguments at the beginning of the argument definition
      */
     public ListParseNode getPre() {
-        return new ListParseNode(getPosition()).addAll(args, 0, getPreCount());
+        return new ArrayParseNode(getPosition()).addAll(args, 0, getPreCount());
     }
 
     public int getOptionalArgsCount() {
@@ -170,7 +170,7 @@ public class ArgsParseNode extends ParseNode {
     }
 
     public ListParseNode getPost() {
-        return new ListParseNode(getPosition()).addAll(args, postIndex, getPostCount());
+        return new ArrayParseNode(getPosition()).addAll(args, postIndex, getPostCount());
     }
 
     /**
@@ -178,7 +178,7 @@ public class ArgsParseNode extends ParseNode {
      * @return Returns a ListParseNode
      */
     public ListParseNode getOptArgs() {
-        return new ListParseNode(getPosition()).addAll(args, optIndex, getOptionalArgsCount());
+        return new ArrayParseNode(getPosition()).addAll(args, optIndex, getOptionalArgsCount());
     }
 
     /**
@@ -211,7 +211,7 @@ public class ArgsParseNode extends ParseNode {
     }
 
     public ListParseNode getKeywords() {
-        return new ListParseNode(getPosition()).addAll(args, keywordsIndex, getKeywordCount());
+        return new ArrayParseNode(getPosition()).addAll(args, keywordsIndex, getKeywordCount());
     }
 
     public KeywordRestArgParseNode getKeyRest() {

--- a/src/main/java/org/truffleruby/parser/ast/ArgsParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ArgsParseNode.java
@@ -35,7 +35,6 @@
 package org.truffleruby.parser.ast;
 
 import org.truffleruby.language.SourceIndexLength;
-import org.truffleruby.parser.Helpers;
 import org.truffleruby.parser.ast.visitor.NodeVisitor;
 
 import java.util.List;
@@ -257,25 +256,6 @@ public class ArgsParseNode extends ParseNode {
 
     public int getKeywordCount() {
         return args.length - keywordsIndex;
-    }
-
-    /**
-     * How many of the keywords listed happen to be required keyword args.  Note: total kwargs - req kwarg = opt kwargs.
-     */
-    public int getRequiredKeywordCount() {
-        if (getKeywordCount() < 1) {
-            return 0;
-        }
-
-        int count = 0;
-        for (int i = 0; i < getKeywordCount(); i++) {
-            KeywordArgParseNode keyWordNode = (KeywordArgParseNode) args[keywordsIndex + i];
-            ParseNode asgnNode = keyWordNode.getAssignable();
-            if (Helpers.isRequiredKeywordArgumentValueNode(asgnNode)) {
-                count++;
-            }
-        }
-        return count;
     }
 
 }

--- a/src/main/java/org/truffleruby/parser/ast/ListParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ListParseNode.java
@@ -101,6 +101,12 @@ public abstract class ListParseNode extends ParseNode {
         size += other.size;
     }
 
+    /**
+     * Add a node to this list
+     *
+     * @param node the node to add
+     * @return this instance for method chaining
+     */
     public ListParseNode add(ParseNode node) {
         // Ruby Grammar productions return plenty of nulls.
         if (node == null || node == NilImplicitParseNode.NIL) {
@@ -146,16 +152,6 @@ public abstract class ListParseNode extends ParseNode {
         }
 
         return this;
-    }
-
-    /**
-     * Add other element to this list
-     *
-     * @param other list which has elements
-     * @return this instance for method chaining
-     */
-    public ListParseNode addAll(ParseNode other) {
-        return add(other);
     }
 
     public ParseNode getLast() {

--- a/src/main/java/org/truffleruby/parser/ast/ListParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ListParseNode.java
@@ -41,7 +41,7 @@ import java.util.List;
  * In particular, f_arg production rule uses this to capture arg information for
  * the editor projects who want position info saved.
  */
-public class ListParseNode extends ParseNode {
+public abstract class ListParseNode extends ParseNode {
     private static final ParseNode[] EMPTY = new ParseNode[0];
     private static final int INITIAL_SIZE = 4;
     private ParseNode[] list;
@@ -53,14 +53,14 @@ public class ListParseNode extends ParseNode {
      * @param position where list is
      * @param firstNode first element of the list
      */
-    public ListParseNode(SourceIndexLength position, ParseNode firstNode) {
+    protected ListParseNode(SourceIndexLength position, ParseNode firstNode) {
         super(position);
 
         list = new ParseNode[INITIAL_SIZE];
         addInternal(firstNode);
     }
 
-    public ListParseNode(SourceIndexLength position) {
+    protected ListParseNode(SourceIndexLength position) {
         super(position);
 
         list = EMPTY;

--- a/src/main/java/org/truffleruby/parser/ast/ParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ParseNode.java
@@ -84,6 +84,8 @@ public abstract class ParseNode {
     }
     
     public abstract <T> T accept(NodeVisitor<T> visitor);
+
+    /** Only for debugging, cast and use getters on specific classes instead. */
     public abstract List<ParseNode> childNodes();
 
     protected static List<ParseNode> createList(ParseNode node) {

--- a/src/main/java/org/truffleruby/parser/ast/visitor/AbstractNodeVisitor.java
+++ b/src/main/java/org/truffleruby/parser/ast/visitor/AbstractNodeVisitor.java
@@ -144,14 +144,6 @@ public abstract class AbstractNodeVisitor<T> implements NodeVisitor<T> {
 
     abstract protected T defaultVisit(ParseNode node);
 
-    protected void visitChildren(ParseNode node) {
-        for (ParseNode child: node.childNodes()) {
-            if (child != null) {
-                child.accept(this);
-            }
-        }
-    }
-
     @Override
     public T visitAliasNode(AliasParseNode node) {
         return defaultVisit(node);

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -331,7 +331,7 @@ public class ParserSupport {
         }
 
         // Assumption: tail is never a list node
-        ((ListParseNode) head).addAll(tail);
+        ((ListParseNode) head).add(tail);
         return head;
     }
 
@@ -1169,14 +1169,14 @@ public class ParserSupport {
             if (head instanceof StrParseNode) { // Str + oDStr -> Dstr(Str, oDStr.contents)
                 DStrParseNode newDStr = new DStrParseNode(head.getPosition(), ((DStrParseNode) tail).getEncoding());
                 newDStr.add(head);
-                newDStr.addAll(tail);
+                newDStr.add(tail);
                 if (getConfiguration().isFrozenStringLiteral()) {
                     newDStr.setFrozen(true);
                 }
                 return newDStr;
             }
 
-            return ((ListParseNode) head).addAll(tail);
+            return ((ListParseNode) head).add(tail);
         }
 
         // tail must be EvStrParseNode at this point
@@ -1477,7 +1477,7 @@ public class ParserSupport {
             if (second instanceof ListParseNode) {
                 return ((ListParseNode) first).addAll((ListParseNode) second);
             } else {
-                return ((ListParseNode) first).addAll(second);
+                return ((ListParseNode) first).add(second);
             }
         }
 

--- a/test/mri/excludes/TestRubyPrimitive.rb
+++ b/test/mri/excludes/TestRubyPrimitive.rb
@@ -1,1 +1,0 @@
-exclude :test_opassign, "needs investigation"


### PR DESCRIPTION
```ruby
digits = '\d+'
case "foo42"
when /oo(#{digits})/
end
```
used to not work correctly, due to the translation of `when` thinking the interpolated regexps is multiple conditions (it's a `ListParseNode` too). That was pretty tough to debug.

I cleaned up two bad patterns in the translator:
* Using `childNodes()` which is unreliable (sometimes returns `null` in it), creates useless lists, and hides the type of nodes we expect.
* `instanceof ListParseNode` which should be `instanceof ArrayParseNode` to mean multiple expressions and not just some node happening to use a sequence of child nodes internally.