### PR TITLE
Fix DeclarationContext for blocks

### DIFF
--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -975,7 +975,8 @@ public abstract class KernelNodes {
                             Layouts.PROC.getMethod(block),
                             Layouts.PROC.getSelf(block),
                             Layouts.PROC.getBlock(block),
-                            null);
+                            null,
+                            Layouts.PROC.getDeclarationContext(block));
         }
 
         @Specialization(guards = "!isLiteralBlock(block)")

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -235,7 +235,8 @@ public abstract class MethodNodes {
                     method,
                     Layouts.METHOD.getReceiver(methodObject),
                     null,
-                    null);
+                    null,
+                    method.getDeclarationContext());
         }
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1079,10 +1079,7 @@ public abstract class ModuleNodes {
             final RubyRootNode newRootNode = new RubyRootNode(getContext(), info.getSourceSection(), rootNode.getFrameDescriptor(), info, newBody);
             final CallTarget newCallTarget = Truffle.getRuntime().createCallTarget(newRootNode);
 
-            // TODO (eregon, 7 Jan. 2018): Should be just the method's declaration context,
-            // but currently block calls do not forward the DeclarationContext.
-            final DeclarationContext declarationContext = declarationFrame != null ? RubyArguments.getDeclarationContext(declarationFrame) : Layouts.PROC.getMethod(proc).getDeclarationContext();
-
+            final DeclarationContext declarationContext = Layouts.PROC.getDeclarationContext(proc);
             final InternalMethod method = InternalMethod.fromProc(getContext(), info, declarationContext, name, module, Visibility.PUBLIC, proc, newCallTarget);
             return addMethod(module, name, method);
         }

--- a/src/main/java/org/truffleruby/core/proc/ProcLayout.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcLayout.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.object.dsl.Layout;
 import com.oracle.truffle.api.object.dsl.Nullable;
 import org.truffleruby.core.basicobject.BasicObjectLayout;
 import org.truffleruby.language.control.FrameOnStackMarker;
+import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.methods.SharedMethodInfo;
 
@@ -44,7 +45,8 @@ public interface ProcLayout extends BasicObjectLayout {
             @Nullable InternalMethod method,
             Object self,
             @Nullable DynamicObject block,
-            @Nullable FrameOnStackMarker frameOnStackMarker);
+            @Nullable FrameOnStackMarker frameOnStackMarker,
+            DeclarationContext declarationContext);
 
     boolean isProc(ObjectType objectType);
     boolean isProc(DynamicObject object);
@@ -67,5 +69,7 @@ public interface ProcLayout extends BasicObjectLayout {
     DynamicObject getBlock(DynamicObject object);
 
     FrameOnStackMarker getFrameOnStackMarker(DynamicObject object);
+
+    DeclarationContext getDeclarationContext(DynamicObject object);
 
 }

