### PR TITLE
Add Regexp#match?, String#match? and Symbol#match?

### DIFF
--- a/src/main/ruby/core/regexp.rb
+++ b/src/main/ruby/core/regexp.rb
@@ -207,6 +207,10 @@ class Regexp
     end
   end
 
+  def match?(str, pos = 0)
+    Truffle::RegexpOperations.match(self, str, pos) != nil
+  end
+
   def ===(other)
     if other.kind_of? Symbol
       other = other.to_s

--- a/src/main/ruby/core/string.rb
+++ b/src/main/ruby/core/string.rb
@@ -1040,6 +1040,11 @@ class String
     result
   end
 
+  def match?(pattern, pos=0)
+    pattern = Truffle::Type.coerce_to_regexp(pattern) unless pattern.kind_of? Regexp
+    pattern.match? self, pos
+  end
+
   def scrub(replace = nil, &block)
     return dup if valid_encoding?
 

--- a/src/main/ruby/core/symbol.rb
+++ b/src/main/ruby/core/symbol.rb
@@ -94,6 +94,11 @@ class Symbol
 
   alias_method :=~, :match
 
+  def match?(pattern, pos=0)
+    pattern = Truffle::Type.coerce_to_regexp(pattern) unless pattern.kind_of? Regexp
+    pattern.match? to_s, pos
+  end
+
   def encoding
     Truffle.invoke_primitive :encoding_get_object_encoding, self
   end


### PR DESCRIPTION
* Those are Ruby 2.4 features but they should not conflict.
* Tested manually with:
  `jt mspec --unguarded spec/ruby/core/{regexp,string,symbol}/match_spec.rb`