### PR TITLE
Implement Method#===

### DIFF
--- a/spec/truffle.mspec
+++ b/spec/truffle.mspec
@@ -103,6 +103,7 @@ class MSpecScript
 
   set :ruby25, [
     "spec/ruby/core/kernel/yield_self_spec.rb",
+    "spec/ruby/core/method/case_compare_spec.rb",
   ]
 
   set :backtrace_filter, /mspec\//

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -86,7 +86,7 @@ public abstract class MethodNodes {
 
     }
 
-    @CoreMethod(names = { "call", "[]" }, needsBlock = true, rest = true)
+    @CoreMethod(names = { "call", "[]", "===" }, needsBlock = true, rest = true)
     public abstract static class CallNode extends CoreMethodArrayArgumentsNode {
 
         @Child private CallBoundMethodNode callBoundMethodNode = CallBoundMethodNodeGen.create(null, null, null);

--- a/src/main/ruby/core/method.rb
+++ b/src/main/ruby/core/method.rb
@@ -24,4 +24,6 @@ class Method
   
   alias_method :to_s, :inspect
 
+  alias_method :===, :call
+
 end

--- a/src/main/ruby/core/method.rb
+++ b/src/main/ruby/core/method.rb
@@ -24,6 +24,4 @@ class Method
   
   alias_method :to_s, :inspect
 
-  alias_method :===, :call
-
 end


### PR DESCRIPTION
The six Method#=== specs that were failing with `jt test :ruby25 spec/ruby/core/method` are now all passing.