### PR TITLE
Simplify Module#const_missing spec by using private visibility

### DIFF
--- a/spec/ruby/core/module/const_missing_spec.rb
+++ b/spec/ruby/core/module/const_missing_spec.rb
@@ -25,7 +25,12 @@ describe "Module#const_missing" do
   end
 
   it "is called regardless of visibility" do
-    klass = Class.new { extend ConstantSpecs::ProtectedConstMissing }
+    klass = Class.new do
+      def self.const_missing(name)
+        "Found:#{name}"
+      end
+      private_class_method :const_missing
+    end
     klass::Hello.should == 'Found:Hello'
   end
 end

--- a/spec/ruby/fixtures/constants.rb
+++ b/spec/ruby/fixtures/constants.rb
@@ -70,14 +70,6 @@ module ConstantSpecs
     CS_CONST10 = :const10_8
   end
 
-  module ProtectedConstMissing
-    protected
-
-    def const_missing(name)
-      "Found:#{name}"
-    end
-  end
-
   # The following classes/modules have all the constants set "statically".
   # Contrast with the classes below where the constants are set as the specs
   # are run.


### PR DESCRIPTION
* So no external Module is needed.
* See #953.

I checked it fails without the fix from #953 and works with it.