### PR TITLE
Don't use null or empty strings for frame slot identifiers

### DIFF
--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -69,6 +69,7 @@ public abstract class BindingNodes {
     @TruffleBoundary
     public static FrameDescriptor newFrameDescriptor(RubyContext context, String name) {
         FrameDescriptor frameDescriptor = new FrameDescriptor(context.getCoreLibrary().getNil());
+        assert name != null && !name.isEmpty();
         frameDescriptor.addFrameSlot(name);
         return frameDescriptor;
     }

--- a/src/main/java/org/truffleruby/debug/DebugHelpers.java
+++ b/src/main/java/org/truffleruby/debug/DebugHelpers.java
@@ -63,7 +63,9 @@ public abstract class DebugHelpers {
         }
 
         for (int n = 0; n < arguments.length; n += 2) {
-            evalFrame.setObject(evalFrame.getFrameDescriptor().findOrAddFrameSlot(arguments[n]), arguments[n + 1]);
+            final Object identifier = arguments[n];
+            assert identifier != null && (!(identifier instanceof String) || !((String) identifier).isEmpty());
+            evalFrame.setObject(evalFrame.getFrameDescriptor().findOrAddFrameSlot(identifier), arguments[n + 1]);
         }
 
         final Source source = Source.newBuilder(code).name("debug-eval").mimeType(RubyLanguage.MIME_TYPE).build();

--- a/src/main/java/org/truffleruby/debug/DebugHelpers.java
+++ b/src/main/java/org/truffleruby/debug/DebugHelpers.java
@@ -64,7 +64,7 @@ public abstract class DebugHelpers {
 
         for (int n = 0; n < arguments.length; n += 2) {
             final Object identifier = arguments[n];
-            assert identifier != null && (!(identifier instanceof String) || !((String) identifier).isEmpty());
+            assert !(identifier == null || (identifier instanceof String && ((String) identifier).isEmpty()));
             evalFrame.setObject(evalFrame.getFrameDescriptor().findOrAddFrameSlot(identifier), arguments[n + 1]);
         }
 

--- a/src/main/java/org/truffleruby/language/SnippetNode.java
+++ b/src/main/java/org/truffleruby/language/SnippetNode.java
@@ -50,7 +50,9 @@ public class SnippetNode extends RubyBaseNode {
             parameterFrameSlots = new FrameSlot[parameters.length];
 
             for (int n = 0; n < parameters.length; n++) {
-                parameterFrameSlots[n] = frameDescriptor.findOrAddFrameSlot(parameters[n]);
+                final String identifier = parameters[n];
+                assert identifier != null && !identifier.isEmpty();
+                parameterFrameSlots[n] = frameDescriptor.findOrAddFrameSlot(identifier);
             }
 
             final Source source = Source.newBuilder(this.expression).name("(snippet)").internal().mimeType(RubyLanguage.MIME_TYPE).build();

--- a/src/main/java/org/truffleruby/language/threadlocal/FindThreadAndFrameLocalStorageNode.java
+++ b/src/main/java/org/truffleruby/language/threadlocal/FindThreadAndFrameLocalStorageNode.java
@@ -132,6 +132,7 @@ public abstract class FindThreadAndFrameLocalStorageNode extends RubyBaseNode {
 
     private static FrameSlot getVariableFrameSlotWrite(MaterializedFrame frame, String variableName) {
         final FrameDescriptor descriptor = frame.getFrameDescriptor();
+        assert variableName != null && !variableName.isEmpty();
         synchronized (descriptor) {
             return descriptor.findOrAddFrameSlot(variableName, FrameSlotKind.Object);
         }

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -1774,7 +1774,7 @@ public class BodyTranslator extends Translator {
 
         final RubyNode rhs;
         if (node.getValueNode() == null) {
-            rhs = new DeadNode(new Exception("null RHS of instance variable assignment"));
+            rhs = new DeadNode("null RHS of instance variable assignment");
             rhs.unsafeSetSourceSection(sourceSection);
         } else {
             rhs = node.getValueNode().accept(this);
@@ -1892,7 +1892,7 @@ public class BodyTranslator extends Translator {
         RubyNode rhs;
 
         if (node.getValueNode() == null) {
-            rhs = new DeadNode(new Exception());
+            rhs = new DeadNode("BodyTranslator#visitLocalAsgnNode");
             rhs.unsafeSetSourceSection(sourceSection);
         } else {
             rhs = node.getValueNode().accept(this);
@@ -2373,7 +2373,7 @@ public class BodyTranslator extends Translator {
         }
 
         if (node.getPosition() == null) {
-            final RubyNode ret = new DeadNode(new Exception());
+            final RubyNode ret = new DeadNode("BodyTranslator#visitNilNode");
             return addNewlineIfNeeded(node, ret);
         }
 

--- a/src/main/java/org/truffleruby/parser/DeadNode.java
+++ b/src/main/java/org/truffleruby/parser/DeadNode.java
@@ -19,9 +19,9 @@ import org.truffleruby.language.RubyNode;
  */
 public class DeadNode extends RubyNode {
 
-    private final Exception reason;
+    private final String reason;
 
-    public DeadNode(Exception reason) {
+    public DeadNode(String reason) {
         this.reason = reason;
     }
 

--- a/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
@@ -264,7 +264,7 @@ public class LoadArgumentsTranslator extends Translator {
     @Override
     public RubyNode visitKeywordRestArgNode(KeywordRestArgParseNode node) {
         final RubyNode readNode = new ReadKeywordRestArgumentNode(required, excludedKeywords.toArray(new String[excludedKeywords.size()]));
-        final FrameSlot slot = methodBodyTranslator.getEnvironment().getFrameDescriptor().findOrAddFrameSlot(node.getName());
+        final FrameSlot slot = methodBodyTranslator.getEnvironment().declareVar(node.getName());
 
         return new WriteLocalVariableNode(slot, readNode);
     }
@@ -275,8 +275,7 @@ public class LoadArgumentsTranslator extends Translator {
 
         final AssignableParseNode asgnNode = node.getAssignable();
         final String name = ((INameNode) asgnNode).getName();
-
-        final FrameSlot slot = methodBodyTranslator.getEnvironment().getFrameDescriptor().findOrAddFrameSlot(name);
+        final FrameSlot slot = methodBodyTranslator.getEnvironment().declareVar(name);
 
         final RubyNode defaultValue;
         if (asgnNode.getValueNode() instanceof RequiredKeywordArgumentValueParseNode) {
@@ -365,7 +364,7 @@ public class LoadArgumentsTranslator extends Translator {
     private RubyNode translateLocalAssignment(SourceIndexLength sourcePosition, String name, ParseNode valueNode) {
         final SourceIndexLength sourceSection = sourcePosition;
 
-        final FrameSlot slot = methodBodyTranslator.getEnvironment().getFrameDescriptor().findOrAddFrameSlot(name);
+        final FrameSlot slot = methodBodyTranslator.getEnvironment().declareVar(name);
 
         final RubyNode readNode;
 

--- a/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
@@ -107,6 +107,7 @@ public class TranslatorEnvironment {
     }
 
     public FrameSlot declareVar(String name) {
+        assert name != null && !name.isEmpty();
         return getFrameDescriptor().findOrAddFrameSlot(name);
     }
 

--- a/src/main/java/org/truffleruby/parser/ast/ConstDeclParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ConstDeclParseNode.java
@@ -48,6 +48,7 @@ public class ConstDeclParseNode extends AssignableParseNode implements INameNode
     public ConstDeclParseNode(SourceIndexLength position, String name, INameNode constNode, ParseNode valueNode) {
         super(position, valueNode);
 
+        assert constNode != null || (name != null && !name.isEmpty());
         this.name = name;
         this.constNode = constNode;
     }

--- a/src/main/java/org/truffleruby/parser/ast/UnnamedRestArgParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/UnnamedRestArgParseNode.java
@@ -30,15 +30,16 @@ package org.truffleruby.parser.ast;
 
 import org.truffleruby.language.SourceIndexLength;
 
-/**
- * a bare '*' or nothing.  Name is "" if it is '*' and null if it is nothing.
- */
 public class UnnamedRestArgParseNode extends RestArgParseNode {
-    public UnnamedRestArgParseNode(SourceIndexLength position, String name, int index) {
+
+    private final boolean star;
+
+    public UnnamedRestArgParseNode(SourceIndexLength position, String name, int index, boolean star) {
         super(position, name, index);
+        this.star = star;
     }
 
     public boolean isStar() {
-        return getName() != null;
+        return star;
     }
 }

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -1289,6 +1289,10 @@ public class ParserSupport {
             return new ArgsTailHolder(position, keywordArg, null, blockArg);
         }
 
+        if (keywordRestArgName.isEmpty()) {
+            keywordRestArgName = "rubytruffle_temp_kwrest";
+        }
+
         String restKwargsName = keywordRestArgName;
 
         int slot = currentScope.exists(restKwargsName);

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -2580,7 +2580,7 @@ states[393] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[394] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    RestArgParseNode rest = new UnnamedRestArgParseNode(((ListParseNode)yyVals[-1+yyTop]).getPosition(), null, support.getCurrentScope().addVariable("*"));
+    RestArgParseNode rest = new UnnamedRestArgParseNode(((ListParseNode)yyVals[-1+yyTop]).getPosition(), "rubytruffle_temp_anon_rest", support.getCurrentScope().addVariable("*"), false);
     yyVal = support.new_args(((ListParseNode)yyVals[-1+yyTop]).getPosition(), ((ListParseNode)yyVals[-1+yyTop]), null, rest, null, (ArgsTailHolder) null);
     return yyVal;
 };
@@ -3481,7 +3481,7 @@ states[596] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[597] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    yyVal = new UnnamedRestArgParseNode(lexer.getPosition(), "", support.getCurrentScope().addVariable("*"));
+    yyVal = new UnnamedRestArgParseNode(lexer.getPosition(), "rubytruffle_temp_rest", support.getCurrentScope().addVariable("*"), true);
     return yyVal;
 };
 states[600] = (support, lexer, yyVal, yyVals, yyTop) -> {

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -1654,7 +1654,7 @@ block_param     : f_arg ',' f_block_optarg ',' f_rest_arg opt_block_args_tail {
                     $$ = support.new_args($1.getPosition(), $1, null, $3, null, $4);
                 }
                 | f_arg ',' {
-                    RestArgParseNode rest = new UnnamedRestArgParseNode($1.getPosition(), null, support.getCurrentScope().addVariable("*"));
+                    RestArgParseNode rest = new UnnamedRestArgParseNode($1.getPosition(), "rubytruffle_temp_anon_rest", support.getCurrentScope().addVariable("*"), false);
                     $$ = support.new_args($1.getPosition(), $1, null, rest, null, (ArgsTailHolder) null);
                 }
                 | f_arg ',' f_rest_arg ',' f_arg opt_block_args_tail {
@@ -2453,7 +2453,7 @@ f_rest_arg      : restarg_mark tIDENTIFIER {
                     $$ = new RestArgParseNode(support.arg_var(support.shadowing_lvar($2)));
                 }
                 | restarg_mark {
-                    $$ = new UnnamedRestArgParseNode(lexer.getPosition(), "", support.getCurrentScope().addVariable("*"));
+                    $$ = new UnnamedRestArgParseNode(lexer.getPosition(), "rubytruffle_temp_rest", support.getCurrentScope().addVariable("*"), true);
                 }
 
 // [!null]


### PR DESCRIPTION
A subsequent PR will use objects that aren't strings for internal identifiers.