### PR TITLE
Remove most SnippetNode usages

### DIFF
--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -1916,7 +1916,14 @@ module Truffle::CExt
   end
 
   def RSTRING_PTR(string)
-    Truffle.invoke_primitive(:string_get_rstring_ptr, string)
+    ptr = Truffle.invoke_primitive(:string_get_rstring_ptr, string)
+    unless ptr
+      Truffle.privately do
+        ptr = RStringPtr.new(string)
+        Truffle.invoke_primitive(:string_set_rstring_ptr, string, ptr)
+      end
+    end
+    ptr
   end
 
   def RSTRING_END(string)

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -1297,6 +1297,10 @@ public class CoreLibrary {
         return stringFactory;
     }
 
+    public DynamicObject getHashClass() {
+        return hashClass;
+    }
+
     public DynamicObjectFactory getHashFactory() {
         return hashFactory;
     }

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -137,6 +137,7 @@ public class CoreLibrary {
     private final DynamicObjectFactory intRangeFactory;
     private final DynamicObjectFactory longRangeFactory;
     private final DynamicObject rangeErrorClass;
+    private final DynamicObject rationalClass;
     private final DynamicObject regexpClass;
     private final DynamicObjectFactory regexpFactory;
     private final DynamicObject regexpErrorClass;
@@ -395,7 +396,7 @@ public class CoreLibrary {
         bignumClass = defineClass(integerClass, "Bignum");
         bignumFactory = alwaysFrozen(Layouts.BIGNUM.createBignumShape(bignumClass, bignumClass));
         Layouts.CLASS.setInstanceFactoryUnsafe(bignumClass, bignumFactory);
-        defineClass(numericClass, "Rational");
+        rationalClass = defineClass(numericClass, "Rational");
 
         // Classes defined in Object
 
@@ -1095,6 +1096,10 @@ public class CoreLibrary {
 
     public DynamicObject getRangeClass() {
         return rangeClass;
+    }
+
+    public DynamicObject getRationalClass() {
+        return rationalClass;
     }
 
     public DynamicObjectFactory getRegexpFactory() {

--- a/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
@@ -21,7 +21,6 @@ import org.truffleruby.core.array.ArrayDupNode;
 import org.truffleruby.core.array.ArrayDupNodeGen;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
 
@@ -93,9 +92,8 @@ public abstract class SplatCastNode extends RubyNode {
     @Specialization(guards = {"!isNil(object)", "!isRubyArray(object)"})
     public DynamicObject splat(VirtualFrame frame, Object object,
             @Cached("create()") BranchProfile errorProfile,
-            @Cached("new()") SnippetNode snippetNode) {
-        final Object array = snippetNode.execute(frame, "Truffle::Type.rb_check_convert_type(v, Array, method)",
-            "v", object, "method", conversionMethod);
+            @Cached("createOnSelf()") CallDispatchHeadNode toArrayNode) {
+        final Object array = toArrayNode.call(null, coreLibrary().getTruffleTypeModule(), "rb_check_convert_type", object, coreLibrary().getArrayClass(), conversionMethod);
         if (RubyGuards.isRubyArray(array)) {
             return (DynamicObject) array;
         } else if (array == nil()) {

--- a/src/main/java/org/truffleruby/core/cast/ToPathNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ToPathNode.java
@@ -12,10 +12,9 @@ package org.truffleruby.core.cast;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
+import org.truffleruby.language.dispatch.CallDispatchHeadNode;
 
 @NodeChild(value = "child", type = RubyNode.class)
 public abstract class ToPathNode extends RubyNode {
@@ -26,11 +25,9 @@ public abstract class ToPathNode extends RubyNode {
     }
 
     @Specialization(guards = "!isRubyString(object)")
-    public DynamicObject coerceObject(
-            VirtualFrame frame,
-            Object object,
-            @Cached("new()") SnippetNode snippetNode) {
-        return (DynamicObject) snippetNode.execute(frame, "Truffle::Type.coerce_to_path(object)", "object", object);
+    public DynamicObject coerceObject(Object object,
+            @Cached("createOnSelf()") CallDispatchHeadNode toPathNode) {
+        return (DynamicObject) toPathNode.call(null, coreLibrary().getTruffleTypeModule(), "coerce_to_path", object);
     }
 
 }

--- a/src/main/java/org/truffleruby/core/cast/ToStrNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ToStrNode.java
@@ -45,8 +45,8 @@ public abstract class ToStrNode extends RubyNode {
         try {
             coerced = toStrNode.call(frame, object, "to_str");
         } catch (RaiseException e) {
+            errorProfile.enter();
             if (Layouts.BASIC_OBJECT.getLogicalClass(e.getException()) == coreLibrary().getNoMethodErrorClass()) {
-                errorProfile.enter();
                 throw new RaiseException(coreExceptions().typeErrorNoImplicitConversion(object, "String", this));
             } else {
                 throw e;

--- a/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
@@ -26,6 +26,7 @@ import org.truffleruby.RubyContext;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeOperations;
+import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.extra.ffi.Pointer;
 import org.truffleruby.platform.NativeConfiguration;
 import org.truffleruby.platform.TruffleNFIPlatform;
@@ -138,6 +139,16 @@ public class EncodingManager {
     @TruffleBoundary
     public DynamicObject getRubyEncoding(Encoding encoding) {
         return ENCODING_LIST_BY_ENCODING_INDEX.get(encoding.getIndex());
+    }
+
+    @TruffleBoundary
+    public int getEncodingListIndex(DynamicObject rubyEncoding) {
+        final int index = ENCODING_LIST_BY_ENCODING_LIST_INDEX.indexOf(rubyEncoding);
+        if (index < 0) {
+            final String encodingName = StringOperations.getString(Layouts.ENCODING.getName(rubyEncoding));
+            throw new UnsupportedOperationException("Encoding not found: " + encodingName);
+        }
+        return index;
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -72,10 +72,7 @@ public abstract class HashNodes {
 
         @ExplodeLoop
         @Specialization(guards = "isSmallArrayOfPairs(args)")
-        public Object construct(
-                        VirtualFrame frame,
-                        DynamicObject hashClass,
-                Object[] args) {
+        public Object construct(VirtualFrame frame, DynamicObject hashClass, Object[] args) {
             final DynamicObject array = (DynamicObject) args[0];
 
             final Object[] store = (Object[]) Layouts.ARRAY.getStore(array);

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1759,6 +1759,7 @@ public abstract class ModuleNodes {
         @Child private CallDispatchHeadNode callRbInspect;
         @Child private StringNodes.MakeStringNode makeStringNode = StringNodes.MakeStringNode.create();
 
+        @TruffleBoundary
         @Specialization
         public DynamicObject toS(DynamicObject module) {
             final String moduleName;

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1786,8 +1786,6 @@ public abstract class ModuleNodes {
                 moduleName = fields.getName();
             }
 
-            // TODO BJF Aug 31, 2016 Add refinements to_s
-
             return makeStringNode.executeMake(moduleName, UTF8Encoding.INSTANCE, CodeRange.CR_UNKNOWN);
         }
 

--- a/src/main/java/org/truffleruby/core/numeric/BignumNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/BignumNodes.java
@@ -32,7 +32,6 @@ import org.truffleruby.core.numeric.BignumNodesFactory.MulNodeFactory;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.language.NotProvided;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
 
@@ -235,12 +234,9 @@ public abstract class BignumNodes {
         }
 
         @Specialization(guards = {"!isInteger(b)", "!isLong(b)", "!isRubyBignum(b)"})
-        public Object mod(
-                VirtualFrame frame,
-                DynamicObject a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "redo_coerced :%, other", "other", b);
+        public Object mod(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCoerced) {
+            return redoCoerced.call(null, a, "redo_coerced", coreStrings().MODULO.getSymbol(), b);
         }
 
     }
@@ -268,12 +264,9 @@ public abstract class BignumNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)"})
-        public Object lessCoerced(
-                VirtualFrame frame,
-                DynamicObject a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce other, :compare_error; a < b", "other", b);
+        public Object lessCoerced(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().LESS_THAN.getSymbol(), b);
         }
 
     }
@@ -301,12 +294,9 @@ public abstract class BignumNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)"})
-        public Object lessEqualCoerced(
-                VirtualFrame frame,
-                DynamicObject a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce other, :compare_error; a <= b", "other", b);
+        public Object lessEqualCoerced(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().LESS_OR_EQUAL.getSymbol(), b);
         }
     }
 
@@ -377,12 +367,9 @@ public abstract class BignumNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)"})
-        public Object greaterEqualCoerced(
-                VirtualFrame frame,
-                DynamicObject a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce other, :compare_error; a >= b", "other", b);
+        public Object greaterEqualCoerced(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().GREATER_OR_EQUAL.getSymbol(), b);
         }
     }
 
@@ -409,12 +396,9 @@ public abstract class BignumNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)"})
-        public Object greaterCoerced(
-                VirtualFrame frame,
-                DynamicObject a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce other, :compare_error; a > b", "other", b);
+        public Object greaterCoerced(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().GREATER_THAN.getSymbol(), b);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/numeric/BignumNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/BignumNodes.java
@@ -442,9 +442,9 @@ public abstract class BignumNodes {
         }
 
         @Specialization(guards = { "!isInteger(b)", "!isLong(b)", "!isRubyBignum(b)" })
-        public Object bitAnd(VirtualFrame frame, DynamicObject a, Object b,
-                             @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "self & bit_coerce(b)[1]", "b", b);
+        public Object bitAnd(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCoerced) {
+            return redoCoerced.call(null, a, "redo_bit_coerced", coreStrings().AMPERSAND.getSymbol(), b);
         }
     }
 
@@ -462,9 +462,9 @@ public abstract class BignumNodes {
         }
 
         @Specialization(guards = { "!isInteger(b)", "!isLong(b)", "!isRubyBignum(b)" })
-        public Object bitAnd(VirtualFrame frame, DynamicObject a, Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "self | bit_coerce(b)[1]", "b", b);
+        public Object bitAnd(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCoerced) {
+            return redoCoerced.call(null, a, "redo_bit_coerced", coreStrings().PIPE.getSymbol(), b);
         }
     }
 
@@ -482,9 +482,9 @@ public abstract class BignumNodes {
         }
 
         @Specialization(guards = { "!isInteger(b)", "!isLong(b)", "!isRubyBignum(b)" })
-        public Object bitAnd(VirtualFrame frame, DynamicObject a, Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "self ^ bit_coerce(b)[1]", "b", b);
+        public Object bitAnd(DynamicObject a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCoerced) {
+            return redoCoerced.call(null, a, "redo_bit_coerced", coreStrings().CIRCUMFLEX.getSymbol(), b);
         }
 
     }

--- a/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
@@ -34,7 +34,6 @@ import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.LazyIntRope;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.language.NotProvided;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
@@ -659,12 +658,9 @@ public abstract class FixnumNodes {
                 "!isLong(b)",
                 "!isDouble(b)",
                 "!isRubyBignum(b)" })
-        public Object compare(
-                VirtualFrame frame,
-                Object a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "begin; b, a = math_coerce(other, :compare_error); a <=> b; rescue ArgumentError; nil; end", "other", b);
+        public Object compare(Object a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare_no_error", b);
         }
 
     }

--- a/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
@@ -463,8 +463,8 @@ public abstract class FixnumNodes {
 
     }
 
-    @CoreMethod(names = "divmod", required = 1)
-    public abstract static class DivModNode extends CoreMethodArrayArgumentsNode {
+    @Primitive(name = "fixnum_divmod")
+    public abstract static class DivModNode extends PrimitiveArrayArgumentsNode {
 
         @Child private GeneralDivModNode divModNode = new GeneralDivModNode();
 
@@ -479,9 +479,8 @@ public abstract class FixnumNodes {
         }
 
         @Specialization(guards = "!isRubyBignum(b)")
-        public DynamicObject divModOther(VirtualFrame frame, long a, DynamicObject b,
-                                         @Cached("new()") SnippetNode snippetNode) {
-            return (DynamicObject) snippetNode.execute(frame, "raise ZeroDivisionError if b === 0; [(a / b).floor, a-b*(a/b).floor]", "a", a, "b", b);
+        public Object divModOther(VirtualFrame frame, long a, DynamicObject b) {
+            return FAILURE;
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FixnumNodes.java
@@ -854,7 +854,7 @@ public abstract class FixnumNodes {
         @Specialization(guards = "!isRubyBignum(b)")
         public Object bitXOr(Object a, DynamicObject b,
                 @Cached("createOnSelf()") CallDispatchHeadNode redoCoerced) {
-            return redoCoerced.call(null, a, "redo_coerced", coreStrings().CIRCUMFLEX.getSymbol(), b);
+            return redoCoerced.call(null, a, "redo_bit_coerced", coreStrings().CIRCUMFLEX.getSymbol(), b);
         }
 
     }

--- a/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
@@ -36,7 +36,6 @@ import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
@@ -317,12 +316,9 @@ public abstract class FloatNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)" })
-        public Object lessCoerced(
-                VirtualFrame frame,
-                double a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce other, :compare_error; a < b", "other", b);
+        public Object lessCoerced(double a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().LESS_THAN.getSymbol(), b);
         }
     }
 
@@ -349,12 +345,9 @@ public abstract class FloatNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)" })
-        public Object lessEqualCoerced(
-                VirtualFrame frame,
-                double a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce other, :compare_error; a <= b", "other", b);
+        public Object lessEqualCoerced(double a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().LESS_OR_EQUAL.getSymbol(), b);
         }
     }
 
@@ -475,12 +468,9 @@ public abstract class FloatNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)" })
-        public Object greaterEqualCoerced(
-                VirtualFrame frame,
-                double a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce other, :compare_error; a >= b", "other", b);
+        public Object greaterEqualCoerced(double a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().GREATER_OR_EQUAL.getSymbol(), b);
         }
 
     }
@@ -508,12 +498,9 @@ public abstract class FloatNodes {
                 "!isInteger(b)",
                 "!isLong(b)",
                 "!isDouble(b)" })
-        public Object greaterCoerced(
-                VirtualFrame frame,
-                double a,
-                Object b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "b, a = math_coerce(other, :compare_error); a > b", "other", b);
+        public Object greaterCoerced(double a, Object b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(null, a, "redo_compare", coreStrings().GREATER_THAN.getSymbol(), b);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/string/CoreStrings.java
+++ b/src/main/java/org/truffleruby/core/string/CoreStrings.java
@@ -49,6 +49,7 @@ public class CoreStrings {
     public final CoreString NIL;
     public final CoreString ONE_HASH_REQUIRED;
     public final CoreString OUT_OF_RANGE;
+    public final CoreString PIPE;
     public final CoreString PLUS;
     public final CoreString POWER;
     public final CoreString PROC_WITHOUT_BLOCK;
@@ -107,6 +108,7 @@ public class CoreStrings {
         NIL = new CoreString(context, "nil");
         ONE_HASH_REQUIRED = new CoreString(context, "one hash required");
         OUT_OF_RANGE = new CoreString(context, "out of range");
+        PIPE = new CoreString(context, "|");
         PLUS = new CoreString(context, "+");
         POWER = new CoreString(context, "**");
         PROC_WITHOUT_BLOCK = new CoreString(context, "tried to create Proc object without a block");

--- a/src/main/java/org/truffleruby/core/string/CoreStrings.java
+++ b/src/main/java/org/truffleruby/core/string/CoreStrings.java
@@ -63,6 +63,7 @@ public class CoreStrings {
     public final CoreString SUPER;
     public final CoreString TIME_INTERVAL_MUST_BE_POS;
     public final CoreString TO_ARY;
+    public final CoreString TO_HASH;
     public final CoreString TO_STR;
     public final CoreString TOO_FEW_ARGUMENTS;
     public final CoreString TRUE;
@@ -123,6 +124,7 @@ public class CoreStrings {
         SUPER = new CoreString(context, "super");
         TIME_INTERVAL_MUST_BE_POS = new CoreString(context, "time interval must be positive");
         TO_ARY = new CoreString(context, "to_ary");
+        TO_HASH = new CoreString(context, "to_hash");
         TO_STR = new CoreString(context, "to_str");
         TOO_FEW_ARGUMENTS = new CoreString(context, "too few arguments");
         TRUE = new CoreString(context, "true");

--- a/src/main/java/org/truffleruby/core/string/CoreStrings.java
+++ b/src/main/java/org/truffleruby/core/string/CoreStrings.java
@@ -58,6 +58,7 @@ public class CoreStrings {
     public final CoreString RESOURCE_TEMP_UNAVAIL_WRITE;
     public final CoreString UNKNOWN;
     public final CoreString SELF;
+    public final CoreString SPACESHIP;
     public final CoreString STACK_LEVEL_TOO_DEEP;
     public final CoreString SUPER;
     public final CoreString TIME_INTERVAL_MUST_BE_POS;
@@ -117,6 +118,7 @@ public class CoreStrings {
         RESOURCE_TEMP_UNAVAIL_WRITE = new CoreString(context, "Resource temporarily unavailable - write would block");
         UNKNOWN = new CoreString(context, "(unknown)");
         SELF = new CoreString(context, "self");
+        SPACESHIP = new CoreString(context, "<=>");
         STACK_LEVEL_TOO_DEEP = new CoreString(context, "stack level too deep");
         SUPER = new CoreString(context, "super");
         TIME_INTERVAL_MUST_BE_POS = new CoreString(context, "time interval must be positive");

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -482,7 +482,7 @@ public abstract class StringNodes {
         @Child private CallDispatchHeadNode dupNode;
         @Child private NormalizeIndexNode normalizeIndexNode;
         @Child private StringSubstringPrimitiveNode substringNode;
-        @Child private SnippetNode snippetNode;
+        @Child private CallDispatchHeadNode toIntNode;
 
         private final BranchProfile outOfBounds = BranchProfile.create();
 
@@ -646,12 +646,12 @@ public abstract class StringNodes {
         }
 
         private int toInt(VirtualFrame frame, Object value) {
-            if (snippetNode == null) {
+            if (toIntNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
-                snippetNode = insert(new SnippetNode());
+                toIntNode = insert(CallDispatchHeadNode.createOnSelf());
             }
 
-            return (int) snippetNode.execute(frame, "Truffle::Type.rb_num2int(v)", "v", value);
+            return (int) toIntNode.call(frame, coreLibrary().getTruffleTypeModule(), "rb_num2int", value);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -134,7 +134,6 @@ import org.truffleruby.language.CheckLayoutNode;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.ReadCallerFrameNode;
 import org.truffleruby.language.control.RaiseException;
@@ -1174,17 +1173,24 @@ public abstract class StringNodes {
     public abstract static class GetRstringPtrNode extends PrimitiveArrayArgumentsNode {
 
         @Specialization(guards = "isRubyString(string)")
-        public DynamicObject getRstringPtr(VirtualFrame frame, DynamicObject string,
-                                           @Cached("new()") SnippetNode snippetNode) {
+        public DynamicObject getRstringPtr(DynamicObject string) {
             final DynamicObject existingPtr = Layouts.STRING.getRstringPtr(string);
-
             if (existingPtr != null) {
                 return existingPtr;
             } else {
-                final DynamicObject rstringPtr = (DynamicObject) snippetNode.execute(frame, "Truffle::CExt::RStringPtr.send(:new, str)", "str", string);
-                Layouts.STRING.setRstringPtr(string, rstringPtr);
-                return rstringPtr;
+                return nil();
             }
+        }
+
+    }
+
+    @Primitive(name = "string_set_rstring_ptr", needsSelf = false)
+    public abstract static class SetRstringPtrNode extends PrimitiveArrayArgumentsNode {
+
+        @Specialization(guards = "isRubyString(string)")
+        public DynamicObject setRstringPtr(DynamicObject string, DynamicObject rstringPtr) {
+            Layouts.STRING.setRstringPtr(string, rstringPtr);
+            return rstringPtr;
         }
 
     }

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -2106,11 +2106,10 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = "isStringSubclass(string)")
-        public Object toSOnSubclass(
-                VirtualFrame frame,
-                DynamicObject string,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "''.replace(self)", "self", string);
+        public Object toSOnSubclass(DynamicObject string,
+                @Cached("create()") IsTaintedNode isTaintedNode) {
+            return coreLibrary().getStringFactory().newInstance(Layouts.STRING.build(
+                    false, isTaintedNode.executeIsTainted(string), rope(string), null));
         }
 
         public boolean isStringSubclass(DynamicObject string) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -513,11 +513,10 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = "isObjectRange(range)")
-        public Object sliceObjectRange(VirtualFrame frame, DynamicObject string, DynamicObject range, NotProvided length,
-                @Cached("new()") SnippetNode snippetNode2) {
+        public Object sliceObjectRange(VirtualFrame frame, DynamicObject string, DynamicObject range, NotProvided length) {
             // TODO (nirvdrum 31-Mar-15) The begin and end values may return Fixnums beyond int boundaries and we should handle that -- Bignums are always errors.
             final int coercedBegin = toInt(frame, Layouts.OBJECT_RANGE.getBegin(range));
-            final int coercedEnd = (int) snippetNode2.execute(frame, "Truffle::Type.rb_num2int(v)", "v", Layouts.OBJECT_RANGE.getEnd(range));
+            final int coercedEnd = toInt(frame, Layouts.OBJECT_RANGE.getEnd(range));
 
             return sliceRange(frame, string, coercedBegin, coercedEnd, Layouts.OBJECT_RANGE.getExcludedEnd(range));
         }
@@ -573,10 +572,8 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = { "!isRubyRange(start)", "!isRubyRegexp(start)", "!isRubyString(start)", "wasProvided(length)" })
-        public Object slice(VirtualFrame frame, DynamicObject string, Object start, Object length,
-                @Cached("new()") SnippetNode snippetNode2) {
-            return slice(frame, string, toInt(frame, start),
-                    (int) snippetNode2.execute(frame, "Truffle::Type.rb_num2int(v)", "v", length));
+        public Object slice(VirtualFrame frame, DynamicObject string, Object start, Object length) {
+            return slice(frame, string, toInt(frame, start), toInt(frame, length));
         }
 
         @Specialization(guards = "isRubyRegexp(regexp)")

--- a/src/main/java/org/truffleruby/interop/InteropNodes.java
+++ b/src/main/java/org/truffleruby/interop/InteropNodes.java
@@ -46,10 +46,8 @@ import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeNodes;
 import org.truffleruby.core.string.StringCachingGuards;
 import org.truffleruby.core.string.StringOperations;
-import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.control.JavaException;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
@@ -648,29 +646,19 @@ public abstract class InteropNodes {
     }
 
     @ImportStatic(Message.class)
-    @CoreMethod(names = "keys", isModuleFunction = true, required = 1, optional = 1)
-    public abstract static class KeysNode extends CoreMethodArrayArgumentsNode {
-
-        public abstract Object executeKeys(VirtualFrame frame, TruffleObject receiver, Object internal);
+    @Primitive(name = "interop_send_keys")
+    public abstract static class KeysNode extends PrimitiveArrayArgumentsNode {
 
         @Specialization
         public Object keys(VirtualFrame frame, TruffleObject receiver, boolean internal,
                 @Cached("KEYS.createNode()") Node keysNode,
-                @Cached("new()") SnippetNode snippetNode,
                 @Cached("create()") BranchProfile exceptionProfile) {
             try {
-                return snippetNode.execute(frame,
-                        "Truffle::Interop.enumerable(keys).map { |key| Truffle::Interop.from_java_string(key) }",
-                        "keys", ForeignAccess.sendKeys(keysNode, receiver, internal));
+                return ForeignAccess.sendKeys(keysNode, receiver, internal);
             } catch (UnsupportedMessageException e) {
                 exceptionProfile.enter();
                 throw new JavaException(e);
             }
-        }
-
-        @Specialization
-        public Object size(VirtualFrame frame, TruffleObject receiver, NotProvided internal) {
-            return executeKeys(frame, receiver, false);
         }
 
     }

--- a/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
+++ b/src/main/java/org/truffleruby/interop/OutgoingForeignCallNode.java
@@ -31,7 +31,6 @@ import org.truffleruby.Log;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.control.JavaException;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
@@ -400,7 +399,7 @@ public abstract class OutgoingForeignCallNode extends RubyNode {
 
     protected class ToAOutgoingNode extends OutgoingNode {
 
-        @Child private SnippetNode snippetNode = new SnippetNode();
+        @Child private CallDispatchHeadNode callToArray = CallDispatchHeadNode.createOnSelf();
 
         @Override
         public Object executeCall(VirtualFrame frame, TruffleObject receiver, Object[] args) {
@@ -409,7 +408,7 @@ public abstract class OutgoingForeignCallNode extends RubyNode {
                 throw new RaiseException(getContext().getCoreExceptions().argumentError(args.length, 0, this));
             }
 
-            return snippetNode.execute(frame, "Truffle::Interop.to_array(object)", "object", receiver);
+            return callToArray.call(frame, coreLibrary().getTruffleInteropModule(), "to_array", receiver);
         }
 
     }

--- a/src/main/java/org/truffleruby/language/arguments/ReadRestArgumentNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ReadRestArgumentNode.java
@@ -16,7 +16,7 @@ import org.truffleruby.Log;
 import org.truffleruby.core.array.ArrayUtils;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
+import org.truffleruby.language.dispatch.CallDispatchHeadNode;
 
 public class ReadRestArgumentNode extends RubyNode {
 
@@ -28,7 +28,7 @@ public class ReadRestArgumentNode extends RubyNode {
     private final BranchProfile subsetOfArgumentsProfile = BranchProfile.create();
 
     @Child private ReadUserKeywordsHashNode readUserKeywordsHashNode;
-    @Child private SnippetNode snippetNode = new SnippetNode();
+    @Child private CallDispatchHeadNode addRejectedNode = CallDispatchHeadNode.createOnSelf();
 
     public ReadRestArgumentNode(int startIndex, int indexFromCount,
                                 boolean keywordArguments, int minimumForKWargs) {
@@ -87,10 +87,7 @@ public class ReadRestArgumentNode extends RubyNode {
                 kwargsHash = nil();
             }
 
-            snippetNode.execute(frame,
-                    "Truffle.add_rejected_kwargs_to_rest(rest, kwargs)",
-                    "rest", rest,
-                    "kwargs", kwargsHash);
+            addRejectedNode.call(frame, coreLibrary().getTruffleModule(), "add_rejected_kwargs_to_rest", rest, kwargsHash);
         }
 
         return rest;

--- a/src/main/java/org/truffleruby/stdlib/bigdecimal/BigDecimalCastNode.java
+++ b/src/main/java/org/truffleruby/stdlib/bigdecimal/BigDecimalCastNode.java
@@ -48,8 +48,8 @@ import com.oracle.truffle.api.object.DynamicObject;
 import org.truffleruby.Layouts;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
+import org.truffleruby.language.objects.IsANode;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -95,11 +95,11 @@ public abstract class BigDecimalCastNode extends RubyNode {
             VirtualFrame frame,
             DynamicObject value,
             Object roundingMode,
-            @Cached("new()") SnippetNode isRationalSnippet,
+            @Cached("create()") IsANode isRationalNode,
             @Cached("create()") CallDispatchHeadNode numeratorCallNode,
             @Cached("create()") CallDispatchHeadNode denominatorCallNode,
             @Cached("create()") CallDispatchHeadNode toFCallNode) {
-        if (roundingMode instanceof RoundingMode && (boolean) isRationalSnippet.execute(frame, "value.is_a?(Rational)", "value", value)) {
+        if (roundingMode instanceof RoundingMode && isRationalNode.executeIsA(value, coreLibrary().getRationalClass())) {
             final Object numerator = numeratorCallNode.call(frame, value, "numerator");
             final Object denominator = denominatorCallNode.call(frame, value, "denominator");
 

--- a/src/main/java/org/truffleruby/stdlib/bigdecimal/BigDecimalNodes.java
+++ b/src/main/java/org/truffleruby/stdlib/bigdecimal/BigDecimalNodes.java
@@ -31,7 +31,6 @@ import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.SnippetNode;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.CallDispatchHeadNode;
@@ -1051,16 +1050,10 @@ public abstract class BigDecimalNodes {
             return nil();
         }
 
-        @Specialization(guards = {
-                "!isRubyBigDecimal(b)",
-                "!isNil(b)"
-        })
-        public Object compareCoerced(
-                VirtualFrame frame,
-                DynamicObject a,
-                DynamicObject b,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "redo_coerced :<=>, b", "b", b);
+        @Specialization(guards = { "!isRubyBigDecimal(b)", "!isNil(b)" })
+        public Object compareCoerced(DynamicObject a, DynamicObject b,
+                @Cached("createOnSelf()") CallDispatchHeadNode redoCoerced) {
+            return redoCoerced.call(null, a, "redo_coerced", coreStrings().SPACESHIP.getSymbol(), b);
         }
 
         @TruffleBoundary

--- a/src/main/ruby/core/array.rb
+++ b/src/main/ruby/core/array.rb
@@ -1308,8 +1308,21 @@ class Array
     raise ArgumentError, 'tried to flatten recursive array' if recursion
     modified
   end
-
   private :recursively_flatten
+
+  private def sort_fallback(&block)
+    # Use this instead of #dup as we want an instance of Array
+    sorted = Array.new(self)
+
+    Truffle.privately do
+      if block
+        sorted.mergesort_block!(block)
+      else
+        sorted.mergesort!
+      end
+    end
+    sorted
+  end
 
   # Non-recursive sort using a temporary array for scratch storage.
   # This is a hybrid mergesort; it's hybrid because for short runs under

--- a/src/main/ruby/core/encoding.rb
+++ b/src/main/ruby/core/encoding.rb
@@ -546,7 +546,10 @@ class Encoding
   end
 
   def replicate(name)
-    Truffle.invoke_primitive(:encoding_replicate, self, StringValue(name))
+    name = StringValue(name)
+    new_encoding, index = Truffle.invoke_primitive :encoding_replicate, self, name
+    EncodingMap[name.upcase.to_sym] = [nil, index]
+    new_encoding
   end
 
   def _dump(depth)

--- a/src/main/ruby/core/fixnum.rb
+++ b/src/main/ruby/core/fixnum.rb
@@ -59,6 +59,15 @@ class Fixnum < Integer
     end
   end
 
+  def divmod(b)
+    Truffle.primitive :fixnum_divmod
+    raise ZeroDivisionError if b == 0
+    [
+      (self / b).floor,
+      self - b * (self / b).floor
+    ]
+  end
+
   def **(o)
     Truffle.primitive :fixnum_pow
 

--- a/src/main/ruby/core/hash.rb
+++ b/src/main/ruby/core/hash.rb
@@ -94,6 +94,7 @@ class Hash
 
     hash
   end
+  private_class_method :_constructor_fallback
 
   alias_method :store, :[]=
 

--- a/src/main/ruby/core/numeric.rb
+++ b/src/main/ruby/core/numeric.rb
@@ -224,8 +224,10 @@ class Numeric
 
       if error == :coerce_error
         raise TypeError, "#{other.class} can't be coerced into #{self.class}"
-      else
+      elsif error == :compare_error
         raise ArgumentError, "comparison of #{self.class} with #{other.class} failed"
+      elsif error == :no_error
+        return nil
       end
     end
 
@@ -257,6 +259,12 @@ class Numeric
     a.__send__ meth, b
   end
   private :redo_compare
+
+  private def redo_compare_no_error(right)
+    b, a = math_coerce(right, :no_error)
+    return nil unless b
+    a <=> b
+  end
 
   def redo_bit_coerced(meth, right)
     b, a = bit_coerce(right)

--- a/src/main/ruby/core/truffle/interop.rb
+++ b/src/main/ruby/core/truffle/interop.rb
@@ -13,10 +13,8 @@ module Truffle
     def self.import_method(name)
       method = import(name.to_s)
 
-      Object.class_eval do
-        define_method(name.to_sym) do |*args|
-          from_java_string execute(method, *args)
-        end
+      Object.send(:define_method, name.to_sym) do |*args|
+        from_java_string execute(method, *args)
       end
     end
 

--- a/src/main/ruby/core/truffle/interop.rb
+++ b/src/main/ruby/core/truffle/interop.rb
@@ -15,8 +15,7 @@ module Truffle
 
       Object.class_eval do
         define_method(name.to_sym) do |*args|
-          ret = Truffle::Interop.execute(method, *args)
-          Truffle::Interop.from_java_string(ret)
+          from_java_string execute(method, *args)
         end
       end
     end
@@ -36,9 +35,7 @@ module Truffle
 
     def self.keys(object, internal = false)
       keys = Truffle.invoke_primitive :interop_send_keys, object, internal
-      Truffle::Interop.enumerable(keys).map { |key|
-        Truffle::Interop.from_java_string(key)
-      }
+      enumerable(keys).map { |key| from_java_string(key) }
     end
 
     def self.object_keys(object, internal)

--- a/src/main/ruby/core/truffle/interop.rb
+++ b/src/main/ruby/core/truffle/interop.rb
@@ -34,6 +34,13 @@ module Truffle
       end
     end
 
+    def self.keys(object, internal = false)
+      keys = Truffle.invoke_primitive :interop_send_keys, object, internal
+      Truffle::Interop.enumerable(keys).map { |key|
+        Truffle::Interop.from_java_string(key)
+      }
+    end
+
     def self.object_keys(object, internal)
       if object.is_a?(Hash)
         keys = object.keys.map(&:to_s)


### PR DESCRIPTION
* Only 2 left which require bigger changes/cleanup.
* Most of these usages were hiding complex Ruby code in Java String, showing SnippetNode was rarely well used. CallDispatchHeadNode (+ helper methods in the Ruby core in some cases) is in general much lighter, more readable and cleaner.