### PR TITLE
Improve footprint in StringNode

### DIFF
--- a/src/main/java/org/truffleruby/core/cast/ToStrNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ToStrNode.java
@@ -29,6 +29,10 @@ public abstract class ToStrNode extends RubyNode {
 
     public abstract DynamicObject executeToStr(VirtualFrame frame, Object object);
 
+    public static ToStrNode create() {
+        return ToStrNodeGen.create(null);
+    }
+
     @Specialization(guards = "isRubyString(string)")
     public DynamicObject coerceRubyString(DynamicObject string) {
         return string;


### PR DESCRIPTION
My first push to this repo, mostly to learn the workflow. Tried to do something useful, so I tried to optimize the memory footprint of the StringNode class.

I moved @Child fields into @Cached arguments of specializations, if the node is only used by that one specialization. The footprint in the node stays the same, but the (child) node is created only lazily, so footprint will go down if that specialization is not hit.

In the opposite direction, I moved @Cached arguments into (lazily or eagerly) initialized @Child fields. I did this to share nodes between different specializations. While the number of child nodes will typically stay the same, this removes the number of fields generated by the TruffleDSL in the *NodeGen class (as it does not automatically share @Cached between specializations).

One might (rightfully!) argue that this should be better optimized by TruffleDSL. Whether these moves pay off depend on knowing TruffleDSL's limit of 3 @Cached children to merge them into a separate data structure, bringing the overhead of an (unused) specialization to 1 field (for this structure). This is the reason why I did not change e.g. StringByteSubstringPrimitiveNode - moving the 3 common @cached arguments would result in (3 common + 2 for the first specialization = ) 5 fields in the node, compared to 2 right now (+ the data structures for the specializations if they are hit; so even now, It would probably be better to merge, assuming the node is lazily created anyway and one of the two specializations IS thus hit).