### PR TITLE
Do not deadlock when the DSL checkers fail

### DIFF
--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -359,7 +359,7 @@ public class CoreMethodNodeManager {
     public void allMethodInstalled() {
         if (CHECK_DSL_USAGE) {
             if (!(AmbiguousOptionalArgumentChecker.SUCCESS && LowerFixnumChecker.SUCCESS)) {
-                System.exit(1);
+                throw new Error("The DSL checkers failed!");
             }
         }
     }


### PR DESCRIPTION
* Truffle's shutdown hook is contending with the monitor taken while
  calling initializeContext(), which causes the hang.