--- a/src/main/java/org/truffleruby/core/proc/ProcLayout.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcLayout.java
@@ -35,8 +35,7 @@ public interface ProcLayout extends BasicObjectLayout {
     DynamicObjectFactory createProcShape(DynamicObject logicalClass,
                                          DynamicObject metaClass);
 
-    DynamicObject createProc(
-            DynamicObjectFactory factory,
+    Object[] build(
             ProcType type,
             SharedMethodInfo sharedMethodInfo,
             CallTarget callTargetForType,

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -126,7 +126,8 @@ public abstract class ProcNodes {
                     Layouts.PROC.getMethod(block),
                     Layouts.PROC.getSelf(block),
                     Layouts.PROC.getBlock(block),
-                    Layouts.PROC.getFrameOnStackMarker(block));
+                    Layouts.PROC.getFrameOnStackMarker(block),
+                    Layouts.PROC.getDeclarationContext(block));
 
             getInitializeNode().callWithBlock(frame, proc, "initialize", block, args);
 
@@ -174,7 +175,8 @@ public abstract class ProcNodes {
                     Layouts.PROC.getMethod(proc),
                     Layouts.PROC.getSelf(proc),
                     Layouts.PROC.getBlock(proc),
-                    Layouts.PROC.getFrameOnStackMarker(proc));
+                    Layouts.PROC.getFrameOnStackMarker(proc),
+                    Layouts.PROC.getDeclarationContext(proc));
 
             return copy;
         }

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -116,8 +116,7 @@ public abstract class ProcNodes {
         public DynamicObject procSpecial(VirtualFrame frame, DynamicObject procClass, Object[] args, DynamicObject block) {
             // Instantiate a new instance of procClass as classes do not correspond
 
-            final DynamicObject proc = getAllocateObjectNode().allocate(
-                    procClass,
+            final DynamicObject proc = getAllocateObjectNode().allocate(procClass, Layouts.PROC.build(
                     Layouts.PROC.getType(block),
                     Layouts.PROC.getSharedMethodInfo(block),
                     Layouts.PROC.getCallTargetForType(block),
@@ -127,7 +126,7 @@ public abstract class ProcNodes {
                     Layouts.PROC.getSelf(block),
                     Layouts.PROC.getBlock(block),
                     Layouts.PROC.getFrameOnStackMarker(block),
-                    Layouts.PROC.getDeclarationContext(block));
+                    Layouts.PROC.getDeclarationContext(block)));
 
             getInitializeNode().callWithBlock(frame, proc, "initialize", block, args);
 
@@ -165,8 +164,7 @@ public abstract class ProcNodes {
 
         @Specialization
         public DynamicObject dup(DynamicObject proc) {
-            final DynamicObject copy = getAllocateObjectNode().allocate(
-                    Layouts.BASIC_OBJECT.getLogicalClass(proc),
+            final DynamicObject copy = getAllocateObjectNode().allocate(Layouts.BASIC_OBJECT.getLogicalClass(proc), Layouts.PROC.build(
                     Layouts.PROC.getType(proc),
                     Layouts.PROC.getSharedMethodInfo(proc),
                     Layouts.PROC.getCallTargetForType(proc),
@@ -176,7 +174,7 @@ public abstract class ProcNodes {
                     Layouts.PROC.getSelf(proc),
                     Layouts.PROC.getBlock(proc),
                     Layouts.PROC.getFrameOnStackMarker(proc),
-                    Layouts.PROC.getDeclarationContext(proc));
+                    Layouts.PROC.getDeclarationContext(proc)));
 
             return copy;
         }

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -24,7 +24,6 @@ import org.truffleruby.language.arguments.ArgumentDescriptorUtils;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
-import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.objects.AllocateObjectNode;
 import org.truffleruby.language.yield.CallBlockNode;
 import org.truffleruby.parser.ArgumentDescriptor;
@@ -219,7 +218,7 @@ public abstract class ProcNodes {
         @Specialization
         public Object call(DynamicObject proc, Object[] args, NotProvided block) {
             return callBlockNode.executeCallBlock(
-                    DeclarationContext.BLOCK,
+                    Layouts.PROC.getDeclarationContext(proc),
                     proc,
                     Layouts.PROC.getSelf(proc),
                     Layouts.PROC.getBlock(proc),
@@ -229,7 +228,7 @@ public abstract class ProcNodes {
         @Specialization
         public Object call(DynamicObject proc, Object[] args, DynamicObject blockArgument) {
             return callBlockNode.executeCallBlock(
-                    DeclarationContext.BLOCK,
+                    Layouts.PROC.getDeclarationContext(proc),
                     proc,
                     Layouts.PROC.getSelf(proc),
                     blockArgument,

--- a/src/main/java/org/truffleruby/core/proc/ProcOperations.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcOperations.java
@@ -17,6 +17,7 @@ import org.truffleruby.Layouts;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.FrameOnStackMarker;
+import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.methods.SharedMethodInfo;
 
@@ -55,7 +56,8 @@ public abstract class ProcOperations {
             MaterializedFrame declarationFrame,
             InternalMethod method,
             Object self, DynamicObject block,
-            FrameOnStackMarker frameOnStackMarker) {
+            FrameOnStackMarker frameOnStackMarker,
+            DeclarationContext declarationContext) {
         assert block == null || RubyGuards.isRubyProc(block);
 
         final CallTarget callTargetForType;
@@ -81,7 +83,8 @@ public abstract class ProcOperations {
                 method,
                 self,
                 block,
-                frameOnStackMarker);
+                frameOnStackMarker,
+                declarationContext);
     }
 
 }

--- a/src/main/java/org/truffleruby/core/proc/ProcOperations.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcOperations.java
@@ -73,8 +73,7 @@ public abstract class ProcOperations {
                 throw new IllegalArgumentException();
         }
 
-        return Layouts.PROC.createProc(
-                instanceFactory,
+        return instanceFactory.newInstance(Layouts.PROC.build(
                 type,
                 sharedMethodInfo,
                 callTargetForType,
@@ -84,7 +83,7 @@ public abstract class ProcOperations {
                 self,
                 block,
                 frameOnStackMarker,
-                declarationContext);
+                declarationContext));
     }
 
 }

--- a/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
@@ -32,6 +32,7 @@ import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.methods.Arity;
+import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.methods.SharedMethodInfo;
 import org.truffleruby.language.methods.SymbolProcNode;
@@ -124,7 +125,8 @@ public abstract class SymbolNodes {
                     method,
                     nil(),
                     null,
-                    null);
+                    null,
+                    DeclarationContext.NONE);
         }
 
         protected InternalMethod getMethod(VirtualFrame frame) {

--- a/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
@@ -109,7 +109,7 @@ public abstract class TruffleGraalNodes {
                 callTargetForLambdas = Layouts.PROC.getCallTargetForLambdas(proc);
             }
 
-            return Layouts.PROC.createProc(coreLibrary().getProcFactory(),
+            return coreLibrary().getProcFactory().newInstance(Layouts.PROC.build(
                     Layouts.PROC.getType(proc),
                     Layouts.PROC.getSharedMethodInfo(proc),
                     newCallTarget,
@@ -119,7 +119,7 @@ public abstract class TruffleGraalNodes {
                     Layouts.PROC.getSelf(proc),
                     Layouts.PROC.getBlock(proc),
                     Layouts.PROC.getFrameOnStackMarker(proc),
-                    Layouts.PROC.getDeclarationContext(proc));
+                    Layouts.PROC.getDeclarationContext(proc)));
         }
 
     }

--- a/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
@@ -118,7 +118,8 @@ public abstract class TruffleGraalNodes {
                     Layouts.PROC.getMethod(proc),
                     Layouts.PROC.getSelf(proc),
                     Layouts.PROC.getBlock(proc),
-                    Layouts.PROC.getFrameOnStackMarker(proc));
+                    Layouts.PROC.getFrameOnStackMarker(proc),
+                    Layouts.PROC.getDeclarationContext(proc));
         }
 
     }

--- a/src/main/java/org/truffleruby/language/methods/BlockDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/BlockDefinitionNode.java
@@ -39,6 +39,7 @@ public class BlockDefinitionNode extends RubyNode {
     private final BreakID breakID;
 
     @Child private ReadFrameSlotNode readFrameOnStackMarkerNode;
+    @Child private WithoutVisibilityNode withoutVisibilityNode = WithoutVisibilityNodeGen.create();
 
     public BlockDefinitionNode(ProcType type, SharedMethodInfo sharedMethodInfo,
                                CallTarget callTargetForProcs, CallTarget callTargetForLambdas, BreakID breakID, FrameSlot frameOnStackMarkerSlot) {
@@ -71,13 +72,17 @@ public class BlockDefinitionNode extends RubyNode {
             assert frameOnStackMarker != null;
         }
 
-        return ProcOperations.createRubyProc(coreLibrary().getProcFactory(), type, sharedMethodInfo,
-                callTargetForProcs, callTargetForLambdas, frame.materialize(),
+        return ProcOperations.createRubyProc(coreLibrary().getProcFactory(),
+                type,
+                sharedMethodInfo,
+                callTargetForProcs,
+                callTargetForLambdas,
+                frame.materialize(),
                 RubyArguments.getMethod(frame),
                 RubyArguments.getSelf(frame),
                 RubyArguments.getBlock(frame),
                 frameOnStackMarker,
-                RubyArguments.getDeclarationContext(frame).withVisibility(null));
+                withoutVisibilityNode.executeWithoutVisibility(RubyArguments.getDeclarationContext(frame)));
     }
 
 }

--- a/src/main/java/org/truffleruby/language/methods/BlockDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/BlockDefinitionNode.java
@@ -77,7 +77,7 @@ public class BlockDefinitionNode extends RubyNode {
                 RubyArguments.getSelf(frame),
                 RubyArguments.getBlock(frame),
                 frameOnStackMarker,
-                RubyArguments.getDeclarationContext(frame));
+                RubyArguments.getDeclarationContext(frame).withVisibility(null));
     }
 
 }

