### PR TITLE
Rename executeVoid so the DSL does not generate useless methods

### DIFF
--- a/src/main/java/org/truffleruby/builtins/InvokePrimitiveNode.java
+++ b/src/main/java/org/truffleruby/builtins/InvokePrimitiveNode.java
@@ -24,7 +24,7 @@ public class InvokePrimitiveNode extends RubyNode {
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         primitive.execute(frame);
     }
 

--- a/src/main/java/org/truffleruby/core/array/ArrayConcatNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayConcatNode.java
@@ -86,9 +86,9 @@ public final class ArrayConcatNode extends RubyNode {
 
     @ExplodeLoop
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         for (int n = 0; n < children.length; n++) {
-            children[n].executeVoid(frame);
+            children[n].doExecuteVoid(frame);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
@@ -63,9 +63,9 @@ public abstract class ArrayLiteralNode extends RubyNode {
 
     @ExplodeLoop
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         for (RubyNode value : values) {
-            value.executeVoid(frame);
+            value.doExecuteVoid(frame);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/cast/ArrayCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ArrayCastNode.java
@@ -111,8 +111,8 @@ public abstract class ArrayCastNode extends RubyNode {
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
-        getChild().executeVoid(frame);
+    public void doExecuteVoid(VirtualFrame frame) {
+        getChild().doExecuteVoid(frame);
     }
 
 }

--- a/src/main/java/org/truffleruby/core/cast/HashCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/HashCastNode.java
@@ -83,8 +83,8 @@ public abstract class HashCastNode extends RubyNode {
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
-        getChild().executeVoid(frame);
+    public void doExecuteVoid(VirtualFrame frame) {
+        getChild().doExecuteVoid(frame);
     }
 
 }

--- a/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
+++ b/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
@@ -57,9 +57,9 @@ public abstract class HashLiteralNode extends RubyNode {
 
     @ExplodeLoop
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         for (RubyNode child : keyValues) {
-            child.executeVoid(frame);
+            child.doExecuteVoid(frame);
         }
     }
 

--- a/src/main/java/org/truffleruby/language/RubyNode.java
+++ b/src/main/java/org/truffleruby/language/RubyNode.java
@@ -21,7 +21,11 @@ public abstract class RubyNode extends RubyBaseNode {
 
     public abstract Object execute(VirtualFrame frame);
 
-    public void executeVoid(VirtualFrame frame) {
+    /**
+     * This method does not start with "execute" on purpose, so the Truffle DSL does not generate
+     * useless copies of this method which would increase the number of runtime compilable methods.
+     */
+    public void doExecuteVoid(VirtualFrame frame) {
         execute(frame);
     }
 

--- a/src/main/java/org/truffleruby/language/arguments/CheckArityNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/CheckArityNode.java
@@ -26,7 +26,7 @@ public class CheckArityNode extends RubyNode {
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         final int given = RubyArguments.getArgumentsCount(frame);
 
         if (!checkArity(arity, given)) {
@@ -41,7 +41,7 @@ public class CheckArityNode extends RubyNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        executeVoid(frame);
+        doExecuteVoid(frame);
         return nil();
     }
 

--- a/src/main/java/org/truffleruby/language/arguments/CheckKeywordArityNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/CheckKeywordArityNode.java
@@ -36,7 +36,7 @@ public class CheckKeywordArityNode extends RubyNode {
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         final Object keywordArguments = readUserKeywordsHashNode.execute(frame);
 
         int given = RubyArguments.getArgumentsCount(frame);
@@ -60,7 +60,7 @@ public class CheckKeywordArityNode extends RubyNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        executeVoid(frame);
+        doExecuteVoid(frame);
         return nil();
     }
 

--- a/src/main/java/org/truffleruby/language/control/ElidableResultNode.java
+++ b/src/main/java/org/truffleruby/language/control/ElidableResultNode.java
@@ -31,12 +31,12 @@ public class ElidableResultNode extends RubyNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        required.executeVoid(frame);
+        required.doExecuteVoid(frame);
         return elidableResult.execute(frame);
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         required.execute(frame);
     }
 

--- a/src/main/java/org/truffleruby/language/control/SequenceNode.java
+++ b/src/main/java/org/truffleruby/language/control/SequenceNode.java
@@ -28,7 +28,7 @@ public final class SequenceNode extends RubyNode {
     @Override
     public Object execute(VirtualFrame frame) {
         for (int n = 0; n < body.length - 1; n++) {
-            body[n].executeVoid(frame);
+            body[n].doExecuteVoid(frame);
         }
 
         return body[body.length - 1].execute(frame);
@@ -36,9 +36,9 @@ public final class SequenceNode extends RubyNode {
 
     @ExplodeLoop
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         for (int n = 0; n < body.length; n++) {
-            body[n].executeVoid(frame);
+            body[n].doExecuteVoid(frame);
         }
     }
 

--- a/src/main/java/org/truffleruby/language/exceptions/EnsureNode.java
+++ b/src/main/java/org/truffleruby/language/exceptions/EnsureNode.java
@@ -42,30 +42,30 @@ public class EnsureNode extends RubyNode {
             throw exception;
         } catch (Throwable throwable) {
             javaExceptionPath.enter();
-            ensurePart.executeVoid(frame);
+            ensurePart.doExecuteVoid(frame);
             throw throwable;
         }
 
-        ensurePart.executeVoid(frame);
+        ensurePart.doExecuteVoid(frame);
 
         return value;
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         try {
-            tryPart.executeVoid(frame);
+            tryPart.doExecuteVoid(frame);
         } catch (RaiseException exception) {
             rubyExceptionPath.enter();
             setLastExceptionAndRunEnsure(frame, exception);
             throw exception;
         } catch (Throwable throwable) {
             javaExceptionPath.enter();
-            ensurePart.executeVoid(frame);
+            ensurePart.doExecuteVoid(frame);
             throw throwable;
         }
 
-        ensurePart.executeVoid(frame);
+        ensurePart.doExecuteVoid(frame);
     }
 
     private void setLastExceptionAndRunEnsure(VirtualFrame frame, RaiseException exception) {

--- a/src/main/java/org/truffleruby/language/exceptions/RescueNodeWrapper.java
+++ b/src/main/java/org/truffleruby/language/exceptions/RescueNodeWrapper.java
@@ -64,10 +64,10 @@ public class RescueNodeWrapper implements InstrumentableFactory<RescueNode> {
         }
 
         @Override
-        public void executeVoid(VirtualFrame frame) {
+        public void doExecuteVoid(VirtualFrame frame) {
             try {
                 probeNode.onEnter(frame);
-                delegateNode.executeVoid(frame);
+                delegateNode.doExecuteVoid(frame);
                 probeNode.onReturnValue(frame, null);
             } catch (Throwable t) {
                 probeNode.onReturnExceptional(frame, t);

--- a/src/main/java/org/truffleruby/language/globals/WriteReadOnlyGlobalNode.java
+++ b/src/main/java/org/truffleruby/language/globals/WriteReadOnlyGlobalNode.java
@@ -25,14 +25,14 @@ public class WriteReadOnlyGlobalNode extends RubyNode {
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
-        value.executeVoid(frame);
+    public void doExecuteVoid(VirtualFrame frame) {
+        value.doExecuteVoid(frame);
         throw new RaiseException(coreExceptions().nameErrorReadOnly(name, this));
     }
 
     @Override
     public Object execute(VirtualFrame frame) {
-        executeVoid(frame);
+        doExecuteVoid(frame);
         return nil();
     }
 

--- a/src/main/java/org/truffleruby/language/locals/InitFlipFlopSlotNode.java
+++ b/src/main/java/org/truffleruby/language/locals/InitFlipFlopSlotNode.java
@@ -22,13 +22,13 @@ public class InitFlipFlopSlotNode extends RubyNode {
     }
 
     @Override
-    public void executeVoid(VirtualFrame frame) {
+    public void doExecuteVoid(VirtualFrame frame) {
         frame.setBoolean(frameSlot, false);
     }
 
     @Override
     public Object execute(VirtualFrame frame) {
-        executeVoid(frame);
+        doExecuteVoid(frame);
         return null;
     }
 


### PR DESCRIPTION
* Reduces the number of runtime compilable methods by ~1100
  and the image size by ~1MB.