### PR TITLE
Optimize string_character_byte_index for the common cases

### DIFF
--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3344,7 +3344,7 @@ public abstract class StringNodes {
         @Child private NormalizeIndexNode normalizeIndexNode = StringNodesFactory.NormalizeIndexNodeGen.create(null, null);
 
         @Specialization(guards = { "isRubyString(pattern)", "!isBrokenCodeRange(pattern)", "isSingleByteSearch(string, pattern)" })
-        public Object stringIndex(VirtualFrame frame, DynamicObject string, DynamicObject pattern, int start,
+        public Object stringIndex(DynamicObject string, DynamicObject pattern, int start,
                                   @Cached("create()") RopeNodes.BytesNode bytesNode,
                                   @Cached("createBinaryProfile()") ConditionProfile badStartProfile,
                                   @Cached("create()") BranchProfile matchFoundProfile,
@@ -3370,13 +3370,13 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = { "isRubyString(pattern)", "!isBrokenCodeRange(pattern)", "!isSingleByteSearch(string, pattern)" })
-        public Object stringIndexGeneric(VirtualFrame frame, DynamicObject string, DynamicObject pattern, int start,
+        public Object stringIndexGeneric(DynamicObject string, DynamicObject pattern, int start,
                                   @Cached("create()") EncodingNodes.CheckEncodingNode checkEncodingNode,
                                   @Cached("createBinaryProfile()") ConditionProfile badIndexProfile) {
             checkEncodingNode.executeCheckEncoding(string, pattern);
 
             // Rubinius will pass in a byte index for the `start` value, but StringSupport.index requires a character index.
-            final int charIndex = byteIndexToCharIndexNode.executeStringByteCharacterIndex(frame, string, start, 0);
+            final int charIndex = byteIndexToCharIndexNode.executeStringByteCharacterIndex(string, start, 0);
 
             final int index = index(rope(string), rope(pattern), charIndex, encoding(string));
 
@@ -3497,8 +3497,6 @@ public abstract class StringNodes {
     @ImportStatic(StringGuards.class)
     public static abstract class CharacterByteIndexNode extends PrimitiveArrayArgumentsNode {
 
-        public abstract int executeInt(VirtualFrame frame, DynamicObject string, int charIndex, int start);
-
         @Specialization(guards = "isSingleByteOptimizable(string)")
         public int stringCharacterByteIndex(DynamicObject string, int charIndex, int start) {
             return start + charIndex;
@@ -3523,7 +3521,7 @@ public abstract class StringNodes {
     @ImportStatic(StringGuards.class)
     public static abstract class StringByteCharacterIndexNode extends PrimitiveArrayArgumentsNode {
 
-        public abstract int executeStringByteCharacterIndex(VirtualFrame frame, DynamicObject string, int byteIndex, int start);
+        public abstract int executeStringByteCharacterIndex(DynamicObject string, int byteIndex, int start);
 
         @Specialization(guards = "isSingleByteOptimizable(string)")
         public int singleByte(DynamicObject string, int byteIndex, int start) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3547,6 +3547,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = { "!isSingleByteOptimizable(string)", "!isFixedWidthEncoding(string)", "isValidUtf8(string)" })
         public int validUtf8(DynamicObject string, int byteIndex) {
+            // Taken from Rubinius's String::find_byte_character_index.
             // TODO (nirvdrum 02-Apr-15) There's a way to optimize this for UTF-8, but porting all that code isn't necessary at the moment.
             return notValidUtf8(string, byteIndex);
         }

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3523,20 +3523,16 @@ public abstract class StringNodes {
 
         @Specialization(guards = "isSingleByteOptimizable(string)")
         public int singleByte(DynamicObject string, int byteIndex) {
-            // Taken from Rubinius's String::find_byte_character_index.
             return byteIndex;
         }
 
         @Specialization(guards = { "!isSingleByteOptimizable(string)", "isFixedWidthEncoding(string)" })
         public int fixedWidth(DynamicObject string, int byteIndex) {
-            // Taken from Rubinius's String::find_byte_character_index.
             return byteIndex / encoding(string).minLength();
         }
 
         @Specialization(guards = { "!isSingleByteOptimizable(string)", "!isFixedWidthEncoding(string)", "isValidUtf8(string)" })
         public int validUtf8(DynamicObject string, int byteIndex) {
-            // Taken from Rubinius's String::find_byte_character_index.
-
             // TODO (nirvdrum 02-Apr-15) There's a way to optimize this for UTF-8, but porting all that code isn't necessary at the moment.
             return notValidUtf8(string, byteIndex);
         }

--- a/src/main/ruby/core/string_mirror.rb
+++ b/src/main/ruby/core/string_mirror.rb
@@ -37,12 +37,12 @@ module Truffle
     class String < Mirror
       self.subject = ::String
 
-      def character_to_byte_index(idx, start=0)
-        Truffle.invoke_primitive :string_character_byte_index, @object, idx, start
+      def character_to_byte_index(idx)
+        Truffle.invoke_primitive :string_character_byte_index, @object, idx
       end
 
-      def byte_to_character_index(idx, start=0)
-        Truffle.invoke_primitive :string_byte_character_index, @object, idx, start
+      def byte_to_character_index(idx)
+        Truffle.invoke_primitive :string_byte_character_index, @object, idx
       end
 
       def character_index(str, start)


### PR DESCRIPTION
* Where charIndex is 0 or characterLength().
* Notably used in RegexpOperations.match and String#index,
  where most cases have a charIndex of 0.