### PR TITLE
Remove obsoleted ruby-progressbar patch.

### DIFF
--- a/lib/patches/ruby-progressbar/ruby-progressbar/refinements.rb
+++ b/lib/patches/ruby-progressbar/ruby-progressbar/refinements.rb
@@ -1,2 +1,0 @@
-# No-op, since we don't yet support refinements.
-# ruby-progressbar degrades gracefully without refinements in order to support Ruby 1.9.

--- a/lib/truffle/truffle/patching.rb
+++ b/lib/truffle/truffle/patching.rb
@@ -19,7 +19,6 @@ module Truffle::Patching
     'rake-compiler' => "#{DIR}/rake-compiler",
     'rspec-core' => "#{DIR}/rspec-core",
     'rspec-support' => "#{DIR}/rspec-support",
-    'ruby-progressbar' => "#{DIR}/ruby-progressbar",
     'thread_safe' => "#{DIR}/thread_safe",
   }
 


### PR DESCRIPTION
We now support refinements, so there's no need for this patch.