### PR TITLE
Refer to native, rather than AOT, in almost all cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We do run Rails, and pass the majority of the Rails test suite. But we are
 missing support for OpenSSL, Nokogiri, and ActiveRecord database drivers
 which makes it not practical to run real Rails applications at the moment.
 
-#### What is happening with AOT, startup time, and the SubstrateVM?
+#### What is happening with native, startup time, and the SubstrateVM?
 
 You don't need a JVM to run TruffleRuby. With the
 [SubstrateVM](doc/user/svm.md)

--- a/doc/user/truffleruby-additions.md
+++ b/doc/user/truffleruby-additions.md
@@ -35,7 +35,7 @@ TruffleRuby using the standard `RUBY_ENGINE_VERSION` constant.
 `Truffle.graal?` reports if the Graal compiler is available and will be
 used.
 
-`Truffle.aot?` reports if TruffleRuby has been ahead-of-time compiled.
+`Truffle.native?` reports if TruffleRuby has been ahead-of-time compiled.
 In practice this implies that the SubstrateVM is being used.
 
 ## Polyglot interoperability

--- a/spec/truffle/truffle/aot_spec.rb
+++ b/spec/truffle/truffle/aot_spec.rb
@@ -8,10 +8,10 @@
 
 require_relative '../../ruby/spec_helper'
 
-describe "Truffle.aot?" do
+describe "Truffle.native?" do
   
   it "returns a Boolean value" do
-    Truffle.aot?.should be_true_or_false
+    Truffle.native?.should be_true_or_false
   end
   
 end

--- a/src/launcher/java/org/truffleruby/launcher/Launcher.java
+++ b/src/launcher/java/org/truffleruby/launcher/Launcher.java
@@ -220,7 +220,7 @@ public class Launcher {
     }
 
     private static void printTruffleMemoryMetric() {
-        // Memory stats aren't available on AOT.
+        // Memory stats aren't available in native.
         if (!IS_NATIVE && METRICS_MEMORY_USED_ON_EXIT) {
             for (int n = 0; n < 10; n++) {
                 System.gc();

--- a/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
+++ b/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
@@ -215,7 +215,7 @@ public abstract class TruffleSystemNodes {
 
     }
 
-    @CoreMethod(names = "aot_set_process_title", isModuleFunction = true, required = 1)
+    @CoreMethod(names = "native_set_process_title", isModuleFunction = true, required = 1)
     public abstract static class SetProcessTitleNode extends PrimitiveArrayArgumentsNode {
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
@@ -67,7 +67,7 @@ public class EncodingManager {
         }
     }
 
-    // This must be run after the locale is set for AOT, see the setLocale() call above
+    // This must be run after the locale is set for native, see the setLocale() call above
     public void initializeLocaleEncoding(TruffleNFIPlatform nfi, NativeConfiguration nativeConfiguration) {
         final String localeEncodingName;
         if (context.getOptions().NATIVE_PLATFORM) {

--- a/src/main/java/org/truffleruby/extra/TruffleNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleNodes.java
@@ -29,11 +29,11 @@ public abstract class TruffleNodes {
 
     }
 
-    @CoreMethod(names = "aot?", onSingleton = true)
-    public abstract static class AOTNode extends CoreMethodArrayArgumentsNode {
+    @CoreMethod(names = "native?", onSingleton = true)
+    public abstract static class NativeNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
-        public boolean aot() {
+        public boolean isNative() {
             return TruffleOptions.AOT;
         }
 

--- a/src/main/java/org/truffleruby/parser/parser/ParserRopeOperations.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserRopeOperations.java
@@ -25,7 +25,7 @@ import static org.truffleruby.core.rope.CodeRange.CR_UNKNOWN;
 public class ParserRopeOperations {
 
     public Rope withEncoding(Rope rope, Encoding encoding) {
-        if (isBuildingAOTImage()) {
+        if (isBuildingNativeImage()) {
             if (rope.isAsciiOnly() && encoding.isAsciiCompatible()) {
                 return rope.withEncoding(encoding, CR_7BIT);
             }
@@ -37,7 +37,7 @@ public class ParserRopeOperations {
     }
 
     public Rope makeShared(Rope rope, int sharedStart, int sharedLength) {
-        if (isBuildingAOTImage()) {
+        if (isBuildingNativeImage()) {
             if (sharedLength == rope.byteLength()) {
                 return rope;
             }
@@ -48,9 +48,9 @@ public class ParserRopeOperations {
         }
     }
 
-    private static boolean isBuildingAOTImage() {
+    private static boolean isBuildingNativeImage() {
         // We can't use a detached RopeNode during image construction because it trips up the static analysis, but
-        // we can use it at runtime. We check if a context has been created as a proxy for whether we're in the AOT
+        // we can use it at runtime. We check if a context has been created as a proxy for whether we're in the native
         // image builder or running at runtime.
         return TruffleOptions.AOT && RubyContext.FIRST_INSTANCE == null;
     }
@@ -85,6 +85,6 @@ public class ParserRopeOperations {
 
     }
 
-    private final RopeNode ropeNode = isBuildingAOTImage() ? null : new RopeNode();
+    private final RopeNode ropeNode = isBuildingNativeImage() ? null : new RopeNode();
 
 }

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -146,8 +146,8 @@ module Process
   #
   def self.setproctitle(title)
     title = Truffle::Type.coerce_to(title, String, :to_str)
-    if Truffle.aot?
-      Truffle::System.aot_set_process_title(title)
+    if Truffle.native?
+      Truffle::System.native_set_process_title(title)
     elsif Truffle.linux? && File.readable?('/proc/self/maps')
       setproctitle_linux_from_proc_maps(title)
     elsif Truffle.darwin?

--- a/test/truffle/docker/README.md
+++ b/test/truffle/docker/README.md
@@ -23,4 +23,4 @@ You need to specify `GRAALVM_VERSION` as the version of GraalVM that you are
 using.
 
 Docker will need to run the container with at least 8 GB of RAM if you are using
-virtualisation, to give enough space for the AOT image to build.
+virtualisation, to give enough space for the native image to build.

--- a/test/truffle/docker/fedora/Dockerfile
+++ b/test/truffle/docker/fedora/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf install -y git
 # Used in spec/truffle.mspec
 RUN dnf install -y which
 
-# The AOT tool uses gcc and zlib.h to figure out struct layouts and link
+# The native image tool uses gcc and zlib.h to figure out struct layouts and link
 RUN dnf install -y gcc zlib-devel
 
 # These are the actual runtime GraalVM dependencies

--- a/test/truffle/docker/ubuntu/Dockerfile
+++ b/test/truffle/docker/ubuntu/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=en_US.UTF-8
 # Tools we will need to get and run our tests
 RUN apt-get install -y git
 
-# The AOT tool uses gcc and zlib.h to figure out struct layouts and link
+# The native image tool uses gcc and zlib.h to figure out struct layouts and link
 RUN apt-get install -y gcc zlib1g-dev
 
 # These are the actual runtime GraalVM dependencies


### PR DESCRIPTION
We've currently got two words for the same thing, and should use one instead.

The flag you use to get the native mode is `--native`, so I think that should be the one name that users see, so changing things like `Truffle.aot?` to `Truffle.native?`.