### PR TITLE
Remove support for "jt build <some other command>"

### DIFF
--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -410,7 +410,7 @@ module Commands
           options                                    build the options
           cexts                                      build only the C extensions (part of "jt build")
           sulong                                     update to latest Sulong and build it
-          native [sulong]                            build a native image of TruffleRuby, optionally with Sulong
+          native [sulong] [extra mx image options]   build a native image of TruffleRuby, optionally with Sulong
       jt build_stats [--json] <attribute>            prints attribute's value from build process (e.g., binary size)
       jt clean                                       clean
       jt env                                         prints the current environment
@@ -1796,9 +1796,9 @@ module Commands
       mx 'build'
       if sulong
         ENV["TRUFFLERUBY_LIBSULONG_DIR"] = "lib/cext/sulong-libs"
-        mx 'image', '-sulong', '-ruby', '-H:MaxRuntimeCompileMethods=15000', '-H:Name=native-ruby'
+        mx 'image', '-sulong', '-ruby', '-H:MaxRuntimeCompileMethods=15000', '-H:Name=native-ruby', *options
       else
-        mx 'image', '-ruby', '-H:Name=native-ruby'
+        mx 'image', '-ruby', '-H:Name=native-ruby', *options
       end
       FileUtils.mv('svmbuild/native-ruby', '../../truffleruby/bin/')
     end

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -500,8 +500,6 @@ module Commands
     super(*args)
   end
 
-  BUILD_OPTIONS = %w[parser options cexts sulong native]
-
   def build(*options)
     project = options.shift
     case project
@@ -1887,19 +1885,6 @@ class JT
       help
       exit
     end
-
-    case args.first
-    when "rebuild"
-      send(args.shift)
-    when "build"
-      command = [args.shift]
-      while Commands::BUILD_OPTIONS.include?(args.first)
-        command << args.shift
-      end
-      send(*command)
-    end
-
-    return if args.empty?
 
     commands = Commands.public_instance_methods(false).map(&:to_s)
 


### PR DESCRIPTION
* Use `$ jt build && jt <some other command>` instead.
* This simplifies the logic to parse `jt build` arguments and allow to extend `jt build` arguments further.
* The same is done for `jt rebuild` for consistency.