--- a/src/main/java/org/truffleruby/language/methods/BlockDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/BlockDefinitionNode.java
@@ -76,7 +76,8 @@ public class BlockDefinitionNode extends RubyNode {
                 RubyArguments.getMethod(frame),
                 RubyArguments.getSelf(frame),
                 RubyArguments.getBlock(frame),
-                frameOnStackMarker);
+                frameOnStackMarker,
+                RubyArguments.getDeclarationContext(frame));
     }
 
 }

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -106,7 +106,6 @@ public class DeclarationContext {
     }
 
     public DeclarationContext withVisibility(Visibility visibility) {
-        assert visibility != null;
         if (visibility == this.visibility) {
             return this;
         } else {

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -31,7 +31,7 @@ public class DeclarationContext {
 
     /** @see <a href="http://yugui.jp/articles/846">http://yugui.jp/articles/846</a> */
     private interface DefaultDefinee {
-        DynamicObject getModuleToDefineMethods(InternalMethod method, SingletonClassNode singletonClassNode);
+        DynamicObject getModuleToDefineMethods(SingletonClassNode singletonClassNode);
     }
 
     public static class SingletonClassOfSelfDefaultDefinee implements DefaultDefinee {
@@ -41,7 +41,7 @@ public class DeclarationContext {
             this.self = self;
         }
 
-        public DynamicObject getModuleToDefineMethods(InternalMethod method, SingletonClassNode singletonClassNode) {
+        public DynamicObject getModuleToDefineMethods(SingletonClassNode singletonClassNode) {
             return singletonClassNode.executeSingletonClass(self);
         }
     }
@@ -54,7 +54,7 @@ public class DeclarationContext {
             this.module = module;
         }
 
-        public DynamicObject getModuleToDefineMethods(InternalMethod method, SingletonClassNode singletonClassNode) {
+        public DynamicObject getModuleToDefineMethods(SingletonClassNode singletonClassNode) {
             return module;
         }
     }
@@ -114,9 +114,9 @@ public class DeclarationContext {
     }
 
     @TruffleBoundary
-    public DynamicObject getModuleToDefineMethods(InternalMethod method, SingletonClassNode singletonClassNode) {
+    public DynamicObject getModuleToDefineMethods(SingletonClassNode singletonClassNode) {
         assert defaultDefinee != null : "Trying to find the default definee but this method should not have method definitions inside";
-        return defaultDefinee.getModuleToDefineMethods(method, singletonClassNode);
+        return defaultDefinee.getModuleToDefineMethods(singletonClassNode);
     }
 
     /** Used when we know there cannot be a method definition inside a given method. */

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -34,12 +34,6 @@ public class DeclarationContext {
         DynamicObject getModuleToDefineMethods(InternalMethod method, SingletonClassNode singletonClassNode);
     }
 
-    private static class LexicalScopeDefaultDefinee implements DefaultDefinee {
-        public DynamicObject getModuleToDefineMethods(InternalMethod method, SingletonClassNode singletonClassNode) {
-            return method.getSharedMethodInfo().getLexicalScope().getLiveModule();
-        }
-    }
-
     public static class SingletonClassOfSelfDefaultDefinee implements DefaultDefinee {
         private final Object self;
 
@@ -125,10 +119,6 @@ public class DeclarationContext {
         assert defaultDefinee != null : "Trying to find the default definee but this method should not have method definitions inside";
         return defaultDefinee.getModuleToDefineMethods(method, singletonClassNode);
     }
-
-    // TODO (eregon, 4 Jan. 2018): This is a hack, the DeclarationContext should be saved in the
-    // Proc from the current value in the frame.
-    public static final DeclarationContext BLOCK = new DeclarationContext(null, new LexicalScopeDefaultDefinee());
 
     /** Used when we know there cannot be a method definition inside a given method. */
     public static final DeclarationContext NONE = new DeclarationContext(Visibility.PUBLIC, null);

--- a/src/main/java/org/truffleruby/language/methods/GetDefaultDefineeNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetDefaultDefineeNode.java
@@ -24,6 +24,6 @@ public class GetDefaultDefineeNode extends RubyNode {
     @Override
     public DynamicObject execute(VirtualFrame frame) {
         final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(frame);
-        return declarationContext.getModuleToDefineMethods(RubyArguments.getMethod(frame), singletonClassNode);
+        return declarationContext.getModuleToDefineMethods(singletonClassNode);
     }
 }

--- a/src/main/java/org/truffleruby/language/methods/WithoutVisibilityNode.java
+++ b/src/main/java/org/truffleruby/language/methods/WithoutVisibilityNode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby.language.methods;
+
+import org.truffleruby.language.RubyBaseNode;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+
+public abstract class WithoutVisibilityNode extends RubyBaseNode {
+
+    public abstract DeclarationContext executeWithoutVisibility(DeclarationContext declarationContext);
+
+    @Specialization(guards = "declarationContext == cachedContext")
+    protected DeclarationContext cached(DeclarationContext declarationContext,
+            @Cached("declarationContext") DeclarationContext cachedContext,
+            @Cached("uncached(cachedContext)") DeclarationContext without) {
+        return without;
+    }
+
+    @Specialization(replaces = "cached")
+    protected DeclarationContext uncached(DeclarationContext declarationContext) {
+        return declarationContext.withVisibility(null);
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/yield/YieldNode.java
+++ b/src/main/java/org/truffleruby/language/yield/YieldNode.java
@@ -13,7 +13,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.Layouts;
-import org.truffleruby.language.methods.DeclarationContext;
 
 public class YieldNode extends Node {
 
@@ -21,7 +20,7 @@ public class YieldNode extends Node {
 
     public Object dispatch(DynamicObject block, Object... argumentsObjects) {
         return getCallBlockNode().executeCallBlock(
-                DeclarationContext.BLOCK,
+                Layouts.PROC.getDeclarationContext(block),
                 block,
                 Layouts.PROC.getSelf(block),
                 Layouts.PROC.getBlock(block),


### PR DESCRIPTION
Follow-up of #926 and needed for implementing refinements when they are blocks in refined methods.