### PR TITLE
Fix the inlined String#bytesize for instances of subclasses of String

### DIFF
--- a/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
+++ b/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
@@ -34,11 +34,10 @@ import org.truffleruby.language.methods.InternalMethod;
  * inlined operation NOT appear in the backtrace.
  * <p>
  * Two strategies are used to check method re-definition.
- * <li>If the class is a leaf class (there cannot be instances of a subclass of that class), or we
- * know the operation will likely be called on instances of a given class, then we only need to
- * check the receiver is an instance of that class and register an Assumption for the given method
- * name (see {@link ModuleFields#registerAssumption(String)}). In such cases the method must be
- * public as we do not check visibility.</li>
+ * <li>If the class is a leaf class (there cannot be instances of a subclass of that class), then we
+ * only need to check the receiver is an instance of that class and register an Assumption for the
+ * given method name (see {@link ModuleFields#registerAssumption(String)}). In such cases the method
+ * must be public as we do not check visibility.</li>
  * <li>Otherwise, we need to do a method lookup and verify the method that would be called is the
  * standard definition we expect.</li>
  */

--- a/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
+++ b/src/main/java/org/truffleruby/core/inlined/CoreMethods.java
@@ -64,11 +64,10 @@ public class CoreMethods {
 
     final Assumption nilClassIsNilAssumption;
 
-    final Assumption stringBytesizeAssumpton;
-
     public final InternalMethod BLOCK_GIVEN;
     public final InternalMethod NOT;
     public final InternalMethod KERNEL_IS_NIL;
+    public final InternalMethod STRING_BYTESIZE;
 
     public CoreMethods(RubyContext context) {
         this.context = context;
@@ -110,11 +109,10 @@ public class CoreMethods {
 
         nilClassIsNilAssumption = registerAssumption(nilClass, "nil?");
 
-        stringBytesizeAssumpton = registerAssumption(stringClass, "bytesize");
-
         BLOCK_GIVEN = getMethod(kernelModule, "block_given?");
         NOT = getMethod(basicObjectClass, "!");
         KERNEL_IS_NIL = getMethod(kernelModule, "nil?");
+        STRING_BYTESIZE = getMethod(stringClass, "bytesize");
     }
 
     private Assumption registerAssumption(DynamicObject klass, String methodName) {

--- a/src/main/java/org/truffleruby/core/inlined/InlinedByteSizeNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedByteSizeNode.java
@@ -16,16 +16,22 @@ import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.language.dispatch.RubyCallNodeParameters;
+import org.truffleruby.language.methods.LookupMethodNode;
 
 public abstract class InlinedByteSizeNode extends UnaryInlinedOperationNode {
 
+    protected static final String METHOD = "bytesize";
+
     public InlinedByteSizeNode(RubyContext context, RubyCallNodeParameters callNodeParameters) {
-        super(callNodeParameters, context.getCoreMethods().stringBytesizeAssumpton);
+        super(callNodeParameters);
     }
 
-    @Specialization(guards = "isRubyString(self)", assumptions = "assumptions")
-    int byteSize(DynamicObject self,
-                 @Cached("create()") StringNodes.ByteSizeNode byteSizeNode) {
+    @Specialization(guards = {
+            "lookupNode.lookup(frame, self, METHOD) == coreMethods().STRING_BYTESIZE",
+    }, assumptions = "assumptions", limit = "1")
+    int byteSize(VirtualFrame frame, DynamicObject self,
+            @Cached("create()") LookupMethodNode lookupNode,
+            @Cached("create()") StringNodes.ByteSizeNode byteSizeNode) {
         return byteSizeNode.executeByteSize(self);
     }
 


### PR DESCRIPTION
Another possibility would be to use a MetaClassNode, but then it would only work for instances of String, while here it will work for subclasses as well if they don't override `bytesize`. In any case, both are just Shape checks on the fast path.
The LookupMethodNode is also needed to properly check the visibility.