### PR TITLE
Implement Hash#transform_keys! and #transform_keys! from Ruby 2.5

### DIFF
--- a/spec/truffle.mspec
+++ b/spec/truffle.mspec
@@ -110,6 +110,7 @@ class MSpecScript
     "spec/ruby/core/enumerable/any_spec.rb",
     "spec/ruby/core/enumerable/none_spec.rb",
     "spec/ruby/core/enumerable/one_spec.rb",
+    "spec/ruby/core/hash/transform_keys_spec.rb",
   ]
 
   set :backtrace_filter, /mspec\//

--- a/src/main/ruby/core/hash.rb
+++ b/src/main/ruby/core/hash.rb
@@ -491,4 +491,26 @@ class Hash
     end
     self
   end
+
+  def transform_keys
+    return to_enum(:transform_keys) { size } unless block_given?
+
+    h = {}
+    each_pair do |key, value|
+      h[yield(key)] = value
+    end
+    h
+  end
+
+  def transform_keys!
+    return to_enum(:transform_keys!) { size } unless block_given?
+
+    Truffle.check_frozen
+
+    keys.each do |key|
+      new_key = yield(key)
+      self[new_key] = delete(key)
+    end
+    self
+  end
 end


### PR DESCRIPTION
The one failing spec with `jt test :ruby25` is `uninitialized constant FrozenError`.

`FrozenError` is being called in a helper [here](https://github.com/graalvm/truffleruby/blob/bee5e871fe7c910afbf60f22a8613f6cc8fb6aca/spec/mspec/lib/mspec/helpers/frozen_error_class.rb#L8) but hasn't been defined yet. Should `FrozenError` rescue to `RuntimeError` for now, or what's the best way to handle it until `FrozenError` exists?